### PR TITLE
[ORCA-548] Ensure policy check does not run for tf versions < 0.12.0

### DIFF
--- a/server/events/runtime/minimum_version_step_runner_delegate.go
+++ b/server/events/runtime/minimum_version_step_runner_delegate.go
@@ -1,0 +1,44 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+// MinimumVersionStepRunnerDelegate ensures that a given step runner can't run unless the command version being used
+// is greater than a provided minimum
+type MinimumVersionStepRunnerDelegate struct {
+	minimumVersion   *version.Version
+	defaultTfVersion *version.Version
+	delegate         Runner
+}
+
+func NewMinimumVersionStepRunnerDelegate(minimumVersionStr string, defaultVersion *version.Version, delegate Runner) (Runner, error) {
+	minimumVersion, err := version.NewVersion(minimumVersionStr)
+
+	if err != nil {
+		return &MinimumVersionStepRunnerDelegate{}, errors.Wrap(err, "initializing minimum version")
+	}
+
+	return &MinimumVersionStepRunnerDelegate{
+		minimumVersion:   minimumVersion,
+		defaultTfVersion: defaultVersion,
+		delegate:         delegate,
+	}, nil
+}
+
+func (r *MinimumVersionStepRunnerDelegate) Run(ctx models.ProjectCommandContext, extraArgs []string, path string, envs map[string]string) (string, error) {
+	tfVersion := r.defaultTfVersion
+	if ctx.TerraformVersion != nil {
+		tfVersion = ctx.TerraformVersion
+	}
+
+	if tfVersion.LessThan(r.minimumVersion) {
+		return fmt.Sprintf("Version: %s is unsupported for this step. Minimum version is: %s", tfVersion.String(), r.minimumVersion.String()), nil
+	}
+
+	return r.delegate.Run(ctx, extraArgs, path, envs)
+}

--- a/server/events/runtime/minimum_version_step_runner_delegate_test.go
+++ b/server/events/runtime/minimum_version_step_runner_delegate_test.go
@@ -1,0 +1,120 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	. "github.com/petergtz/pegomock"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/runtime/mocks"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestRunMinimumVersionDelegate(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	mockDelegate := mocks.NewMockRunner()
+
+	tfVersion12, _ := version.NewVersion("0.12.0")
+	tfVersion11, _ := version.NewVersion("0.11.14")
+
+	// these stay the same for all tests
+	extraArgs := []string{"extra", "args"}
+	envs := map[string]string{}
+	path := ""
+
+	expectedOut := "some valid output from delegate"
+
+	t.Run("default version success", func(t *testing.T) {
+		subject := &MinimumVersionStepRunnerDelegate{
+			defaultTfVersion: tfVersion12,
+			minimumVersion:   tfVersion12,
+			delegate:         mockDelegate,
+		}
+
+		ctx := models.ProjectCommandContext{}
+
+		When(mockDelegate.Run(ctx, extraArgs, path, envs)).ThenReturn(expectedOut, nil)
+
+		output, err := subject.Run(
+			ctx,
+			extraArgs,
+			path,
+			envs,
+		)
+
+		Equals(t, expectedOut, output)
+		Ok(t, err)
+	})
+
+	t.Run("ctx version success", func(t *testing.T) {
+		subject := &MinimumVersionStepRunnerDelegate{
+			defaultTfVersion: tfVersion11,
+			minimumVersion:   tfVersion12,
+			delegate:         mockDelegate,
+		}
+
+		ctx := models.ProjectCommandContext{
+			TerraformVersion: tfVersion12,
+		}
+
+		When(mockDelegate.Run(ctx, extraArgs, path, envs)).ThenReturn(expectedOut, nil)
+
+		output, err := subject.Run(
+			ctx,
+			extraArgs,
+			path,
+			envs,
+		)
+
+		Equals(t, expectedOut, output)
+		Ok(t, err)
+	})
+
+	t.Run("default version failure", func(t *testing.T) {
+		subject := &MinimumVersionStepRunnerDelegate{
+			defaultTfVersion: tfVersion11,
+			minimumVersion:   tfVersion12,
+			delegate:         mockDelegate,
+		}
+
+		ctx := models.ProjectCommandContext{}
+
+		output, err := subject.Run(
+			ctx,
+			extraArgs,
+			path,
+			envs,
+		)
+
+		mockDelegate.VerifyWasCalled(Never())
+
+		Equals(t, "Version: 0.11.14 is unsupported for this step. Minimum version is: 0.12.0", output)
+		Ok(t, err)
+	})
+
+	t.Run("ctx version failure", func(t *testing.T) {
+		subject := &MinimumVersionStepRunnerDelegate{
+			defaultTfVersion: tfVersion12,
+			minimumVersion:   tfVersion12,
+			delegate:         mockDelegate,
+		}
+
+		ctx := models.ProjectCommandContext{
+			TerraformVersion: tfVersion11,
+		}
+
+		output, err := subject.Run(
+			ctx,
+			extraArgs,
+			path,
+			envs,
+		)
+
+		mockDelegate.VerifyWasCalled(Never())
+
+		Equals(t, "Version: 0.11.14 is unsupported for this step. Minimum version is: 0.12.0", output)
+		Ok(t, err)
+	})
+
+}

--- a/server/events/runtime/policy_check_step_runner.go
+++ b/server/events/runtime/policy_check_step_runner.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
 )
@@ -12,14 +13,17 @@ type PolicyCheckStepRunner struct {
 }
 
 // NewPolicyCheckStepRunner creates a new step runner from an executor workflow
-func NewPolicyCheckStepRunner(executorWorkflow VersionedExecutorWorkflow) Runner {
-	return &PlanTypeStepRunnerDelegate{
+func NewPolicyCheckStepRunner(defaultTfVersion *version.Version, executorWorkflow VersionedExecutorWorkflow) (Runner, error) {
+
+	runner := &PlanTypeStepRunnerDelegate{
 		defaultRunner: &PolicyCheckStepRunner{
 			versionEnsurer: executorWorkflow,
 			executor:       executorWorkflow,
 		},
 		remotePlanRunner: RemoteBackendUnsupportedRunner{},
 	}
+
+	return NewMinimumVersionStepRunnerDelegate(minimumShowTfVersion, defaultTfVersion, runner)
 }
 
 // Run ensures a given version for the executable, builds the args from the project context and then runs executable returning the result

--- a/server/events/runtime/show_step_runner.go
+++ b/server/events/runtime/show_step_runner.go
@@ -10,14 +10,18 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-func NewShowStepRunner(executor TerraformExec, defaultTFVersion *version.Version) Runner {
-	return &PlanTypeStepRunnerDelegate{
+const minimumShowTfVersion string = "0.12.0"
+
+func NewShowStepRunner(executor TerraformExec, defaultTFVersion *version.Version) (Runner, error) {
+	runner := &PlanTypeStepRunnerDelegate{
 		defaultRunner: &ShowStepRunner{
 			TerraformExecutor: executor,
 			DefaultTFVersion:  defaultTFVersion,
 		},
 		remotePlanRunner: NullRunner{},
 	}
+
+	return NewMinimumVersionStepRunnerDelegate(minimumShowTfVersion, defaultTFVersion, runner)
 }
 
 // ShowStepRunner runs terraform show on an existing plan file and outputs it to a json file

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -954,6 +954,17 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 		logger,
 	)
 
+	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTFVersion)
+
+	Ok(t, err)
+
+	policyCheckRunner, err := runtime.NewPolicyCheckStepRunner(
+		defaultTFVersion,
+		policy.NewConfTestExecutorWorkflow(logger, binDir, &NoopTFDownloader{}),
+	)
+
+	Ok(t, err)
+
 	commandRunner := &events.DefaultCommandRunner{
 		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
 			Locker:           projectLocker,
@@ -966,13 +977,8 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 				TerraformExecutor: terraformClient,
 				DefaultTFVersion:  defaultTFVersion,
 			},
-			ShowStepRunner: &runtime.ShowStepRunner{
-				TerraformExecutor: terraformClient,
-				DefaultTFVersion:  defaultTFVersion,
-			},
-			PolicyCheckStepRunner: runtime.NewPolicyCheckStepRunner(
-				policy.NewConfTestExecutorWorkflow(logger, binDir, &NoopTFDownloader{}),
-			),
+			ShowStepRunner:        showStepRunner,
+			PolicyCheckStepRunner: policyCheckRunner,
 			ApplyStepRunner: &runtime.ApplyStepRunner{
 				TerraformExecutor: terraformClient,
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -418,6 +418,21 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		logger,
 	)
 
+	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfVersion)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing show step runner")
+	}
+
+	policyCheckRunner, err := runtime.NewPolicyCheckStepRunner(
+		defaultTfVersion,
+		policy.NewConfTestExecutorWorkflow(logger, binDir, &terraform.DefaultDownloader{}),
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing policy check runner")
+	}
+
 	projectCommandRunner := &events.DefaultProjectCommandRunner{
 		Locker:           projectLocker,
 		LockURLGenerator: router,
@@ -431,10 +446,8 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			CommitStatusUpdater: commitStatusUpdater,
 			AsyncTFExec:         terraformClient,
 		},
-		ShowStepRunner: runtime.NewShowStepRunner(terraformClient, defaultTfVersion),
-		PolicyCheckStepRunner: runtime.NewPolicyCheckStepRunner(
-			policy.NewConfTestExecutorWorkflow(logger, binDir, &terraform.DefaultDownloader{}),
-		),
+		ShowStepRunner: showStepRunner,
+		PolicyCheckStepRunner: policyCheckRunner,
 		ApplyStepRunner: &runtime.ApplyStepRunner{
 			TerraformExecutor:   terraformClient,
 			CommitStatusUpdater: commitStatusUpdater,

--- a/server/server.go
+++ b/server/server.go
@@ -446,7 +446,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			CommitStatusUpdater: commitStatusUpdater,
 			AsyncTFExec:         terraformClient,
 		},
-		ShowStepRunner: showStepRunner,
+		ShowStepRunner:        showStepRunner,
 		PolicyCheckStepRunner: policyCheckRunner,
 		ApplyStepRunner: &runtime.ApplyStepRunner{
 			TerraformExecutor:   terraformClient,


### PR DESCRIPTION
since we can't get a json plan prior to 0.12.0, we should just not run this step. Instead of failing we just output the message since we take the approach of enabling the feature for workspaces that can support it and not forcing clients to do upgrades.