### PR TITLE
[ORCA-468] Get GH actions working for ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     - run: yarn website:build
     - run:
         name: http-server
-        command: http-server runatlantis.io/.vuepress/dist
+        command: http-server runatlantis.io/.vuepress/di
         background: true
       # We use dockerize -wait here to wait until the server is up.
     - run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: cedrickring/golang-action@1.14.0
+    - uses: cedrickring/golang-action/go1.14@1.6.0
       env:
-          GO111MODULE: "on"
-          IMPORT: "lyft/atlantis"
+        GO111MODULE: "on"
+        IMPORT: "lyft/atlantis"
       with:
-          args: make test
+        args: make test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup file system permissions
       run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
     - uses: actions/checkout@master
-      run: make test-coverage
+    - run: make test-coverage
     # - uses: cedrickring/golang-action/go1.14@1.6.0
     #   env:
     #     GO111MODULE: "on"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,12 +1,13 @@
 on: push
 name: Tests
 jobs:
-  unit:
+  test:
     runs-on: ubuntu-latest
     container: runatlantis/testing-env:latest
     env:
       GOFLAGS: "-mod=vendor"
     steps:
+      # user in image needs write access to do anything
     - name: Setup file system permissions
       run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
     - uses: actions/checkout@master

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,6 +3,9 @@ name: Tests
 jobs:
   unit:
     runs-on: ubuntu-latest
+    container: runatlantis/testing-env:latest
+    env:
+      GOFLAGS: "-mod=vendor"
     steps:
     - uses: actions/checkout@master
     - uses: cedrickring/golang-action/go1.14@1.6.0
@@ -10,4 +13,4 @@ jobs:
         GO111MODULE: "on"
         IMPORT: "lyft/atlantis"
       with:
-        args: make test
+        args: make test-coverage

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,8 +6,8 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: cedrickring/golang-action@1.14.0
-    env:
-        GO111MODULE: "on"
-        IMPORT: "lyft/atlantis"
-    with:
-        args: make test
+      env:
+          GO111MODULE: "on"
+          IMPORT: "lyft/atlantis"
+      with:
+          args: make test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -7,10 +7,13 @@ jobs:
     env:
       GOFLAGS: "-mod=vendor"
     steps:
+    - name: Setup file system permissions
+      run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
     - uses: actions/checkout@master
-    - uses: cedrickring/golang-action/go1.14@1.6.0
-      env:
-        GO111MODULE: "on"
-        IMPORT: "lyft/atlantis"
-      with:
-        args: make test-coverage
+      run: make test-coverage
+    # - uses: cedrickring/golang-action/go1.14@1.6.0
+    #   env:
+    #     GO111MODULE: "on"
+    #     IMPORT: "lyft/atlantis"
+    #   with:
+    #     args: make test-coverage

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,9 +11,5 @@ jobs:
       run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
     - uses: actions/checkout@master
     - run: make test-coverage
-    # - uses: cedrickring/golang-action/go1.14@1.6.0
-    #   env:
-    #     GO111MODULE: "on"
-    #     IMPORT: "lyft/atlantis"
-    #   with:
-    #     args: make test-coverage
+    - run: make check-fmt
+    - run: make check-lint

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -157,7 +157,7 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	var pull github.PullRequest
 	modelPull := models.PullRequest{
 		BaseRepo: fixtures.GithubRepo,
-		State: models.OpenPullState,
+		State:    models.OpenPullState,
 	}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
 

--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/events"
 	eventMocks "github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
-	vcsMocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	"github.com/runatlantis/atlantis/server/events/vcs/fixtures"
+	vcsMocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
 	. "github.com/runatlantis/atlantis/testing"
-	. "github.com/petergtz/pegomock"
 )
 
 // Test that if we don't have any existing files, we check out the repo with a github app.
@@ -50,7 +50,7 @@ func TestClone_GithubAppNoneExisting(t *testing.T) {
 	}
 
 	cloneDir, _, err := gwd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 	}, "default")
 	Ok(t, err)
@@ -66,8 +66,8 @@ func TestClone_GithubAppSetsCorrectUrl(t *testing.T) {
 	credentials := vcsMocks.NewMockGithubCredentials()
 
 	ghAppWorkingDir := events.GithubAppWorkingDir{
-		WorkingDir: workingDir,
-		Credentials: credentials,
+		WorkingDir:     workingDir,
+		Credentials:    credentials,
 		GithubHostname: "some-host",
 	}
 

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -625,9 +625,9 @@ func TestGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.RequestURI {
 					case "/api/v3/repos/owner/repo/commits/2/status?per_page=100":
-						w.Write([]byte(
+						w.Write([]byte( // nolint: errcheck
 							fmt.Sprintf(combinedStatusJSON, strings.Join(c.statuses, ",")),
-						)) // nolint: errcheck
+						))
 						return
 					case "/api/v3/repos/owner/repo/pulls/1":
 						w.Write([]byte(pullResponse)) // nolint: errcheck

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -41,7 +41,7 @@ func TestClone_NoneExisting(t *testing.T) {
 	}
 
 	cloneDir, _, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 	}, "default")
 	Ok(t, err)
@@ -91,7 +91,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	}
 
 	cloneDir, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -140,7 +140,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	}
 
 	_, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -152,7 +152,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 
 	// Now run the clone again.
 	cloneDir, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -190,7 +190,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	}
 
 	_, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -202,7 +202,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 
 	// Now run the clone again.
 	cloneDir, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -245,7 +245,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	}
 
 	_, _, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		BaseBranch: "master",
 	}, "default")
@@ -276,7 +276,7 @@ func TestClone_NoReclone(t *testing.T) {
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 	cloneDir, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 	}, "default")
 	Ok(t, err)
@@ -312,7 +312,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 	cloneDir, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "branch",
 		HeadCommit: expCommit,
 	}, "default")
@@ -378,7 +378,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 		CheckoutMerge: true,
 	}
 	_, hasDiverged, err := wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "second-pr",
 		BaseBranch: "master",
 	}, "default")
@@ -389,7 +389,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	// false.
 	wd.CheckoutMerge = false
 	_, hasDiverged, err = wd.Clone(nil, models.Repo{}, models.PullRequest{
-		BaseRepo: models.Repo{},
+		BaseRepo:   models.Repo{},
 		HeadBranch: "second-pr",
 		BaseBranch: "master",
 	}, "default")


### PR DESCRIPTION
Circle CI config already exists in the repo. GH Actions is probably a more blessed way to run these tests at least internally.

Eventually we should add the link checker test as well here, but i've omitted just to get this started.