### PR TITLE
Expanding Owners field to support different types.

### DIFF
--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -402,7 +402,9 @@ func TestApprovedPoliciesUpdateFailedPolicyStatus(t *testing.T) {
 		{
 			CommandName: models.ApprovePoliciesCommand,
 			PolicySets: valid.PolicySets{
-				Owners: []string{fixtures.User.Username},
+				Owners: valid.PolicyOwners{
+					Users: []string{fixtures.User.Username},
+				},
 			},
 		},
 	}, nil)

--- a/server/events/yaml/raw/policies.go
+++ b/server/events/yaml/raw/policies.go
@@ -8,9 +8,9 @@ import (
 
 // PolicySets is the raw schema for repo-level atlantis.yaml config.
 type PolicySets struct {
-	Version    *string     `yaml:"conftest_version,omitempty" json:"conftest_version,omitempty"`
-	Owners     []string    `yaml:"owners,omitempty" json:"owners,omitempty"`
-	PolicySets []PolicySet `yaml:"policy_sets" json:"policy_sets"`
+	Version    *string      `yaml:"conftest_version,omitempty" json:"conftest_version,omitempty"`
+	Owners     PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	PolicySets []PolicySet  `yaml:"policy_sets" json:"policy_sets"`
 }
 
 func (p PolicySets) Validate() error {
@@ -27,9 +27,7 @@ func (p PolicySets) ToValid() valid.PolicySets {
 		policySets.Version, _ = version.NewVersion(*p.Version)
 	}
 
-	if len(p.Owners) > 0 {
-		policySets.Owners = p.Owners
-	}
+	policySets.Owners = p.Owners.ToValid()
 
 	validPolicySets := make([]valid.PolicySet, 0)
 	for _, rawPolicySet := range p.PolicySets {
@@ -40,11 +38,24 @@ func (p PolicySets) ToValid() valid.PolicySets {
 	return policySets
 }
 
+type PolicyOwners struct {
+	Users []string `yaml:"users,omitempty" json:"users,omitempty"`
+}
+
+func (o PolicyOwners) ToValid() valid.PolicyOwners {
+	var policyOwners valid.PolicyOwners
+
+	if len(o.Users) > 0 {
+		policyOwners.Users = o.Users
+	}
+	return policyOwners
+}
+
 type PolicySet struct {
-	Path   string   `yaml:"path" json:"path"`
-	Source string   `yaml:"source" json:"source"`
-	Name   string   `yaml:"name" json:"name"`
-	Owners []string `yaml:"owners,omitempty" json:"owners,omitempty"`
+	Path   string       `yaml:"path" json:"path"`
+	Source string       `yaml:"source" json:"source"`
+	Name   string       `yaml:"name" json:"name"`
+	Owners PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
 }
 
 func (p PolicySet) Validate() error {
@@ -62,7 +73,7 @@ func (p PolicySet) ToValid() valid.PolicySet {
 	policySet.Name = p.Name
 	policySet.Path = p.Path
 	policySet.Source = p.Source
-	policySet.Owners = p.Owners
+	policySet.Owners = p.Owners.ToValid()
 
 	return policySet
 }

--- a/server/events/yaml/raw/policies_test.go
+++ b/server/events/yaml/raw/policies_test.go
@@ -80,9 +80,11 @@ func TestPolicySets_Validate(t *testing.T) {
 					},
 					{
 						Name: "policy-name-2",
-						Owners: []string{
-							"john-doe",
-							"jane-doe",
+						Owners: raw.PolicyOwners{
+							Users: []string{
+								"john-doe",
+								"jane-doe",
+							},
 						},
 						Path:   "rel/path/to/source",
 						Source: valid.GithubPolicySet,
@@ -174,15 +176,19 @@ func TestPolicySets_ToValid(t *testing.T) {
 			description: "valid policies with owners",
 			input: raw.PolicySets{
 				Version: String("v1.0.0"),
-				Owners: []string{
-					"test",
+				Owners: raw.PolicyOwners{
+					Users: []string{
+						"test",
+					},
 				},
 				PolicySets: []raw.PolicySet{
 					{
 						Name: "good-policy",
-						Owners: []string{
-							"john-doe",
-							"jane-doe",
+						Owners: raw.PolicyOwners{
+							Users: []string{
+								"john-doe",
+								"jane-doe",
+							},
 						},
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
@@ -191,13 +197,17 @@ func TestPolicySets_ToValid(t *testing.T) {
 			},
 			exp: valid.PolicySets{
 				Version: version,
-				Owners:  []string{"test"},
+				Owners: valid.PolicyOwners{
+					Users: []string{"test"},
+				},
 				PolicySets: []valid.PolicySet{
 					{
 						Name: "good-policy",
-						Owners: []string{
-							"john-doe",
-							"jane-doe",
+						Owners: valid.PolicyOwners{
+							Users: []string{
+								"john-doe",
+								"jane-doe",
+							},
 						},
 						Path:   "rel/path/to/source",
 						Source: "local",
@@ -206,15 +216,17 @@ func TestPolicySets_ToValid(t *testing.T) {
 			},
 		},
 		{
-			description: "valid policies wihthout owners",
+			description: "valid policies without owners",
 			input: raw.PolicySets{
 				Version: String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
 						Name: "good-policy",
-						Owners: []string{
-							"john-doe",
-							"jane-doe",
+						Owners: raw.PolicyOwners{
+							Users: []string{
+								"john-doe",
+								"jane-doe",
+							},
 						},
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
@@ -226,9 +238,11 @@ func TestPolicySets_ToValid(t *testing.T) {
 				PolicySets: []valid.PolicySet{
 					{
 						Name: "good-policy",
-						Owners: []string{
-							"john-doe",
-							"jane-doe",
+						Owners: valid.PolicyOwners{
+							Users: []string{
+								"john-doe",
+								"jane-doe",
+							},
 						},
 						Path:   "rel/path/to/source",
 						Source: "local",

--- a/server/events/yaml/valid/policies.go
+++ b/server/events/yaml/valid/policies.go
@@ -14,15 +14,19 @@ const (
 // context to enforce policies.
 type PolicySets struct {
 	Version    *version.Version
-	Owners     []string
+	Owners     PolicyOwners
 	PolicySets []PolicySet
+}
+
+type PolicyOwners struct {
+	Users []string
 }
 
 type PolicySet struct {
 	Source string
 	Path   string
 	Name   string
-	Owners []string
+	Owners PolicyOwners
 }
 
 func (p *PolicySets) HasPolicies() bool {
@@ -30,7 +34,7 @@ func (p *PolicySets) HasPolicies() bool {
 }
 
 func (p *PolicySets) IsOwner(username string) bool {
-	for _, uname := range p.Owners {
+	for _, uname := range p.Owners.Users {
 		if uname == username {
 			return true
 		}


### PR DESCRIPTION
Policy Owners might be different types, for that reason we are refactoring Owners into its own struct with specific keys defining different owner types.