### PR TITLE
Adding parallel plan execution logic per project.

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	paths "path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -370,6 +371,16 @@ type ProjectCommandContext struct {
 	// PolicySets represent the policies that are run on the plan as part of the
 	// policy check stage
 	PolicySets valid.PolicySets
+}
+
+// ProjectCloneDir creates relative path to clone the repo to. If we are running
+// plans and apply in parallel we want to have a directory per project.
+func (p ProjectCommandContext) ProjectCloneDir() string {
+	if p.ParallelPlanEnabled || p.ParallelApplyEnabled {
+		return filepath.Join(p.ProjectName, p.Workspace)
+	}
+
+	return p.Workspace
 }
 
 // SetScope sets the scope of the stats object field. Note: we deliberately set this on the value

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -174,14 +174,14 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx models.ProjectCommandCon
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.ProjectCloneDir())
 	if err != nil {
 		return nil, "", err
 	}
 	defer unlockFn()
 
 	// Clone is idempotent so okay to run even if the repo was already cloned.
-	repoDir, hasDiverged, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, ctx.Workspace)
+	repoDir, hasDiverged, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, ctx.ProjectCloneDir())
 	if cloneErr != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after policy_check error: %v", unlockErr)
@@ -222,14 +222,14 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx models.ProjectCommandContext) (
 	ctx.Log.Debug("acquired lock for project")
 
 	// Acquire internal lock for the directory we're going to operate in.
-	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.Workspace)
+	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, ctx.ProjectCloneDir())
 	if err != nil {
 		return nil, "", err
 	}
 	defer unlockFn()
 
 	// Clone is idempotent so okay to run even if the repo was already cloned.
-	repoDir, hasDiverged, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, ctx.Workspace)
+	repoDir, hasDiverged, cloneErr := p.WorkingDir.Clone(ctx.Log, ctx.HeadRepo, ctx.Pull, ctx.ProjectCloneDir())
 	if cloneErr != nil {
 		if unlockErr := lockAttempt.UnlockFn(); unlockErr != nil {
 			ctx.Log.Err("error unlocking state after plan error: %v", unlockErr)

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -37,7 +37,7 @@ type WorkingDir interface {
 	// absolute path to the root of the cloned repo. It also returns
 	// a boolean indicating if we should warn users that the branch we're
 	// merging into has been updated since we cloned it.
-	Clone(log *logging.SimpleLogger, headRepo models.Repo, p models.PullRequest, workspace string) (string, bool, error)
+	Clone(log *logging.SimpleLogger, headRepo models.Repo, p models.PullRequest, projectCloneDir string) (string, bool, error)
 	// GetWorkingDir returns the path to the workspace for this repo and pull.
 	// If workspace does not exist on disk, error will be of type os.IsNotExist.
 	GetWorkingDir(r models.Repo, p models.PullRequest, workspace string) (string, error)
@@ -74,8 +74,8 @@ func (w *FileWorkspace) Clone(
 	log *logging.SimpleLogger,
 	headRepo models.Repo,
 	p models.PullRequest,
-	workspace string) (string, bool, error) {
-	cloneDir := w.cloneDir(p.BaseRepo, p, workspace)
+	projectCloneDir string) (string, bool, error) {
+	cloneDir := w.cloneDir(p.BaseRepo, p, projectCloneDir)
 
 	// If the directory already exists, check if it's at the right commit.
 	// If so, then we do nothing.


### PR DESCRIPTION
To allow for parallel plans per project we will clone the repository per
project. Another optimisation we can perform is to copy the default
repository that is cloned regardless of the execution type. Default
workspace is required to be cloned to setup the project configs.