### PR TITLE
[ORCA-393] Add basic stats.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,6 +69,7 @@ const (
 	GitlabWebhookSecretFlag    = "gitlab-webhook-secret" // nolint: gosec
 	HidePrevPlanComments       = "hide-prev-plan-comments"
 	LogLevelFlag               = "log-level"
+	StatsNamespace             = "stats-namespace"
 	AllowDraftPRs              = "allow-draft-prs"
 	PortFlag                   = "port"
 	RepoConfigFlag             = "repo-config"
@@ -102,6 +103,7 @@ const (
 	DefaultGHHostname       = "github.com"
 	DefaultGitlabHostname   = "gitlab.com"
 	DefaultLogLevel         = "info"
+	DefaultStatsNamespace   = "atlantis"
 	DefaultPort             = 4141
 	DefaultTFDownloadURL    = "https://releases.hashicorp.com"
 	DefaultTFEHostname      = "app.terraform.io"
@@ -208,6 +210,10 @@ var stringFlags = map[string]stringFlag{
 	LogLevelFlag: {
 		description:  "Log level. Either debug, info, warn, or error.",
 		defaultValue: DefaultLogLevel,
+	},
+	StatsNamespace: {
+		description:  "Namespace for aggregating stats.",
+		defaultValue: DefaultStatsNamespace,
 	},
 	RepoConfigFlag: {
 		description: "Path to a repo config file, used to customize how Atlantis runs on each repo. See runatlantis.io/docs for more details.",
@@ -557,6 +563,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.LogLevel == "" {
 		c.LogLevel = DefaultLogLevel
+	}
+	if c.StatsNamespace == "" {
+		c.StatsNamespace = DefaultStatsNamespace
 	}
 	if c.Port == 0 {
 		c.Port = DefaultPort

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -78,6 +78,7 @@ var testFlags = map[string]interface{}{
 	GitlabUserFlag:             "gitlab-user",
 	GitlabWebhookSecretFlag:    "gitlab-secret",
 	LogLevelFlag:               "debug",
+	StatsNamespace:             "atlantis",
 	AllowDraftPRs:              true,
 	PortFlag:                   8181,
 	RepoAllowlistFlag:          "github.com/runatlantis/atlantis",

--- a/server/events/command_context.go
+++ b/server/events/command_context.go
@@ -13,6 +13,7 @@
 package events
 
 import (
+	stats "github.com/lyft/gostats"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 )
@@ -27,8 +28,9 @@ type CommandContext struct {
 	HeadRepo models.Repo
 	Pull     models.PullRequest
 	// User is the user that triggered this command.
-	User models.User
-	Log  *logging.SimpleLogger
+	User  models.User
+	Log   *logging.SimpleLogger
+	Scope stats.Scope
 	// PullMergeable is true if Pull is able to be merged. This is available in
 	// the CommandContext because we want to collect this information before we
 	// set our own build statuses which can affect mergeability if users have

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	stats "github.com/lyft/gostats"
 	"github.com/runatlantis/atlantis/server/events/db"
 	"github.com/runatlantis/atlantis/server/logging"
 
@@ -72,6 +73,8 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 	When(logger.GetLevel()).ThenReturn(logging.Info)
 	When(logger.NewLogger("runatlantis/atlantis#1", true, logging.Info)).
 		ThenReturn(pullLogger)
+
+	scope := stats.NewDefaultStore()
 	ch = events.DefaultCommandRunner{
 		VCSClient:                vcsClient,
 		CommitStatusUpdater:      &events.DefaultCommitStatusUpdater{vcsClient, "atlantis"},
@@ -81,6 +84,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		GitlabMergeRequestGetter: gitlabGetter,
 		AzureDevopsPullGetter:    azuredevopsGetter,
 		Logger:                   logger,
+		StatsScope:               scope,
 		AllowForkPRs:             false,
 		AllowForkPRsFlag:         "allow-fork-prs-flag",
 		ProjectCommandBuilder:    projectCommandBuilder,

--- a/server/events/instrumented_project_command_builder.go
+++ b/server/events/instrumented_project_command_builder.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type InstrumentedProjectCommandBuilder struct {
+	ProjectCommandBuilder
+	Logger *logging.SimpleLogger
+}
+
+func (b *InstrumentedProjectCommandBuilder) BuildApplyCommands(ctx *CommandContext, comment *CommentCommand) ([]models.ProjectCommandContext, error) {
+	scope := ctx.Scope.Scope("builder")
+
+	timer := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer timer.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	projectCmds, err := b.ProjectCommandBuilder.BuildApplyCommands(ctx, comment)
+
+	if err != nil {
+		executionError.Inc()
+		b.Logger.Err("Error building apply commands: %s", err)
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return projectCmds, err
+
+}
+func (b *InstrumentedProjectCommandBuilder) BuildAutoplanCommands(ctx *CommandContext) ([]models.ProjectCommandContext, error) {
+	scope := ctx.Scope.Scope("builder")
+
+	timer := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer timer.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	projectCmds, err := b.ProjectCommandBuilder.BuildAutoplanCommands(ctx)
+
+	if err != nil {
+		executionError.Inc()
+		b.Logger.Err("Error building auto plan commands: %s", err)
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return projectCmds, err
+
+}
+func (b *InstrumentedProjectCommandBuilder) BuildPlanCommands(ctx *CommandContext, comment *CommentCommand) ([]models.ProjectCommandContext, error) {
+	scope := ctx.Scope.Scope("builder")
+
+	timer := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer timer.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	projectCmds, err := b.ProjectCommandBuilder.BuildPlanCommands(ctx, comment)
+
+	if err != nil {
+		executionError.Inc()
+		b.Logger.Err("Error building plan commands: %s", err)
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return projectCmds, err
+
+}

--- a/server/events/instrumented_project_command_runner.go
+++ b/server/events/instrumented_project_command_runner.go
@@ -1,0 +1,56 @@
+package events
+
+import (
+	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type InstrumentedProjectCommandRunner struct {
+	ProjectCommandRunner
+}
+
+func (p *InstrumentedProjectCommandRunner) Plan(ctx models.ProjectCommandContext) models.ProjectResult {
+	return RunAndEmitStats("plan", ctx, p.ProjectCommandRunner.Plan)
+}
+
+func (p *InstrumentedProjectCommandRunner) PolicyCheck(ctx models.ProjectCommandContext) models.ProjectResult {
+	return RunAndEmitStats("policy check", ctx, p.ProjectCommandRunner.PolicyCheck)
+}
+
+func (p *InstrumentedProjectCommandRunner) Apply(ctx models.ProjectCommandContext) models.ProjectResult {
+	return RunAndEmitStats("apply", ctx, p.ProjectCommandRunner.Apply)
+}
+
+func RunAndEmitStats(commandName string, ctx models.ProjectCommandContext, execute func(ctx models.ProjectCommandContext) models.ProjectResult) models.ProjectResult {
+
+	// ensures we are differentiating between project level command and overall command
+	ctx.SetScope("project")
+
+	scope := ctx.Scope
+	logger := ctx.Log
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+	executionFailure := scope.NewCounter(metrics.ExecutionFailureMetric)
+
+	result := execute(ctx)
+
+	if result.Error != nil {
+		executionError.Inc()
+		logger.Err("Error running %s operation: %s", commandName, result.Error.Error())
+		return result
+	}
+
+	if result.Failure == "" {
+		executionFailure.Inc()
+		logger.Err("Failure running %s operation: %s", commandName, result.Failure)
+		return result
+	}
+
+	executionSuccess.Inc()
+	return result
+
+}

--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -1,0 +1,8 @@
+package metrics
+
+const (
+	ExecutionTimeMetric    = "execution_time"
+	ExecutionSuccessMetric = "execution_success"
+	ExecutionErrorMetric   = "execution_error"
+	ExecutionFailureMetric = "execution_failure"
+)

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	stats "github.com/lyft/gostats"
 	"github.com/runatlantis/atlantis/server/logging"
 
 	"github.com/pkg/errors"
@@ -335,6 +336,8 @@ type ProjectCommandContext struct {
 	HeadRepo Repo
 	// Log is a logger that's been set up for this context.
 	Log *logging.SimpleLogger
+	// Scope is the scope for reporting stats setup for this context
+	Scope stats.Scope
 	// PullMergeable is true if the pull request for this project is able to be merged.
 	PullMergeable bool
 	// Pull is the pull request we're responding to.
@@ -367,6 +370,12 @@ type ProjectCommandContext struct {
 	// PolicySets represent the policies that are run on the plan as part of the
 	// policy check stage
 	PolicySets valid.PolicySets
+}
+
+// SetScope sets the scope of the stats object field. Note: we deliberately set this on the value
+// instead of a pointer since we want scopes to mirror our function stack
+func (p ProjectCommandContext) SetScope(scope string) {
+	p.Scope = p.Scope.Scope(scope)
 }
 
 // GetShowResultFileName returns the filename (not the path) to store the tf show result

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	stats "github.com/lyft/gostats"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
+	"github.com/runatlantis/atlantis/server/logging"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -38,7 +40,9 @@ func NewProjectCommandBuilder(
 	pendingPlanFinder *DefaultPendingPlanFinder,
 	commentBuilder CommentBuilder,
 	skipCloneNoChanges bool,
-) *DefaultProjectCommandBuilder {
+	scope stats.Scope,
+	logger *logging.SimpleLogger,
+) ProjectCommandBuilder {
 	projectCommandBuilder := &DefaultProjectCommandBuilder{
 		ParserValidator:    parserValidator,
 		ProjectFinder:      projectFinder,
@@ -51,10 +55,14 @@ func NewProjectCommandBuilder(
 		ProjectCommandContextBuilder: NewProjectCommandContextBulder(
 			policyChecksSupported,
 			commentBuilder,
+			scope,
 		),
 	}
 
-	return projectCommandBuilder
+	return &InstrumentedProjectCommandBuilder{
+		ProjectCommandBuilder: projectCommandBuilder,
+		Logger:                logger,
+	}
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_project_command_builder.go ProjectCommandBuilder

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -790,7 +790,7 @@ workflows:
 				PendingPlanFinder:  &DefaultPendingPlanFinder{},
 				SkipCloneNoChanges: true,
 				ProjectCommandContextBuilder: &PolicyCheckProjectCommandContextBuilder{
-					ProjectCommandContextBuilder: &DefaultProjectCommandContextBuilder {
+					ProjectCommandContextBuilder: &DefaultProjectCommandContextBuilder{
 						CommentBuilder: &CommentParser{},
 					},
 					CommentBuilder: &CommentParser{},

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -577,18 +577,19 @@ projects:
 				Ok(t, ioutil.WriteFile(filepath.Join(tmp, "atlantis.yaml"), []byte(c.repoCfg), 0600))
 			}
 
-			builder := NewProjectCommandBuilder(
-				false,
-				parser,
-				&DefaultProjectFinder{},
-				vcsClient,
-				workingDir,
-				NewDefaultWorkingDirLocker(),
-				globalCfg,
-				&DefaultPendingPlanFinder{},
-				&CommentParser{},
-				false,
-			)
+			builder := &DefaultProjectCommandBuilder{
+				ParserValidator:    &yaml.ParserValidator{},
+				ProjectFinder:      &DefaultProjectFinder{},
+				VCSClient:          vcsClient,
+				WorkingDir:         workingDir,
+				WorkingDirLocker:   NewDefaultWorkingDirLocker(),
+				GlobalCfg:          globalCfg,
+				PendingPlanFinder:  &DefaultPendingPlanFinder{},
+				SkipCloneNoChanges: false,
+				ProjectCommandContextBuilder: &DefaultProjectCommandContextBuilder{
+					CommentBuilder: &CommentParser{},
+				},
+			}
 
 			// We run a test for each type of command.
 			for _, cmd := range []models.CommandName{models.PlanCommand, models.ApplyCommand} {
@@ -640,7 +641,7 @@ projects:
 	}
 }
 
-func TestBuildProjectCmdCtx_WithPolicCheckEnabled(t *testing.T) {
+func TestBuildProjectCmdCtx_WithPolicyCheckEnabled(t *testing.T) {
 	emptyPolicySets := valid.PolicySets{
 		Version:    nil,
 		PolicySets: []valid.PolicySet{},
@@ -779,18 +780,22 @@ workflows:
 				Ok(t, ioutil.WriteFile(filepath.Join(tmp, "atlantis.yaml"), []byte(c.repoCfg), 0600))
 			}
 
-			builder := NewProjectCommandBuilder(
-				true,
-				parser,
-				&DefaultProjectFinder{},
-				vcsClient,
-				workingDir,
-				NewDefaultWorkingDirLocker(),
-				globalCfg,
-				&DefaultPendingPlanFinder{},
-				&CommentParser{},
-				false,
-			)
+			builder := &DefaultProjectCommandBuilder{
+				ParserValidator:    &yaml.ParserValidator{},
+				ProjectFinder:      &DefaultProjectFinder{},
+				VCSClient:          vcsClient,
+				WorkingDir:         workingDir,
+				WorkingDirLocker:   NewDefaultWorkingDirLocker(),
+				GlobalCfg:          globalCfg,
+				PendingPlanFinder:  &DefaultPendingPlanFinder{},
+				SkipCloneNoChanges: true,
+				ProjectCommandContextBuilder: &PolicyCheckProjectCommandContextBuilder{
+					ProjectCommandContextBuilder: &DefaultProjectCommandContextBuilder {
+						CommentBuilder: &CommentParser{},
+					},
+					CommentBuilder: &CommentParser{},
+				},
+			}
 
 			cmd := models.PolicyCheckCommand
 			t.Run(cmd.String(), func(t *testing.T) {

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	stats "github.com/lyft/gostats"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
 )
 
-func NewProjectCommandContextBulder(policyCheckEnabled bool, commentBuilder CommentBuilder) ProjectCommandContextBuilder {
+func NewProjectCommandContextBulder(policyCheckEnabled bool, commentBuilder CommentBuilder, scope stats.Scope) ProjectCommandContextBuilder {
 	projectCommandContextBuilder := &DefaultProjectCommandContextBuilder{
 		CommentBuilder: commentBuilder,
 	}
@@ -22,7 +23,11 @@ func NewProjectCommandContextBulder(policyCheckEnabled bool, commentBuilder Comm
 		}
 	}
 
-	return projectCommandContextBuilder
+	return &CommandScopedStatsProjectCommandContextBuilder{
+		ProjectCommandContextBuilder: projectCommandContextBuilder,
+		ProjectCounter: scope.NewCounter("projects"),
+
+	}
 }
 
 type ProjectCommandContextBuilder interface {
@@ -35,6 +40,43 @@ type ProjectCommandContextBuilder interface {
 		repoDir string,
 		automerge, parallelPlan, parallelApply, verbose bool,
 	) []models.ProjectCommandContext
+}
+
+// CommandScopedStatsProjectCommandContextBuilder ensures that project command context contains a scoped stats
+// object relevant to the command it applies to.
+type CommandScopedStatsProjectCommandContextBuilder struct {
+	ProjectCommandContextBuilder
+	// Conciously making this global since it gets flushed periodically anyways
+	ProjectCounter stats.Counter
+}
+
+// BuildProjectContext builds the context and injects the appropriate command level scope after the fact.
+func (cb *CommandScopedStatsProjectCommandContextBuilder) BuildProjectContext(
+	ctx *CommandContext,
+	cmdName models.CommandName,
+	prjCfg valid.MergedProjectCfg,
+	commentFlags []string,
+	repoDir string,
+	automerge, parallelApply, parallelPlan, verbose bool,
+) (projectCmds []models.ProjectCommandContext) {
+	cb.ProjectCounter.Inc()
+
+	cmds := cb.ProjectCommandContextBuilder.BuildProjectContext(
+		ctx, cmdName, prjCfg, commentFlags, repoDir, automerge, parallelApply, parallelPlan, verbose,
+	)
+
+	projectCmds = []models.ProjectCommandContext{}
+
+	for _, cmd := range cmds {
+
+		// specifically use the command name in the context instead of the arg
+		// since we can return multiple commands worth of contexts for a given command name arg
+		// to effectively pipeline them.
+		cmd.SetScope(cmd.CommandName.String())
+		projectCmds = append(projectCmds, cmd)
+	}
+
+	return
 }
 
 type DefaultProjectCommandContextBuilder struct {
@@ -78,6 +120,7 @@ func (cb *DefaultProjectCommandContextBuilder) BuildProjectContext(
 		parallelApply,
 		parallelPlan,
 		verbose,
+		ctx.Scope,
 	))
 
 	return
@@ -128,6 +171,7 @@ func (cb *PolicyCheckProjectCommandContextBuilder) BuildProjectContext(
 			parallelApply,
 			parallelPlan,
 			verbose,
+			ctx.Scope,
 		))
 	}
 
@@ -148,6 +192,7 @@ func newProjectCommandContext(ctx *CommandContext,
 	parallelApplyEnabled bool,
 	parallelPlanEnabled bool,
 	verbose bool,
+	scope stats.Scope,
 ) models.ProjectCommandContext {
 	return models.ProjectCommandContext{
 		CommandName:          cmd,
@@ -161,6 +206,7 @@ func newProjectCommandContext(ctx *CommandContext,
 		Steps:                steps,
 		HeadRepo:             ctx.HeadRepo,
 		Log:                  ctx.Log,
+		Scope:                scope,
 		PullMergeable:        ctx.PullMergeable,
 		Pull:                 ctx.Pull,
 		ProjectName:          projCfg.Name,

--- a/server/events/project_command_context_builder.go
+++ b/server/events/project_command_context_builder.go
@@ -25,8 +25,7 @@ func NewProjectCommandContextBulder(policyCheckEnabled bool, commentBuilder Comm
 
 	return &CommandScopedStatsProjectCommandContextBuilder{
 		ProjectCommandContextBuilder: projectCommandContextBuilder,
-		ProjectCounter: scope.NewCounter("projects"),
-
+		ProjectCounter:               scope.NewCounter("projects"),
 	}
 }
 

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -1,0 +1,228 @@
+package vcs
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/v31/github"
+	stats "github.com/lyft/gostats"
+	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+// NewInstrumentedGithubClient creates a client proxy responsible for gathering stats and logging
+func NewInstrumentedGithubClient(client *GithubClient, statsScope stats.Scope, logger *logging.SimpleLogger) IGithubClient {
+	scope := statsScope.Scope("github")
+
+	instrumentedGHClient := &InstrumentedClient{
+		Client:     client,
+		StatsScope: scope,
+		Logger:     logger,
+	}
+
+	return &InstrumentedGithubClient{
+		InstrumentedClient: instrumentedGHClient,
+		PullRequestGetter:  client,
+		StatsScope:         scope,
+		Logger:             logger,
+	}
+}
+
+type GithubPullRequestGetter interface {
+	GetPullRequest(repo models.Repo, pullNum int) (*github.PullRequest, error)
+}
+
+// IGithubClient exists to bridge the gap between GithubPullRequestGetter and Client interface to allow
+// for a single instrumented client
+type IGithubClient interface {
+	Client
+	GithubPullRequestGetter
+}
+
+// InstrumentedGithubClient should delegate to the underlying InstrumentedClient for vcs provider-agnostic
+// methods and implement soley any github specific interfaces.
+type InstrumentedGithubClient struct {
+	*InstrumentedClient
+	PullRequestGetter GithubPullRequestGetter
+	StatsScope        stats.Scope
+	Logger            *logging.SimpleLogger
+}
+
+func (c *InstrumentedGithubClient) GetPullRequest(repo models.Repo, pullNum int) (*github.PullRequest, error) {
+	scope := c.StatsScope.Scope("get_pull_request")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pullNum), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	pull, err := c.PullRequestGetter.GetPullRequest(repo, pullNum)
+
+	if err != nil {
+		executionError.Inc()
+		logger.Err("Unable to get pull number for repo, error: %s", err.Error())
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return pull, err
+
+}
+
+type InstrumentedClient struct {
+	Client
+	StatsScope stats.Scope
+	Logger     *logging.SimpleLogger
+}
+
+func (c *InstrumentedClient) GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]string, error) {
+	scope := c.StatsScope.Scope("get_modified_files")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pull.Num), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	files, err := c.Client.GetModifiedFiles(repo, pull)
+
+	if err != nil {
+		executionError.Inc()
+		logger.Err("Unable to get modified files, error: %s", err.Error())
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return files, err
+
+}
+func (c *InstrumentedClient) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
+	scope := c.StatsScope.Scope("create_comment")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pullNum), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	if err := c.Client.CreateComment(repo, pullNum, comment, command); err != nil {
+		executionError.Inc()
+		logger.Err("Unable to create comment for command %s, error: %s", command, err.Error())
+		return err
+	}
+
+	executionSuccess.Inc()
+	return nil
+}
+func (c *InstrumentedClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+	scope := c.StatsScope.Scope("hide_prev_plan_comments")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pullNum), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	if err := c.Client.HidePrevPlanComments(repo, pullNum); err != nil {
+		executionError.Inc()
+		logger.Err("Unable to hide previous plan comments, error: %s", err.Error())
+		return err
+	}
+
+	executionSuccess.Inc()
+	return nil
+
+}
+func (c *InstrumentedClient) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error) {
+	scope := c.StatsScope.Scope("pull_is_approved")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pull.Num), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	approved, err := c.Client.PullIsApproved(repo, pull)
+
+	if err != nil {
+		executionError.Inc()
+		logger.Err("Unable to check pull approval status, error: %s", err.Error())
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return approved, err
+
+}
+func (c *InstrumentedClient) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+	scope := c.StatsScope.Scope("pull_is_mergeable")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pull.Num), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	mergeable, err := c.Client.PullIsMergeable(repo, pull)
+
+	if err != nil {
+		executionError.Inc()
+		logger.Err("Unable to check pull mergeable status, error: %s", err.Error())
+	} else {
+		executionSuccess.Inc()
+	}
+
+	return mergeable, err
+}
+
+func (c *InstrumentedClient) UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, src string, description string, url string) error {
+	scope := c.StatsScope.Scope("update_status")
+	logger := c.Logger.NewLogger(fmtLogSrc(repo, pull.Num), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	if err := c.Client.UpdateStatus(repo, pull, state, src, description, url); err != nil {
+		executionError.Inc()
+		logger.Err("Unable to update status at url: %s, error: %s", url, err.Error())
+		return err
+	}
+
+	executionSuccess.Inc()
+	return nil
+
+}
+func (c *InstrumentedClient) MergePull(pull models.PullRequest) error {
+	scope := c.StatsScope.Scope("merge_pull")
+	logger := c.Logger.NewLogger(fmt.Sprintf("#%d", pull.Num), true, c.Logger.GetLevel())
+
+	executionTime := scope.NewTimer(metrics.ExecutionTimeMetric).AllocateSpan()
+	defer executionTime.Complete()
+
+	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
+	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
+
+	if err := c.Client.MergePull(pull); err != nil {
+		executionError.Inc()
+		logger.Err("Unable to merge pull, error: %s", err.Error())
+	}
+
+	executionSuccess.Inc()
+	return nil
+
+}
+
+// taken from other parts of the code, would be great to have this in a shared spot
+func fmtLogSrc(repo models.Repo, pullNum int) string {
+	return fmt.Sprintf("%s#%d", repo.FullName, pullNum)
+}

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-github/v31/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
+	stats "github.com/lyft/gostats"
 	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server"
 	"github.com/runatlantis/atlantis/server/events"
@@ -936,6 +937,8 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 		Drainer:               drainer,
 		PreWorkflowHookRunner: &runtime.PreWorkflowHookRunner{},
 	}
+	statsScope := stats.NewStore(stats.NewNullSink(), false)
+
 	projectCommandBuilder := events.NewProjectCommandBuilder(
 		policyChecksEnabled,
 		parser,
@@ -947,6 +950,8 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 		&events.DefaultPendingPlanFinder{},
 		commentParser,
 		false,
+		statsScope,
+		logger,
 	)
 
 	commandRunner := &events.DefaultCommandRunner{
@@ -987,6 +992,7 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 		CommitStatusUpdater:      e2eStatusUpdater,
 		MarkdownRenderer:         &events.MarkdownRenderer{},
 		Logger:                   logger,
+		StatsScope:               statsScope,
 		AllowForkPRs:             allowForkPRs,
 		AllowForkPRsFlag:         "allow-fork-prs",
 		ProjectCommandBuilder:    projectCommandBuilder,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -39,6 +39,7 @@ type UserConfig struct {
 	GitlabWebhookSecret        string `mapstructure:"gitlab-webhook-secret"`
 	HidePrevPlanComments       bool   `mapstructure:"hide-prev-plan-comments"`
 	LogLevel                   string `mapstructure:"log-level"`
+	StatsNamespace             string `mapstructure:"stats-namespace"`
 	PlanDrafts                 bool   `mapstructure:"allow-draft-prs"`
 	Port                       int    `mapstructure:"port"`
 	RepoConfig                 string `mapstructure:"repo-config"`


### PR DESCRIPTION
Added a namespace flag. For our usecase we can add `production.app.atlantis.$ENVIRONMENT` which we will pass in through our server config.

Based on this change you can imagine our metrics will look something like this:
```

#execution time for planning all projects in a given command
production.app.atlantis.production.cmd.comment.plan.execution_time 

# builder metrics
production.app.atlantis.production.cmd.comment.plan.builder.
production.app.atlantis.production.autoplan.builder.

#per project command metrics
production.app.atlantis.production.cmd.comment.plan.policy_check.project.execution_time 

#number of projects in a given command
production.app.atlantis.production.projects.count 

#github client metrics
production.app.atlantis.production.github.pull_is_mergeable
```