### PR TITLE
[ORCA-558] Fix mergeability clause for tfe statuses.

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -310,7 +310,7 @@ func (g *GithubClient) getSubmitQueueMergeability(repo models.Repo, pull models.
 			ownersCheckApplied = true
 		}
 
-		if status.GetContext() == AtlantisApplyStatusContext ||
+		if strings.HasPrefix(status.GetContext(), AtlantisApplyStatusContext) ||
 			state == "success" ||
 			(state == "pending" && status.GetContext() == SubmitQueueReadinessStatusContext) {
 			continue

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -598,6 +598,7 @@ func TestGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 				fmt.Sprintf(statusJSON, "pending", "sq-ready-to-merge"),
 				fmt.Sprintf(statusJSON, "success", "_owners-check"),
 				fmt.Sprintf(statusJSON, "failure", "atlantis/apply"),
+				fmt.Sprintf(statusJSON, "failure", "atlantis/apply: terraform_cloud_workspace"),
 			},
 			true,
 		},


### PR DESCRIPTION
TF Enterprise/Cloud have the apply statuses as:
```
atlantis/apply: <WS_NAME>
```

so we need to check the prefix instead of the whole status.