### PR TITLE
[ORCA-542] conftest: support non `main` packages

### DIFF
--- a/server/events/runtime/policy/conftest_client.go
+++ b/server/events/runtime/policy/conftest_client.go
@@ -59,7 +59,7 @@ func (c ConftestTestCommandArgs) build() ([]string, error) {
 		commandArgs = append(commandArgs, a.build()...)
 	}
 
-	commandArgs = append(commandArgs, c.InputFile, "--no-color")
+	commandArgs = append(commandArgs, c.InputFile, "--no-color", "--all-namespaces")
 
 	return commandArgs, nil
 }

--- a/server/events/runtime/policy/conftest_client_test.go
+++ b/server/events/runtime/policy/conftest_client_test.go
@@ -173,7 +173,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutput := "Success"
 		expectedResult := "Checking plan against the following policies: \n  policy1\n  policy2\nSuccess"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn(localPolicySetPath2, nil)
@@ -194,7 +194,7 @@ func TestRun(t *testing.T) {
 
 		expectedOutput := "Success"
 		expectedResult := "Checking plan against the following policies: \n  policy1\nSuccess"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn("", errors.New("err"))
@@ -212,7 +212,7 @@ func TestRun(t *testing.T) {
 	t.Run("error resolving both policy sources", func(t *testing.T) {
 
 		expectedResult := "Success"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn("", errors.New("err"))
 		When(mockResolver.Resolve(policySet2)).ThenReturn("", errors.New("err"))
@@ -230,7 +230,7 @@ func TestRun(t *testing.T) {
 	t.Run("error running cmd", func(t *testing.T) {
 		expectedOutput := "FAIL - /some_workdir/testproj-default.json - failure"
 		expectedResult := "Checking plan against the following policies: \n  policy1\n  policy2\nFAIL - <redacted plan file> - failure"
-		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color"}
+		expectedArgs := []string{executablePath, "test", "-p", localPolicySetPath1, "-p", localPolicySetPath2, "/some_workdir/testproj-default.json", "--no-color", "--all-namespaces"}
 
 		When(mockResolver.Resolve(policySet1)).ThenReturn(localPolicySetPath1, nil)
 		When(mockResolver.Resolve(policySet2)).ThenReturn(localPolicySetPath2, nil)


### PR DESCRIPTION
By default conftest only executes `main` package when running a policy.
We want to allow for conftest to run all packages in the directory