### PR TITLE
[ORCA-559] Fix hide previous command logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/Laisky/graphql v1.0.4
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.15.0+incompatible
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/aws/aws-sdk-go v1.17.14 // indirect
@@ -64,7 +62,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200403201458-baeed622b8d8
 	golang.org/x/oauth2 v0.0.0-20191122200657-5d9234df094c // indirect
 	google.golang.org/appengine v1.6.5 // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.20.2
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,6 @@ github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 h1:EBTWhcAX7rNQ80RLwLCpHZBBrJuzallFHnF+yMXo928=
-github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
@@ -118,6 +114,7 @@ github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVo
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-getter v1.4.0 h1:ENHNi8494porjD0ZhIrjlAHnveSFhY7hvOJrV/fsKkw=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
@@ -150,6 +147,7 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -189,12 +187,12 @@ github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb h1:e+l77LJOEqXTIQih
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/nlopes/slack v0.1.0 h1:YnVhdQvWT/m0TDh3VNpSoCBDlD7Y4pz1qUqb/NrNyUs=
 github.com/nlopes/slack v0.1.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.9.0 h1:SZjF721BByVj8QH636/8S2DnX4n0Re3SteMmw3N+tzc=
-github.com/onsi/ginkgo v1.9.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -206,8 +204,6 @@ github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWo
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.0.0 h1:QFDlmAXZrfPXEF6c9+15fMqhQIS3O0pxszhnk936vg4=
 github.com/pelletier/go-toml v1.0.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/petergtz/pegomock v2.7.0+incompatible h1:42rJ5wIOBAg9OGdkLaPW9PlF/RtqDc5aGl6PcTCXl3o=
-github.com/petergtz/pegomock v2.7.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
 github.com/petergtz/pegomock v2.9.0+incompatible h1:BKfb5XfkJfehe5T+O1xD4Zm26Sb9dnRj7tHxLYwUPiI=
 github.com/petergtz/pegomock v2.9.0+incompatible/go.mod h1:nuBLWZpVyv/fLo56qTwt/AUau7jgouO1h7bEvZCq82o=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -244,6 +240,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
@@ -253,8 +250,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/negroni v0.2.0 h1:cadBY8/+9L/dTagBqV7N0l/SJiB4Wg+os5QdmaFY5Wg=
 github.com/urfave/negroni v0.2.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/xanzy/go-gitlab v0.22.2-0.20191127083556-16a492660b8c h1:3F9W4LSqOnDh5Jwxoo2aq5EZMDrueyScA53Ium7/ZpE=
-github.com/xanzy/go-gitlab v0.22.2-0.20191127083556-16a492660b8c/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xanzy/go-gitlab v0.34.1 h1:Dtqla2gWIQIevfZVS6FY4qjgrKf+5LYLzW6XBNstGSw=
 github.com/xanzy/go-gitlab v0.34.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/zclconf/go-cty v1.0.0 h1:EWtv3gKe2wPLIB9hQRQJa7k/059oIfAqcEkCNnaVckk=
@@ -294,8 +289,6 @@ golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 h1:e6HwijUxhDe+hPNjZQQn9bA5PW3vNmnN64U2ZW759Lk=
-golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -349,6 +342,7 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0 h1:Dh6fw+p6FyRl5x/FvNswO1ji0lIGzm3KP8Y9VkS9PTE=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -382,8 +376,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -403,6 +395,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -350,7 +350,7 @@ func (c *DefaultCommandRunner) updatePull(ctx *CommandContext, command PullComma
 	// clutter in a pull/merge request. This will not delete the comment, since the
 	// comment trail may be useful in auditing or backtracing problems.
 	if c.HidePrevPlanComments {
-		if err := c.VCSClient.HidePrevPlanComments(ctx.Pull.BaseRepo, ctx.Pull.Num); err != nil {
+		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, command.CommandName().String()); err != nil {
 			ctx.Log.Err("unable to hide old comments: %s", err)
 		}
 	}

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -350,7 +350,7 @@ func (c *DefaultCommandRunner) updatePull(ctx *CommandContext, command PullComma
 	// clutter in a pull/merge request. This will not delete the comment, since the
 	// comment trail may be useful in auditing or backtracing problems.
 	if c.HidePrevPlanComments {
-		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, command.CommandName().String()); err != nil {
+		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, command.CommandName().TitleString()); err != nil {
 			ctx.Log.Err("unable to hide old comments: %s", err)
 		}
 	}

--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -23,11 +23,11 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-const (
-	planCommandTitle            = "Plan"
-	applyCommandTitle           = "Apply"
-	policyCheckCommandTitle     = "Policy Check"
-	approvePoliciesCommandTitle = "Approve Policies"
+var (
+	planCommandTitle            = models.PlanCommand.TitleString()
+	applyCommandTitle           = models.ApplyCommand.TitleString()
+	policyCheckCommandTitle     = models.PolicyCheckCommand.TitleString()
+	approvePoliciesCommandTitle = models.ApprovePoliciesCommand.TitleString()
 	// maxUnwrappedLines is the maximum number of lines the Terraform output
 	// can be before we wrap it in an expandable template.
 	maxUnwrappedLines = 12

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -601,6 +601,12 @@ const (
 	// Adding more? Don't forget to update String() below
 )
 
+// TitleString returns the string representation in title form.
+// ie. policy_check becomes Policy Check
+func (c CommandName) TitleString() string {
+	return strings.Title(strings.ReplaceAll(strings.ToLower(c.String()), "_", " "))
+}
+
 // String returns the string representation of c.
 func (c CommandName) String() string {
 	switch c {

--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -124,7 +124,7 @@ func (g *AzureDevopsClient) CreateComment(repo models.Repo, pullNum int, comment
 	return nil
 }
 
-func (g *AzureDevopsClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (g *AzureDevopsClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	return nil
 }
 

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -100,7 +100,7 @@ func (b *Client) CreateComment(repo models.Repo, pullNum int, comment string, co
 	return err
 }
 
-func (b *Client) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (b *Client) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	return nil
 }
 

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -141,7 +141,7 @@ func (b *Client) CreateComment(repo models.Repo, pullNum int, comment string, co
 	return nil
 }
 
-func (b *Client) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (b *Client) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	return nil
 }
 

--- a/server/events/vcs/client.go
+++ b/server/events/vcs/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	// relative to the repo root, e.g. parent/child/file.txt.
 	GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]string, error)
 	CreateComment(repo models.Repo, pullNum int, comment string, command string) error
-	HidePrevPlanComments(repo models.Repo, pullNum int) error
+	HidePrevCommandComments(repo models.Repo, pullNum int, command string) error
 	PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error)
 	PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error)
 	// UpdateStatus updates the commit status to state for pull. src is the

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -211,7 +211,9 @@ func (g *GithubClient) HidePrevCommandComments(repo models.Repo, pullNum int, co
 			continue
 		}
 		firstLine := strings.ToLower(body[0])
-		if !strings.Contains(firstLine, command) {
+		g.logger.Debug("Command Name: %s", command)
+		g.logger.Debug("First line: %s", firstLine)
+		if !strings.Contains(firstLine, strings.ToLower(command)) {
 			continue
 		}
 		var m struct {

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -175,7 +175,7 @@ func (g *GithubClient) CreateComment(repo models.Repo, pullNum int, comment stri
 	return nil
 }
 
-func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (g *GithubClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	var allComments []*github.IssueComment
 	nextPage := 0
 	for {
@@ -211,7 +211,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 			continue
 		}
 		firstLine := strings.ToLower(body[0])
-		if !strings.Contains(firstLine, models.PlanCommand.String()) {
+		if !strings.Contains(firstLine, command) {
 			continue
 		}
 		var m struct {

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -225,7 +225,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 			},
 		},
 		123,
-		models.PlanCommand.String(),
+		models.PlanCommand.TitleString(),
 	)
 	Ok(t, err)
 	Equals(t, 2, len(gotMinimizeCalls))
@@ -314,7 +314,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 			},
 		},
 		123,
-		models.PlanCommand.String(),
+		models.PlanCommand.TitleString(),
 	)
 	Ok(t, err)
 	Equals(t, 3, len(gotMinimizeCalls))

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -212,7 +212,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	Ok(t, err)
 	defer disableSSLVerification()()
 
-	err = client.HidePrevPlanComments(
+	err = client.HidePrevCommandComments(
 		models.Repo{
 			FullName:          "owner/repo",
 			Owner:             "owner",
@@ -225,6 +225,7 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 			},
 		},
 		123,
+		models.PlanCommand.String(),
 	)
 	Ok(t, err)
 	Equals(t, 2, len(gotMinimizeCalls))
@@ -300,7 +301,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	Ok(t, err)
 	defer disableSSLVerification()()
 
-	err = client.HidePrevPlanComments(
+	err = client.HidePrevCommandComments(
 		models.Repo{
 			FullName:          "owner/repo",
 			Owner:             "owner",
@@ -313,6 +314,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 			},
 		},
 		123,
+		models.PlanCommand.String(),
 	)
 	Ok(t, err)
 	Equals(t, 3, len(gotMinimizeCalls))

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -148,7 +148,7 @@ func (g *GitlabClient) CreateComment(repo models.Repo, pullNum int, comment stri
 	return err
 }
 
-func (g *GitlabClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (g *GitlabClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	return nil
 }
 

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -130,7 +130,7 @@ func (c *InstrumentedClient) HidePrevCommandComments(repo models.Repo, pullNum i
 
 	if err := c.Client.HidePrevCommandComments(repo, pullNum, command); err != nil {
 		executionError.Inc()
-		logger.Err("Unable to hide previous plan comments, error: %s", err.Error())
+		logger.Err("Unable to hide previous %s comments, error: %s", command, err.Error())
 		return err
 	}
 

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -118,7 +118,7 @@ func (c *InstrumentedClient) CreateComment(repo models.Repo, pullNum int, commen
 	executionSuccess.Inc()
 	return nil
 }
-func (c *InstrumentedClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (c *InstrumentedClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	scope := c.StatsScope.Scope("hide_prev_plan_comments")
 	logger := c.Logger.NewLogger(fmtLogSrc(repo, pullNum), true, c.Logger.GetLevel())
 
@@ -128,7 +128,7 @@ func (c *InstrumentedClient) HidePrevPlanComments(repo models.Repo, pullNum int)
 	executionSuccess := scope.NewCounter(metrics.ExecutionSuccessMetric)
 	executionError := scope.NewCounter(metrics.ExecutionErrorMetric)
 
-	if err := c.Client.HidePrevPlanComments(repo, pullNum); err != nil {
+	if err := c.Client.HidePrevCommandComments(repo, pullNum, command); err != nil {
 		executionError.Inc()
 		logger.Err("Unable to hide previous plan comments, error: %s", err.Error())
 		return err

--- a/server/events/vcs/mocks/matchers/models_commitstatus.go
+++ b/server/events/vcs/mocks/matchers/models_commitstatus.go
@@ -2,8 +2,9 @@
 package matchers
 
 import (
-	"reflect"
 	"github.com/petergtz/pegomock"
+	"reflect"
+
 	models "github.com/runatlantis/atlantis/server/events/models"
 )
 
@@ -15,6 +16,18 @@ func AnyModelsCommitStatus() models.CommitStatus {
 
 func EqModelsCommitStatus(value models.CommitStatus) models.CommitStatus {
 	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
+	var nullValue models.CommitStatus
+	return nullValue
+}
+
+func NotEqModelsCommitStatus(value models.CommitStatus) models.CommitStatus {
+	pegomock.RegisterMatcher(&pegomock.NotEqMatcher{Value: value})
+	var nullValue models.CommitStatus
+	return nullValue
+}
+
+func ModelsCommitStatusThat(matcher pegomock.ArgumentMatcher) models.CommitStatus {
+	pegomock.RegisterMatcher(matcher)
 	var nullValue models.CommitStatus
 	return nullValue
 }

--- a/server/events/vcs/mocks/matchers/models_pullrequest.go
+++ b/server/events/vcs/mocks/matchers/models_pullrequest.go
@@ -2,8 +2,9 @@
 package matchers
 
 import (
-	"reflect"
 	"github.com/petergtz/pegomock"
+	"reflect"
+
 	models "github.com/runatlantis/atlantis/server/events/models"
 )
 
@@ -15,6 +16,18 @@ func AnyModelsPullRequest() models.PullRequest {
 
 func EqModelsPullRequest(value models.PullRequest) models.PullRequest {
 	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
+	var nullValue models.PullRequest
+	return nullValue
+}
+
+func NotEqModelsPullRequest(value models.PullRequest) models.PullRequest {
+	pegomock.RegisterMatcher(&pegomock.NotEqMatcher{Value: value})
+	var nullValue models.PullRequest
+	return nullValue
+}
+
+func ModelsPullRequestThat(matcher pegomock.ArgumentMatcher) models.PullRequest {
+	pegomock.RegisterMatcher(matcher)
 	var nullValue models.PullRequest
 	return nullValue
 }

--- a/server/events/vcs/mocks/matchers/models_repo.go
+++ b/server/events/vcs/mocks/matchers/models_repo.go
@@ -2,8 +2,9 @@
 package matchers
 
 import (
-	"reflect"
 	"github.com/petergtz/pegomock"
+	"reflect"
+
 	models "github.com/runatlantis/atlantis/server/events/models"
 )
 
@@ -15,6 +16,18 @@ func AnyModelsRepo() models.Repo {
 
 func EqModelsRepo(value models.Repo) models.Repo {
 	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
+	var nullValue models.Repo
+	return nullValue
+}
+
+func NotEqModelsRepo(value models.Repo) models.Repo {
+	pegomock.RegisterMatcher(&pegomock.NotEqMatcher{Value: value})
+	var nullValue models.Repo
+	return nullValue
+}
+
+func ModelsRepoThat(matcher pegomock.ArgumentMatcher) models.Repo {
+	pegomock.RegisterMatcher(matcher)
 	var nullValue models.Repo
 	return nullValue
 }

--- a/server/events/vcs/mocks/matchers/slice_of_byte.go
+++ b/server/events/vcs/mocks/matchers/slice_of_byte.go
@@ -2,9 +2,8 @@
 package matchers
 
 import (
-	"reflect"
 	"github.com/petergtz/pegomock"
-	
+	"reflect"
 )
 
 func AnySliceOfByte() []byte {
@@ -15,6 +14,18 @@ func AnySliceOfByte() []byte {
 
 func EqSliceOfByte(value []byte) []byte {
 	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
+	var nullValue []byte
+	return nullValue
+}
+
+func NotEqSliceOfByte(value []byte) []byte {
+	pegomock.RegisterMatcher(&pegomock.NotEqMatcher{Value: value})
+	var nullValue []byte
+	return nullValue
+}
+
+func SliceOfByteThat(matcher pegomock.ArgumentMatcher) []byte {
+	pegomock.RegisterMatcher(matcher)
 	var nullValue []byte
 	return nullValue
 }

--- a/server/events/vcs/mocks/matchers/slice_of_string.go
+++ b/server/events/vcs/mocks/matchers/slice_of_string.go
@@ -2,9 +2,8 @@
 package matchers
 
 import (
-	"reflect"
 	"github.com/petergtz/pegomock"
-	
+	"reflect"
 )
 
 func AnySliceOfString() []string {
@@ -15,6 +14,18 @@ func AnySliceOfString() []string {
 
 func EqSliceOfString(value []string) []string {
 	pegomock.RegisterMatcher(&pegomock.EqMatcher{Value: value})
+	var nullValue []string
+	return nullValue
+}
+
+func NotEqSliceOfString(value []string) []string {
+	pegomock.RegisterMatcher(&pegomock.NotEqMatcher{Value: value})
+	var nullValue []string
+	return nullValue
+}
+
+func SliceOfStringThat(matcher pegomock.ArgumentMatcher) []string {
+	pegomock.RegisterMatcher(matcher)
 	var nullValue []string
 	return nullValue
 }

--- a/server/events/vcs/mocks/mock_client.go
+++ b/server/events/vcs/mocks/mock_client.go
@@ -59,12 +59,12 @@ func (mock *MockClient) CreateComment(repo models.Repo, pullNum int, comment str
 	return ret0
 }
 
-func (mock *MockClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (mock *MockClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockClient().")
 	}
-	params := []pegomock.Param{repo, pullNum}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("HidePrevPlanComments", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
+	params := []pegomock.Param{repo, pullNum, command}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("HidePrevCommandComments", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 error
 	if len(result) != 0 {
 		if result[0] != nil {
@@ -206,14 +206,14 @@ func (mock *MockClient) VerifyWasCalledOnce() *VerifierMockClient {
 	}
 }
 
-func (mock *MockClient) VerifyWasCalled(invocationCountMatcher pegomock.Matcher) *VerifierMockClient {
+func (mock *MockClient) VerifyWasCalled(invocationCountMatcher pegomock.InvocationCountMatcher) *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
 	}
 }
 
-func (mock *MockClient) VerifyWasCalledInOrder(invocationCountMatcher pegomock.Matcher, inOrderContext *pegomock.InOrderContext) *VerifierMockClient {
+func (mock *MockClient) VerifyWasCalledInOrder(invocationCountMatcher pegomock.InvocationCountMatcher, inOrderContext *pegomock.InOrderContext) *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -221,7 +221,7 @@ func (mock *MockClient) VerifyWasCalledInOrder(invocationCountMatcher pegomock.M
 	}
 }
 
-func (mock *MockClient) VerifyWasCalledEventually(invocationCountMatcher pegomock.Matcher, timeout time.Duration) *VerifierMockClient {
+func (mock *MockClient) VerifyWasCalledEventually(invocationCountMatcher pegomock.InvocationCountMatcher, timeout time.Duration) *VerifierMockClient {
 	return &VerifierMockClient{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -231,7 +231,7 @@ func (mock *MockClient) VerifyWasCalledEventually(invocationCountMatcher pegomoc
 
 type VerifierMockClient struct {
 	mock                   *MockClient
-	invocationCountMatcher pegomock.Matcher
+	invocationCountMatcher pegomock.InvocationCountMatcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
 }
@@ -306,23 +306,23 @@ func (c *MockClient_CreateComment_OngoingVerification) GetAllCapturedArguments()
 	return
 }
 
-func (verifier *VerifierMockClient) HidePrevPlanComments(repo models.Repo, pullNum int) *MockClient_HidePrevPlanComments_OngoingVerification {
-	params := []pegomock.Param{repo, pullNum}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HidePrevPlanComments", params, verifier.timeout)
-	return &MockClient_HidePrevPlanComments_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+func (verifier *VerifierMockClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) *MockClient_HidePrevCommandComments_OngoingVerification {
+	params := []pegomock.Param{repo, pullNum, command}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HidePrevCommandComments", params, verifier.timeout)
+	return &MockClient_HidePrevCommandComments_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
 
-type MockClient_HidePrevPlanComments_OngoingVerification struct {
+type MockClient_HidePrevCommandComments_OngoingVerification struct {
 	mock              *MockClient
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockClient_HidePrevPlanComments_OngoingVerification) GetCapturedArguments() (models.Repo, int) {
-	repo, pullNum := c.GetAllCapturedArguments()
-	return repo[len(repo)-1], pullNum[len(pullNum)-1]
+func (c *MockClient_HidePrevCommandComments_OngoingVerification) GetCapturedArguments() (models.Repo, int, string) {
+	repo, pullNum, command := c.GetAllCapturedArguments()
+	return repo[len(repo)-1], pullNum[len(pullNum)-1], command[len(command)-1]
 }
 
-func (c *MockClient_HidePrevPlanComments_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []int) {
+func (c *MockClient_HidePrevCommandComments_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []int, _param2 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]models.Repo, len(c.methodInvocations))
@@ -332,6 +332,10 @@ func (c *MockClient_HidePrevPlanComments_OngoingVerification) GetAllCapturedArgu
 		_param1 = make([]int, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(int)
+		}
+		_param2 = make([]string, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(string)
 		}
 	}
 	return

--- a/server/events/vcs/not_configured_vcs_client.go
+++ b/server/events/vcs/not_configured_vcs_client.go
@@ -32,7 +32,7 @@ func (a *NotConfiguredVCSClient) GetModifiedFiles(repo models.Repo, pull models.
 func (a *NotConfiguredVCSClient) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
 	return a.err()
 }
-func (a *NotConfiguredVCSClient) HidePrevPlanComments(repo models.Repo, pullNum int) error {
+func (a *NotConfiguredVCSClient) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
 	return nil
 }
 func (a *NotConfiguredVCSClient) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error) {

--- a/server/events/vcs/proxy.go
+++ b/server/events/vcs/proxy.go
@@ -60,8 +60,8 @@ func (d *ClientProxy) CreateComment(repo models.Repo, pullNum int, comment strin
 	return d.clients[repo.VCSHost.Type].CreateComment(repo, pullNum, comment, command)
 }
 
-func (d *ClientProxy) HidePrevPlanComments(repo models.Repo, pullNum int) error {
-	return d.clients[repo.VCSHost.Type].HidePrevPlanComments(repo, pullNum)
+func (d *ClientProxy) HidePrevCommandComments(repo models.Repo, pullNum int, command string) error {
+	return d.clients[repo.VCSHost.Type].HidePrevCommandComments(repo, pullNum, command)
 }
 
 func (d *ClientProxy) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,10 +19,6 @@ github.com/Masterminds/semver
 github.com/Masterminds/sprig
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
-# github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
-## explicit
-# github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4
-## explicit
 # github.com/aokoli/goutils v1.0.1
 ## explicit
 github.com/aokoli/goutils
@@ -449,8 +445,6 @@ google.golang.org/protobuf/types/descriptorpb
 google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
-# gopkg.in/alecthomas/kingpin.v2 v2.2.6
-## explicit
 # gopkg.in/go-playground/assert.v1 v1.2.1
 ## explicit
 # gopkg.in/go-playground/validator.v9 v9.20.2


### PR DESCRIPTION
This should hide the previous comments from each command as and when each command is executed. 

Also this creates a new function on CommandName which eliminates underscores (another underlying bug with hiding policy check command comments)