### PR TITLE
Filter out atlantis apply status during mergeability check.

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -38,6 +38,7 @@ const (
 
 	SubmitQueueReadinessStatusContext = "sq-ready-to-merge"
 	OwnersStatusContext               = "_owners-check"
+	AtlantisApplyStatusContext        = "atlantis/apply"
 )
 
 // GithubClient is used to perform GitHub actions.
@@ -285,7 +286,7 @@ func (g *GithubClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 	return true, nil
 }
 
-// Checks to make sure that all statuses are passing except the Submit Queue Readiness check
+// Checks to make sure that all statuses are passing except the Submit Queue Readiness check and atlantis/apply
 // Additionally checks if the Owners Check has been applied and is successful.
 func (g *GithubClient) getSubmitQueueMergeability(repo models.Repo, pull models.PullRequest) (bool, error) {
 	statuses, err := g.getRepoStatuses(repo, pull)
@@ -302,7 +303,9 @@ func (g *GithubClient) getSubmitQueueMergeability(repo models.Repo, pull models.
 			ownersCheckApplied = true
 		}
 
-		if state == "success" || (state == "pending" && status.GetContext() == SubmitQueueReadinessStatusContext) {
+		if status.GetContext() == AtlantisApplyStatusContext ||
+			state == "success" ||
+			(state == "pending" && status.GetContext() == SubmitQueueReadinessStatusContext) {
 			continue
 		}
 

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -593,10 +593,11 @@ func TestGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 		expMergeable bool
 	}{
 		{
-			"sq-pending+owners-success",
+			"sq-pending+owners-success+apply-failure",
 			[]string{
 				fmt.Sprintf(statusJSON, "pending", "sq-ready-to-merge"),
 				fmt.Sprintf(statusJSON, "success", "_owners-check"),
+				fmt.Sprintf(statusJSON, "failure", "atlantis/apply"),
 			},
 			true,
 		},


### PR DESCRIPTION
atlantis/apply can be in the failure state when this check is occuring. Yet we want to be able to re-run the apply, without this check this is not possible.