### PR TITLE
Refactor command runners to singletons.

### DIFF
--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -1,28 +1,45 @@
 package events
 
 import (
+	"github.com/runatlantis/atlantis/server/events/db"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
-func NewApplyCommandRunner(cmdRunner *DefaultCommandRunner) *ApplyCommandRunner {
+func NewApplyCommandRunner(
+	vcsClient vcs.Client,
+	disableApplyAll bool,
+	commitStatusUpdater CommitStatusUpdater,
+	prjCommandBuilder ProjectApplyCommandBuilder,
+	prjCmdRunner ProjectApplyCommandRunner,
+	autoMerger *AutoMerger,
+	pullUpdater *PullUpdater,
+	dbUpdater *DBUpdater,
+	db *db.BoltDB,
+) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
-		cmdRunner:           cmdRunner,
-		vcsClient:           cmdRunner.VCSClient,
-		disableApplyAll:     cmdRunner.DisableApplyAll,
-		commitStatusUpdater: cmdRunner.CommitStatusUpdater,
-		prjCmdBuilder:       cmdRunner.ProjectCommandBuilder,
-		prjCmdRunner:        cmdRunner.ProjectCommandRunner,
+		vcsClient:           vcsClient,
+		DisableApplyAll:     disableApplyAll,
+		commitStatusUpdater: commitStatusUpdater,
+		prjCmdBuilder:       prjCommandBuilder,
+		prjCmdRunner:        prjCmdRunner,
+		autoMerger:          autoMerger,
+		pullUpdater:         pullUpdater,
+		dbUpdater:           dbUpdater,
+		DB:                  db,
 	}
 }
 
 type ApplyCommandRunner struct {
-	cmdRunner           *DefaultCommandRunner
-	disableApplyAll     bool
+	DisableApplyAll     bool
+	DB                  *db.BoltDB
 	vcsClient           vcs.Client
 	commitStatusUpdater CommitStatusUpdater
 	prjCmdBuilder       ProjectApplyCommandBuilder
 	prjCmdRunner        ProjectApplyCommandRunner
+	autoMerger          *AutoMerger
+	pullUpdater         *PullUpdater
+	dbUpdater           *DBUpdater
 }
 
 func (a *ApplyCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
@@ -30,7 +47,7 @@ func (a *ApplyCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull
 
-	if a.disableApplyAll && !cmd.IsForSpecificProject() {
+	if a.DisableApplyAll && !cmd.IsForSpecificProject() {
 		ctx.Log.Info("ignoring apply command without flags since apply all is disabled")
 		if err := a.vcsClient.CreateComment(baseRepo, pull.Num, applyAllDisabledComment, models.ApplyCommand.String()); err != nil {
 			ctx.Log.Err("unable to comment on pull request: %s", err)
@@ -72,7 +89,7 @@ func (a *ApplyCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 		if statusErr := a.commitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, cmd.CommandName()); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
-		a.cmdRunner.updatePull(ctx, cmd, CommandResult{Error: err})
+		a.pullUpdater.updatePull(ctx, cmd, CommandResult{Error: err})
 		return
 	}
 
@@ -85,21 +102,21 @@ func (a *ApplyCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 		result = runProjectCmds(projectCmds, a.prjCmdRunner.Apply)
 	}
 
-	a.cmdRunner.updatePull(
+	a.pullUpdater.updatePull(
 		ctx,
 		cmd,
 		result)
 
-	pullStatus, err := a.cmdRunner.updateDB(ctx, pull, result.ProjectResults)
+	pullStatus, err := a.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
 	if err != nil {
-		a.cmdRunner.Logger.Err("writing results: %s", err)
+		ctx.Log.Err("writing results: %s", err)
 		return
 	}
 
 	a.updateCommitStatus(ctx, pullStatus)
 
-	if a.cmdRunner.automergeEnabled(projectCmds) {
-		a.cmdRunner.automerge(ctx, pullStatus)
+	if a.autoMerger.automergeEnabled(projectCmds) {
+		a.autoMerger.automerge(ctx, pullStatus)
 	}
 }
 
@@ -136,7 +153,7 @@ func (a *ApplyCommandRunner) updateCommitStatus(ctx *CommandContext, pullStatus 
 }
 
 func (a *ApplyCommandRunner) anyFailedPolicyChecks(pull models.PullRequest) bool {
-	policyCheckPullStatus, _ := a.cmdRunner.DB.GetPullStatus(pull)
+	policyCheckPullStatus, _ := a.DB.GetPullStatus(pull)
 	if policyCheckPullStatus != nil && policyCheckPullStatus.StatusCount(models.ErroredPolicyCheckStatus) > 0 {
 		return true
 	}

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -7,12 +7,10 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
-
 type AutoMerger struct {
-	VCSClient vcs.Client
+	VCSClient       vcs.Client
 	GlobalAutomerge bool
 }
-
 
 func (c *AutoMerger) automerge(ctx *CommandContext, pullStatus models.PullStatus) {
 	// We only automerge if all projects have been successfully applied.

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -1,0 +1,52 @@
+package events
+
+import (
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+)
+
+
+type AutoMerger struct {
+	VCSClient vcs.Client
+	GlobalAutomerge bool
+}
+
+
+func (c *AutoMerger) automerge(ctx *CommandContext, pullStatus models.PullStatus) {
+	// We only automerge if all projects have been successfully applied.
+	for _, p := range pullStatus.Projects {
+		if p.Status != models.AppliedPlanStatus {
+			ctx.Log.Info("not automerging because project at dir %q, workspace %q has status %q", p.RepoRelDir, p.Workspace, p.Status.String())
+			return
+		}
+	}
+
+	// Comment that we're automerging the pull request.
+	if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, automergeComment, models.ApplyCommand.String()); err != nil {
+		ctx.Log.Err("failed to comment about automerge: %s", err)
+		// Commenting isn't required so continue.
+	}
+
+	// Make the API call to perform the merge.
+	ctx.Log.Info("automerging pull request")
+	err := c.VCSClient.MergePull(ctx.Pull)
+
+	if err != nil {
+		ctx.Log.Err("automerging failed: %s", err)
+
+		failureComment := fmt.Sprintf("Automerging failed:\n```\n%s\n```", err)
+		if commentErr := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, failureComment, models.ApplyCommand.String()); commentErr != nil {
+			ctx.Log.Err("failed to comment about automerge failing: %s", err)
+		}
+	}
+}
+
+// automergeEnabled returns true if automerging is enabled in this context.
+func (c *AutoMerger) automergeEnabled(projectCmds []models.ProjectCommandContext) bool {
+	// If the global automerge is set, we always automerge.
+	return c.GlobalAutomerge ||
+		// Otherwise we check if this repo is configured for automerging.
+		(len(projectCmds) > 0 && projectCmds[0].AutomergeEnabled)
+}

--- a/server/events/command_context.go
+++ b/server/events/command_context.go
@@ -29,8 +29,6 @@ const (
 	Comment
 )
 
-
-
 // CommandContext represents the context of a command that should be executed
 // for a pull request.
 type CommandContext struct {

--- a/server/events/command_context.go
+++ b/server/events/command_context.go
@@ -18,6 +18,19 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
+// CommandTrigger represents the how the command was triggered
+type CommandTrigger int
+
+const (
+	// Commands that are automatically triggered (ie. automatic plans)
+	Auto CommandTrigger = iota
+
+	// Commands that are triggered by comments (ie. atlantis plan)
+	Comment
+)
+
+
+
 // CommandContext represents the context of a command that should be executed
 // for a pull request.
 type CommandContext struct {
@@ -36,4 +49,6 @@ type CommandContext struct {
 	// set our own build statuses which can affect mergeability if users have
 	// required the Atlantis status to be successful prior to merging.
 	PullMergeable bool
+
+	Trigger CommandTrigger
 }

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -76,9 +76,15 @@ func buildCommentCommandRunner(
 	cmdRunner *DefaultCommandRunner,
 	cmdName models.CommandName,
 ) CommentCommandRunner {
-	// no need for error checking here, we want to fail fast and hard since
+	// panic here, we want to fail fast and hard since
 	// this would be an internal service configuration error.
-	return cmdRunner.CommentCommandRunnerByCmd[cmdName]
+	runner, ok := cmdRunner.CommentCommandRunnerByCmd[cmdName]
+
+	if !ok {
+		panic(fmt.Sprintf("command runner not configured for command %s", cmdName.String()))
+	}
+
+	return runner
 }
 
 // DefaultCommandRunner is the first step when processing a comment command.

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -15,14 +15,11 @@ package events
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/google/go-github/v31/github"
 	stats "github.com/lyft/gostats"
 	"github.com/mcdafydd/go-azuredevops/azuredevops"
 	"github.com/pkg/errors"
-	"github.com/remeh/sizedwaitgroup"
-	"github.com/runatlantis/atlantis/server/events/db"
 	"github.com/runatlantis/atlantis/server/events/metrics"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
@@ -78,23 +75,10 @@ type CommentCommandRunner interface {
 func buildCommentCommandRunner(
 	cmdRunner *DefaultCommandRunner,
 	cmdName models.CommandName,
-	isAutoplan bool,
 ) CommentCommandRunner {
-	switch cmdName {
-	case models.ApplyCommand:
-		return NewApplyCommandRunner(cmdRunner)
-	case models.UnlockCommand:
-		return NewUnlockCommandRunner(
-			cmdRunner.DeleteLockCommand,
-			cmdRunner.VCSClient,
-		)
-	case models.PlanCommand:
-		return NewPlanCommandRunner(cmdRunner, isAutoplan)
-	case models.ApprovePoliciesCommand:
-		return NewApprovePoliciesCommandRunner(cmdRunner)
-	}
-
-	return nil
+	// no need for error checking here, we want to fail fast and hard since
+	// this would be an internal service configuration error.
+	return cmdRunner.CommentCommandRunnerByCmd[cmdName]
 }
 
 // DefaultCommandRunner is the first step when processing a comment command.
@@ -103,11 +87,8 @@ type DefaultCommandRunner struct {
 	GithubPullGetter         GithubPullGetter
 	AzureDevopsPullGetter    AzureDevopsPullGetter
 	GitlabMergeRequestGetter GitlabMergeRequestGetter
-	CommitStatusUpdater      CommitStatusUpdater
-	DisableApplyAll          bool
 	DisableAutoplan          bool
 	EventParser              EventParsing
-	MarkdownRenderer         *MarkdownRenderer
 	Logger                   logging.SimpleLogging
 	StatsScope               stats.Scope
 	// AllowForkPRs controls whether we operate on pull requests from forks.
@@ -116,27 +97,14 @@ type DefaultCommandRunner struct {
 	// this in our error message back to the user on a forked PR so they know
 	// how to enable this functionality.
 	AllowForkPRsFlag string
-	// HidePrevPlanComments will hide previous plan comments to declutter PRs.
-	HidePrevPlanComments bool
 	// SilenceForkPRErrors controls whether to comment on Fork PRs when AllowForkPRs = False
 	SilenceForkPRErrors bool
 	// SilenceForkPRErrorsFlag is the name of the flag that controls fork PR's. We use
 	// this in our error message back to the user on a forked PR so they know
 	// how to disable error comment
-	SilenceForkPRErrorsFlag string
-	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
-	// are found
-	SilenceVCSStatusNoPlans bool
-	ProjectCommandBuilder   ProjectCommandBuilder
-	ProjectCommandRunner    ProjectCommandRunner
-	// GlobalAutomerge is true if we should automatically merge pull requests if all
-	// plans have been successfully applied. This is set via a CLI flag.
-	GlobalAutomerge   bool
-	PendingPlanFinder PendingPlanFinder
-	WorkingDir        WorkingDir
-	DB                *db.BoltDB
-	Drainer           *Drainer
-	DeleteLockCommand DeleteLockCommand
+	SilenceForkPRErrorsFlag   string
+	CommentCommandRunnerByCmd map[models.CommandName]CommentCommandRunner
+	Drainer                   *Drainer
 }
 
 // RunAutoplanCommand runs plan and policy_checks when a pull request is opened or updated.
@@ -162,6 +130,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 		Scope:    scope,
 		Pull:     pull,
 		HeadRepo: headRepo,
+		Trigger:  Auto,
 	}
 	if !c.validateCtxAndComment(ctx) {
 		return
@@ -170,7 +139,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 		return
 	}
 
-	autoPlanRunner := buildCommentCommandRunner(c, models.PlanCommand, true)
+	autoPlanRunner := buildCommentCommandRunner(c, models.PlanCommand)
 	if autoPlanRunner == nil {
 		ctx.Log.Err("invalid autoplan command")
 		return
@@ -215,13 +184,14 @@ func (c *DefaultCommandRunner) RunCommentCommand(baseRepo models.Repo, maybeHead
 		Pull:     pull,
 		HeadRepo: headRepo,
 		Scope:    scope,
+		Trigger:  Comment,
 	}
 
 	if !c.validateCtxAndComment(ctx) {
 		return
 	}
 
-	cmdRunner := buildCommentCommandRunner(c, cmd.CommandName(), false)
+	cmdRunner := buildCommentCommandRunner(c, cmd.CommandName())
 	if cmdRunner == nil {
 		ctx.Log.Err("command %s is not supported", cmd.Name.String())
 		return
@@ -338,29 +308,6 @@ func (c *DefaultCommandRunner) validateCtxAndComment(ctx *CommandContext) bool {
 	return true
 }
 
-func (c *DefaultCommandRunner) updatePull(ctx *CommandContext, command PullCommand, res CommandResult) {
-	// Log if we got any errors or failures.
-	if res.Error != nil {
-		ctx.Log.Err(res.Error.Error())
-	} else if res.Failure != "" {
-		ctx.Log.Warn(res.Failure)
-	}
-
-	// HidePrevPlanComments will hide old comments left from previous plan runs to reduce
-	// clutter in a pull/merge request. This will not delete the comment, since the
-	// comment trail may be useful in auditing or backtracing problems.
-	if c.HidePrevPlanComments {
-		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, command.CommandName().TitleString()); err != nil {
-			ctx.Log.Err("unable to hide old comments: %s", err)
-		}
-	}
-
-	comment := c.MarkdownRenderer.Render(res, command.CommandName(), ctx.Log.History.String(), command.IsVerbose(), ctx.Pull.BaseRepo.VCSHost.Type)
-	if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, comment, command.CommandName().String()); err != nil {
-		ctx.Log.Err("unable to comment: %s", err)
-	}
-}
-
 // logPanics logs and creates a comment on the pull request for panics.
 func (c *DefaultCommandRunner) logPanics(baseRepo models.Repo, pullNum int, logger logging.SimpleLogging) {
 	if err := recover(); err != nil {
@@ -375,102 +322,6 @@ func (c *DefaultCommandRunner) logPanics(baseRepo models.Repo, pullNum int, logg
 			logger.Err("unable to comment: %s", commentErr)
 		}
 	}
-}
-
-func (c *DefaultCommandRunner) updateDB(ctx *CommandContext, pull models.PullRequest, results []models.ProjectResult) (models.PullStatus, error) {
-	// Filter out results that errored due to the directory not existing. We
-	// don't store these in the database because they would never be "apply-able"
-	// and so the pull request would always have errors.
-	var filtered []models.ProjectResult
-	for _, r := range results {
-		if _, ok := r.Error.(DirNotExistErr); ok {
-			ctx.Log.Debug("ignoring error result from project at dir %q workspace %q because it is dir not exist error", r.RepoRelDir, r.Workspace)
-			continue
-		}
-		filtered = append(filtered, r)
-	}
-	ctx.Log.Debug("updating DB with pull results")
-	return c.DB.UpdatePullWithResults(pull, filtered)
-}
-
-func (c *DefaultCommandRunner) automerge(ctx *CommandContext, pullStatus models.PullStatus) {
-	// We only automerge if all projects have been successfully applied.
-	for _, p := range pullStatus.Projects {
-		if p.Status != models.AppliedPlanStatus {
-			ctx.Log.Info("not automerging because project at dir %q, workspace %q has status %q", p.RepoRelDir, p.Workspace, p.Status.String())
-			return
-		}
-	}
-
-	// Comment that we're automerging the pull request.
-	if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, automergeComment, models.ApplyCommand.String()); err != nil {
-		ctx.Log.Err("failed to comment about automerge: %s", err)
-		// Commenting isn't required so continue.
-	}
-
-	// Make the API call to perform the merge.
-	ctx.Log.Info("automerging pull request")
-	err := c.VCSClient.MergePull(ctx.Pull)
-
-	if err != nil {
-		ctx.Log.Err("automerging failed: %s", err)
-
-		failureComment := fmt.Sprintf("Automerging failed:\n```\n%s\n```", err)
-		if commentErr := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, failureComment, models.ApplyCommand.String()); commentErr != nil {
-			ctx.Log.Err("failed to comment about automerge failing: %s", err)
-		}
-	}
-}
-
-// automergeEnabled returns true if automerging is enabled in this context.
-func (c *DefaultCommandRunner) automergeEnabled(projectCmds []models.ProjectCommandContext) bool {
-	// If the global automerge is set, we always automerge.
-	return c.GlobalAutomerge ||
-		// Otherwise we check if this repo is configured for automerging.
-		(len(projectCmds) > 0 && projectCmds[0].AutomergeEnabled)
-}
-
-type prjCmdRunnerFunc func(ctx models.ProjectCommandContext) models.ProjectResult
-
-func runProjectCmdsParallel(
-	cmds []models.ProjectCommandContext,
-	runnerFunc prjCmdRunnerFunc,
-) CommandResult {
-	var results []models.ProjectResult
-	mux := &sync.Mutex{}
-
-	wg := sizedwaitgroup.New(15)
-	for _, pCmd := range cmds {
-		pCmd := pCmd
-		var execute func()
-		wg.Add()
-
-		execute = func() {
-			defer wg.Done()
-			res := runnerFunc(pCmd)
-			mux.Lock()
-			results = append(results, res)
-			mux.Unlock()
-		}
-
-		go execute()
-	}
-
-	wg.Wait()
-	return CommandResult{ProjectResults: results}
-}
-
-func runProjectCmds(
-	cmds []models.ProjectCommandContext,
-	runnerFunc prjCmdRunnerFunc,
-) CommandResult {
-	var results []models.ProjectResult
-	for _, pCmd := range cmds {
-		res := runnerFunc(pCmd)
-
-		results = append(results, res)
-	}
-	return CommandResult{ProjectResults: results}
 }
 
 // automergeComment is the comment that gets posted when Atlantis automatically

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -51,6 +51,18 @@ var drainer *events.Drainer
 var deleteLockCommand *mocks.MockDeleteLockCommand
 var commitUpdater *mocks.MockCommitStatusUpdater
 
+// TODO: refactor these into their own unit tests.
+// these were all split out from default command runner in an effort to improve
+// readability however the tests were kept as is.
+var dbUpdater *events.DBUpdater
+var pullUpdater *events.PullUpdater
+var autoMerger *events.AutoMerger
+var policyCheckCommandRunner *events.PolicyCheckCommandRunner
+var approvePoliciesCommandRunner *events.ApprovePoliciesCommandRunner
+var planCommandRunner *events.PlanCommandRunner
+var applyCommandRunner *events.ApplyCommandRunner
+var unlockCommandRunner *events.UnlockCommandRunner
+
 func setup(t *testing.T) *vcsmocks.MockClient {
 	RegisterMockTestingT(t)
 	projectCommandBuilder = mocks.NewMockProjectCommandBuilder()
@@ -78,26 +90,86 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		ThenReturn(pullLogger)
 
 	scope := stats.NewDefaultStore()
+	dbUpdater = &events.DBUpdater{
+		DB: defaultBoltDB,
+	}
+
+	pullUpdater = &events.PullUpdater{
+		HidePrevCommandComments: false,
+		VCSClient:               vcsClient,
+		MarkdownRenderer:        &events.MarkdownRenderer{},
+	}
+
+	autoMerger = &events.AutoMerger{
+		VCSClient:       vcsClient,
+		GlobalAutomerge: false,
+	}
+
+	policyCheckCommandRunner = events.NewPolicyCheckCommandRunner(
+		dbUpdater,
+		pullUpdater,
+		commitUpdater,
+		projectCommandRunner,
+	)
+
+	planCommandRunner = events.NewPlanCommandRunner(
+		false,
+		vcsClient,
+		pendingPlanFinder,
+		workingDir,
+		commitUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		dbUpdater,
+		pullUpdater,
+		policyCheckCommandRunner,
+		autoMerger,
+	)
+
+	applyCommandRunner = events.NewApplyCommandRunner(
+		vcsClient,
+		false,
+		commitUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		autoMerger,
+		pullUpdater,
+		dbUpdater,
+		defaultBoltDB,
+	)
+
+	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(
+		commitUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		pullUpdater,
+		dbUpdater,
+	)
+
+	unlockCommandRunner = events.NewUnlockCommandRunner(
+		deleteLockCommand,
+		vcsClient,
+	)
+
+	commentCommandRunnerByCmd := map[models.CommandName]events.CommentCommandRunner{
+		models.PlanCommand:            planCommandRunner,
+		models.ApplyCommand:           applyCommandRunner,
+		models.ApprovePoliciesCommand: approvePoliciesCommandRunner,
+		models.UnlockCommand:          unlockCommandRunner,
+	}
+
 	ch = events.DefaultCommandRunner{
-		VCSClient:                vcsClient,
-		CommitStatusUpdater:      commitUpdater, //&events.DefaultCommitStatusUpdater{vcsClient, "atlantis"},
-		EventParser:              eventParsing,
-		MarkdownRenderer:         &events.MarkdownRenderer{},
-		GithubPullGetter:         githubGetter,
-		GitlabMergeRequestGetter: gitlabGetter,
-		AzureDevopsPullGetter:    azuredevopsGetter,
-		Logger:                   logger,
-		StatsScope:               scope,
-		AllowForkPRs:             false,
-		AllowForkPRsFlag:         "allow-fork-prs-flag",
-		ProjectCommandBuilder:    projectCommandBuilder,
-		ProjectCommandRunner:     projectCommandRunner,
-		PendingPlanFinder:        pendingPlanFinder,
-		WorkingDir:               workingDir,
-		DisableApplyAll:          false,
-		DB:                       defaultBoltDB,
-		Drainer:                  drainer,
-		DeleteLockCommand:        deleteLockCommand,
+		VCSClient:                 vcsClient,
+		CommentCommandRunnerByCmd: commentCommandRunnerByCmd,
+		EventParser:               eventParsing,
+		GithubPullGetter:          githubGetter,
+		GitlabMergeRequestGetter:  gitlabGetter,
+		AzureDevopsPullGetter:     azuredevopsGetter,
+		Logger:                    logger,
+		StatsScope:                scope,
+		AllowForkPRs:              false,
+		AllowForkPRsFlag:          "allow-fork-prs-flag",
+		Drainer:                   drainer,
 	}
 	return vcsClient
 }
@@ -200,7 +272,7 @@ func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run and this is disabled atlantis should" +
 		" comment saying that this is not allowed")
 	vcsClient := setup(t)
-	ch.DisableApplyAll = true
+	applyCommandRunner.DisableApplyAll = true
 	pull := &github.PullRequest{
 		State: github.String("open"),
 	}
@@ -291,9 +363,10 @@ func TestRunAutoplanCommand_DeletePlans(t *testing.T) {
 	defer cleanup()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	ch.DB = boltDB
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	dbUpdater.DB = boltDB
+	applyCommandRunner.DB = boltDB
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	When(projectCommandBuilder.BuildAutoplanCommands(matchers.AnyPtrToEventsCommandContext())).
 		ThenReturn([]models.ProjectCommandContext{
@@ -337,9 +410,10 @@ func TestFailedApprovalCreatesFailedStatusUpdate(t *testing.T) {
 	defer cleanup()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	ch.DB = boltDB
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	dbUpdater.DB = boltDB
+	applyCommandRunner.DB = boltDB
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	pull := &github.PullRequest{
 		State: github.String("open"),
@@ -382,9 +456,10 @@ func TestApprovedPoliciesUpdateFailedPolicyStatus(t *testing.T) {
 	defer cleanup()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	ch.DB = boltDB
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	dbUpdater.DB = boltDB
+	applyCommandRunner.DB = boltDB
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	pull := &github.PullRequest{
 		State: github.String("open"),
@@ -427,9 +502,10 @@ func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 	defer cleanup()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	ch.DB = boltDB
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	dbUpdater.DB = boltDB
+	applyCommandRunner.DB = boltDB
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	pull := &github.PullRequest{
 		State: github.String("open"),
@@ -486,8 +562,8 @@ func TestApplyWithAutoMerge_VSCMerge(t *testing.T) {
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(pull, nil)
 	When(eventParsing.ParseGithubPull(pull)).ThenReturn(modelPull, modelPull.BaseRepo, fixtures.GithubRepo, nil)
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 
 	ch.RunCommentCommand(fixtures.GithubRepo, &fixtures.GithubRepo, nil, fixtures.User, fixtures.Pull.Num, &events.CommentCommand{Name: models.ApplyCommand})
 	vcsClient.VerifyWasCalledOnce().MergePull(modelPull)
@@ -497,13 +573,14 @@ func TestRunApply_DiscardedProjects(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run with automerge and at least one project" +
 		" has a discarded plan, automerge should not take place")
 	vcsClient := setup(t)
-	ch.GlobalAutomerge = true
-	defer func() { ch.GlobalAutomerge = false }()
+	autoMerger.GlobalAutomerge = true
+	defer func() { autoMerger.GlobalAutomerge = false }()
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
 	boltDB, err := db.New(tmp)
 	Ok(t, err)
-	ch.DB = boltDB
+	dbUpdater.DB = boltDB
+	applyCommandRunner.DB = boltDB
 	pull := fixtures.Pull
 	pull.BaseRepo = fixtures.GithubRepo
 	_, err = boltDB.UpdatePullWithResults(pull, []models.ProjectResult{

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -5,7 +5,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-
 type DBUpdater struct {
 	DB *db.BoltDB
 }

--- a/server/events/db_updater.go
+++ b/server/events/db_updater.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"github.com/runatlantis/atlantis/server/events/db"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+
+type DBUpdater struct {
+	DB *db.BoltDB
+}
+
+func (c *DBUpdater) updateDB(ctx *CommandContext, pull models.PullRequest, results []models.ProjectResult) (models.PullStatus, error) {
+	// Filter out results that errored due to the directory not existing. We
+	// don't store these in the database because they would never be "apply-able"
+	// and so the pull request would always have errors.
+	var filtered []models.ProjectResult
+	for _, r := range results {
+		if _, ok := r.Error.(DirNotExistErr); ok {
+			ctx.Log.Debug("ignoring error result from project at dir %q workspace %q because it is dir not exist error", r.RepoRelDir, r.Workspace)
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	ctx.Log.Debug("updating DB with pull results")
+	return c.DB.UpdatePullWithResults(pull, filtered)
+}

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -6,34 +6,47 @@ import (
 )
 
 func NewPlanCommandRunner(
-	cmdRunner *DefaultCommandRunner,
-	isAutoplan bool,
+	silenceVCSStatusNoPlans bool,
+	vcsClient vcs.Client,
+	pendingPlanFinder PendingPlanFinder,
+	workingDir WorkingDir,
+	commitStatusUpdater CommitStatusUpdater,
+	projectCommandBuilder ProjectPlanCommandBuilder,
+	projectCommandRunner ProjectCommandRunner,
+	dbUpdater *DBUpdater,
+	pullUpdater *PullUpdater,
+	policyCheckCommandRunner *PolicyCheckCommandRunner,
+	autoMerger *AutoMerger,
 ) *PlanCommandRunner {
 	return &PlanCommandRunner{
-		isAutoplan:              isAutoplan,
-		cmdRunner:               cmdRunner,
-		silenceVCSStatusNoPlans: cmdRunner.SilenceVCSStatusNoPlans,
-		globalAutomerge:         cmdRunner.GlobalAutomerge,
-		vcsClient:               cmdRunner.VCSClient,
-		pendingPlanFinder:       cmdRunner.PendingPlanFinder,
-		workingDir:              cmdRunner.WorkingDir,
-		commitStatusUpdater:     cmdRunner.CommitStatusUpdater,
-		prjCmdBuilder:           cmdRunner.ProjectCommandBuilder,
-		prjCmdRunner:            cmdRunner.ProjectCommandRunner,
+		silenceVCSStatusNoPlans:  silenceVCSStatusNoPlans,
+		vcsClient:                vcsClient,
+		pendingPlanFinder:        pendingPlanFinder,
+		workingDir:               workingDir,
+		commitStatusUpdater:      commitStatusUpdater,
+		prjCmdBuilder:            projectCommandBuilder,
+		prjCmdRunner:             projectCommandRunner,
+		dbUpdater:                dbUpdater,
+		pullUpdater:              pullUpdater,
+		policyCheckCommandRunner: policyCheckCommandRunner,
+		autoMerger:               autoMerger,
 	}
 }
 
 type PlanCommandRunner struct {
-	cmdRunner               *DefaultCommandRunner
-	vcsClient               vcs.Client
-	globalAutomerge         bool
-	isAutoplan              bool
-	silenceVCSStatusNoPlans bool
-	commitStatusUpdater     CommitStatusUpdater
-	pendingPlanFinder       PendingPlanFinder
-	workingDir              WorkingDir
-	prjCmdBuilder           ProjectPlanCommandBuilder
-	prjCmdRunner            ProjectPlanCommandRunner
+	vcsClient                vcs.Client
+	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
+	// are found
+	silenceVCSStatusNoPlans  bool
+	commitStatusUpdater      CommitStatusUpdater
+	pendingPlanFinder        PendingPlanFinder
+	workingDir               WorkingDir
+	prjCmdBuilder            ProjectPlanCommandBuilder
+	prjCmdRunner             ProjectPlanCommandRunner
+	dbUpdater                *DBUpdater
+	pullUpdater              *PullUpdater
+	policyCheckCommandRunner *PolicyCheckCommandRunner
+	autoMerger               *AutoMerger
 }
 
 func (p *PlanCommandRunner) runAutoplan(ctx *CommandContext) {
@@ -45,7 +58,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *CommandContext) {
 		if statusErr := p.commitStatusUpdater.UpdateCombined(baseRepo, pull, models.FailedCommitStatus, models.PlanCommand); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
-		p.cmdRunner.updatePull(ctx, AutoplanCommand{}, CommandResult{Error: err})
+		p.pullUpdater.updatePull(ctx, AutoplanCommand{}, CommandResult{Error: err})
 		return
 	}
 
@@ -79,17 +92,17 @@ func (p *PlanCommandRunner) runAutoplan(ctx *CommandContext) {
 		result = runProjectCmds(projectCmds, p.prjCmdRunner.Plan)
 	}
 
-	if p.cmdRunner.automergeEnabled(projectCmds) && result.HasErrors() {
+	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
 		p.deletePlans(ctx)
 		result.PlansDeleted = true
 	}
 
-	p.cmdRunner.updatePull(ctx, AutoplanCommand{}, result)
+	p.pullUpdater.updatePull(ctx, AutoplanCommand{}, result)
 
-	pullStatus, err := p.cmdRunner.updateDB(ctx, ctx.Pull, result.ProjectResults)
+	pullStatus, err := p.dbUpdater.updateDB(ctx, ctx.Pull, result.ProjectResults)
 	if err != nil {
-		p.cmdRunner.Logger.Err("writing results: %s", err)
+		ctx.Log.Err("writing results: %s", err)
 	}
 
 	p.updateCommitStatus(ctx, pullStatus)
@@ -99,8 +112,7 @@ func (p *PlanCommandRunner) runAutoplan(ctx *CommandContext) {
 		!(result.HasErrors() || result.PlansDeleted) {
 		// Run policy_check command
 		ctx.Log.Info("Running policy_checks for all plans")
-		pcCmdRunner := NewPolicyCheckCommandRunner(p.cmdRunner, policyCheckCmds)
-		pcCmdRunner.Run(ctx)
+		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
 	}
 }
 
@@ -118,7 +130,7 @@ func (p *PlanCommandRunner) run(ctx *CommandContext, cmd *CommentCommand) {
 		if statusErr := p.commitStatusUpdater.UpdateCombined(ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, models.PlanCommand); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
-		p.cmdRunner.updatePull(ctx, cmd, CommandResult{Error: err})
+		p.pullUpdater.updatePull(ctx, cmd, CommandResult{Error: err})
 		return
 	}
 
@@ -133,20 +145,20 @@ func (p *PlanCommandRunner) run(ctx *CommandContext, cmd *CommentCommand) {
 		result = runProjectCmds(projectCmds, p.prjCmdRunner.Plan)
 	}
 
-	if p.cmdRunner.automergeEnabled(projectCmds) && result.HasErrors() {
+	if p.autoMerger.automergeEnabled(projectCmds) && result.HasErrors() {
 		ctx.Log.Info("deleting plans because there were errors and automerge requires all plans succeed")
 		p.deletePlans(ctx)
 		result.PlansDeleted = true
 	}
 
-	p.cmdRunner.updatePull(
+	p.pullUpdater.updatePull(
 		ctx,
 		cmd,
 		result)
 
-	pullStatus, err := p.cmdRunner.updateDB(ctx, pull, result.ProjectResults)
+	pullStatus, err := p.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
 	if err != nil {
-		p.cmdRunner.Logger.Err("writing results: %s", err)
+		ctx.Log.Err("writing results: %s", err)
 		return
 	}
 
@@ -157,13 +169,12 @@ func (p *PlanCommandRunner) run(ctx *CommandContext, cmd *CommentCommand) {
 	if len(result.ProjectResults) > 0 &&
 		!(result.HasErrors() || result.PlansDeleted) {
 		ctx.Log.Info("Running policy check for %s", cmd.String())
-		pcCmdRunner := NewPolicyCheckCommandRunner(p.cmdRunner, policyCheckCmds)
-		pcCmdRunner.Run(ctx)
+		p.policyCheckCommandRunner.Run(ctx, policyCheckCmds)
 	}
 }
 
 func (p *PlanCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
-	if p.isAutoplan {
+	if ctx.Trigger == Auto {
 		p.runAutoplan(ctx)
 	} else {
 		p.run(ctx, cmd)

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -34,7 +34,7 @@ func NewPlanCommandRunner(
 }
 
 type PlanCommandRunner struct {
-	vcsClient                vcs.Client
+	vcsClient vcs.Client
 	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
 	// are found
 	silenceVCSStatusNoPlans  bool

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -12,7 +12,7 @@ func NewPlanCommandRunner(
 	workingDir WorkingDir,
 	commitStatusUpdater CommitStatusUpdater,
 	projectCommandBuilder ProjectPlanCommandBuilder,
-	projectCommandRunner ProjectCommandRunner,
+	projectCommandRunner ProjectPlanCommandRunner,
 	dbUpdater *DBUpdater,
 	pullUpdater *PullUpdater,
 	policyCheckCommandRunner *PolicyCheckCommandRunner,

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -9,8 +9,8 @@ func NewPolicyCheckCommandRunner(
 	projectCommandRunner ProjectPolicyCheckCommandRunner,
 ) *PolicyCheckCommandRunner {
 	return &PolicyCheckCommandRunner{
-		dbUpdater: dbUpdater,
-		pullUpdater: pullUpdater,
+		dbUpdater:           dbUpdater,
+		pullUpdater:         pullUpdater,
 		commitStatusUpdater: commitStatusUpdater,
 		prjCmdRunner:        projectCommandRunner,
 	}

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -3,26 +3,28 @@ package events
 import "github.com/runatlantis/atlantis/server/events/models"
 
 func NewPolicyCheckCommandRunner(
-	cmdRunner *DefaultCommandRunner,
-	prjCmds []models.ProjectCommandContext,
+	dbUpdater *DBUpdater,
+	pullUpdater *PullUpdater,
+	commitStatusUpdater CommitStatusUpdater,
+	projectCommandRunner ProjectPolicyCheckCommandRunner,
 ) *PolicyCheckCommandRunner {
 	return &PolicyCheckCommandRunner{
-		cmdRunner:           cmdRunner,
-		cmds:                prjCmds,
-		commitStatusUpdater: cmdRunner.CommitStatusUpdater,
-		prjCmdRunner:        cmdRunner.ProjectCommandRunner,
+		dbUpdater: dbUpdater,
+		pullUpdater: pullUpdater,
+		commitStatusUpdater: commitStatusUpdater,
+		prjCmdRunner:        projectCommandRunner,
 	}
 }
 
 type PolicyCheckCommandRunner struct {
-	cmdRunner           *DefaultCommandRunner
-	cmds                []models.ProjectCommandContext
+	dbUpdater           *DBUpdater
+	pullUpdater         *PullUpdater
 	commitStatusUpdater CommitStatusUpdater
 	prjCmdRunner        ProjectPolicyCheckCommandRunner
 }
 
-func (p *PolicyCheckCommandRunner) Run(ctx *CommandContext) {
-	if len(p.cmds) == 0 {
+func (p *PolicyCheckCommandRunner) Run(ctx *CommandContext, cmds []models.ProjectCommandContext) {
+	if len(cmds) == 0 {
 		return
 	}
 
@@ -32,18 +34,18 @@ func (p *PolicyCheckCommandRunner) Run(ctx *CommandContext) {
 	}
 
 	var result CommandResult
-	if p.isParallelEnabled() {
+	if p.isParallelEnabled(cmds) {
 		ctx.Log.Info("Running policy_checks in parallel")
-		result = runProjectCmdsParallel(p.cmds, p.prjCmdRunner.PolicyCheck)
+		result = runProjectCmdsParallel(cmds, p.prjCmdRunner.PolicyCheck)
 	} else {
-		result = runProjectCmds(p.cmds, p.prjCmdRunner.PolicyCheck)
+		result = runProjectCmds(cmds, p.prjCmdRunner.PolicyCheck)
 	}
 
-	p.cmdRunner.updatePull(ctx, PolicyCheckCommand{}, result)
+	p.pullUpdater.updatePull(ctx, PolicyCheckCommand{}, result)
 
-	pullStatus, err := p.cmdRunner.updateDB(ctx, ctx.Pull, result.ProjectResults)
+	pullStatus, err := p.dbUpdater.updateDB(ctx, ctx.Pull, result.ProjectResults)
 	if err != nil {
-		p.cmdRunner.Logger.Err("writing results: %s", err)
+		ctx.Log.Err("writing results: %s", err)
 	}
 
 	p.updateCommitStatus(ctx, pullStatus)
@@ -66,6 +68,6 @@ func (p *PolicyCheckCommandRunner) updateCommitStatus(ctx *CommandContext, pullS
 	}
 }
 
-func (p *PolicyCheckCommandRunner) isParallelEnabled() bool {
-	return len(p.cmds) > 0 && p.cmds[0].ParallelPolicyCheckEnabled
+func (p *PolicyCheckCommandRunner) isParallelEnabled(cmds []models.ProjectCommandContext) bool {
+	return len(cmds) > 0 && cmds[0].ParallelPolicyCheckEnabled
 }

--- a/server/events/project_command_pool_executor.go
+++ b/server/events/project_command_pool_executor.go
@@ -9,7 +9,6 @@ import (
 
 type prjCmdRunnerFunc func(ctx models.ProjectCommandContext) models.ProjectResult
 
-
 func runProjectCmdsParallel(
 	cmds []models.ProjectCommandContext,
 	runnerFunc prjCmdRunnerFunc,

--- a/server/events/project_command_pool_executor.go
+++ b/server/events/project_command_pool_executor.go
@@ -1,0 +1,52 @@
+package events
+
+import (
+	"sync"
+
+	"github.com/remeh/sizedwaitgroup"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type prjCmdRunnerFunc func(ctx models.ProjectCommandContext) models.ProjectResult
+
+
+func runProjectCmdsParallel(
+	cmds []models.ProjectCommandContext,
+	runnerFunc prjCmdRunnerFunc,
+) CommandResult {
+	var results []models.ProjectResult
+	mux := &sync.Mutex{}
+
+	wg := sizedwaitgroup.New(15)
+	for _, pCmd := range cmds {
+		pCmd := pCmd
+		var execute func()
+		wg.Add()
+
+		execute = func() {
+			defer wg.Done()
+			res := runnerFunc(pCmd)
+			mux.Lock()
+			results = append(results, res)
+			mux.Unlock()
+		}
+
+		go execute()
+	}
+
+	wg.Wait()
+	return CommandResult{ProjectResults: results}
+}
+
+func runProjectCmds(
+	cmds []models.ProjectCommandContext,
+	runnerFunc prjCmdRunnerFunc,
+) CommandResult {
+	var results []models.ProjectResult
+	for _, pCmd := range cmds {
+		res := runnerFunc(pCmd)
+
+		results = append(results, res)
+	}
+	return CommandResult{ProjectResults: results}
+}

--- a/server/events/pull_updater.go
+++ b/server/events/pull_updater.go
@@ -1,0 +1,32 @@
+package events
+
+import "github.com/runatlantis/atlantis/server/events/vcs"
+
+type PullUpdater struct {
+	HidePrevCommandComments bool
+	VCSClient               vcs.Client
+	MarkdownRenderer        *MarkdownRenderer
+}
+
+func (c *PullUpdater) updatePull(ctx *CommandContext, command PullCommand, res CommandResult) {
+	// Log if we got any errors or failures.
+	if res.Error != nil {
+		ctx.Log.Err(res.Error.Error())
+	} else if res.Failure != "" {
+		ctx.Log.Warn(res.Failure)
+	}
+
+	// HidePrevCommandComments will hide old comments left from previous plan runs to reduce
+	// clutter in a pull/merge request. This will not delete the comment, since the
+	// comment trail may be useful in auditing or backtracing problems.
+	if c.HidePrevCommandComments {
+		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, command.CommandName().TitleString()); err != nil {
+			ctx.Log.Err("unable to hide old comments: %s", err)
+		}
+	}
+
+	comment := c.MarkdownRenderer.Render(res, command.CommandName(), ctx.Log.History.String(), command.IsVerbose(), ctx.Pull.BaseRepo.VCSHost.Type)
+	if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, comment, command.CommandName().String()); err != nil {
+		ctx.Log.Err("unable to comment: %s", err)
+	}
+}

--- a/server/events_controller_e2e_test.go
+++ b/server/events_controller_e2e_test.go
@@ -965,48 +965,111 @@ func setupE2E(t *testing.T, repoDir string, policyChecksEnabled bool) (server.Ev
 
 	Ok(t, err)
 
-	commandRunner := &events.DefaultCommandRunner{
-		ProjectCommandRunner: &events.DefaultProjectCommandRunner{
-			Locker:           projectLocker,
-			LockURLGenerator: &mockLockURLGenerator{},
-			InitStepRunner: &runtime.InitStepRunner{
-				TerraformExecutor: terraformClient,
-				DefaultTFVersion:  defaultTFVersion,
-			},
-			PlanStepRunner: &runtime.PlanStepRunner{
-				TerraformExecutor: terraformClient,
-				DefaultTFVersion:  defaultTFVersion,
-			},
-			ShowStepRunner:        showStepRunner,
-			PolicyCheckStepRunner: policyCheckRunner,
-			ApplyStepRunner: &runtime.ApplyStepRunner{
-				TerraformExecutor: terraformClient,
-			},
-			RunStepRunner: &runtime.RunStepRunner{
-				TerraformExecutor: terraformClient,
-				DefaultTFVersion:  defaultTFVersion,
-			},
-			PullApprovedChecker: e2eVCSClient,
-			WorkingDir:          workingDir,
-			Webhooks:            &mockWebhookSender{},
-			WorkingDirLocker:    locker,
+	projectCommandRunner := &events.DefaultProjectCommandRunner{
+		Locker:           projectLocker,
+		LockURLGenerator: &mockLockURLGenerator{},
+		InitStepRunner: &runtime.InitStepRunner{
+			TerraformExecutor: terraformClient,
+			DefaultTFVersion:  defaultTFVersion,
 		},
-		EventParser:              eventParser,
-		VCSClient:                e2eVCSClient,
-		GithubPullGetter:         e2eGithubGetter,
-		GitlabMergeRequestGetter: e2eGitlabGetter,
-		CommitStatusUpdater:      e2eStatusUpdater,
-		MarkdownRenderer:         &events.MarkdownRenderer{},
-		Logger:                   logger,
-		StatsScope:               statsScope,
-		AllowForkPRs:             allowForkPRs,
-		AllowForkPRsFlag:         "allow-fork-prs",
-		ProjectCommandBuilder:    projectCommandBuilder,
-		DB:                       boltdb,
-		PendingPlanFinder:        &events.DefaultPendingPlanFinder{},
-		GlobalAutomerge:          false,
-		WorkingDir:               workingDir,
-		Drainer:                  drainer,
+		PlanStepRunner: &runtime.PlanStepRunner{
+			TerraformExecutor: terraformClient,
+			DefaultTFVersion:  defaultTFVersion,
+		},
+		ShowStepRunner:        showStepRunner,
+		PolicyCheckStepRunner: policyCheckRunner,
+		ApplyStepRunner: &runtime.ApplyStepRunner{
+			TerraformExecutor: terraformClient,
+		},
+		RunStepRunner: &runtime.RunStepRunner{
+			TerraformExecutor: terraformClient,
+			DefaultTFVersion:  defaultTFVersion,
+		},
+		PullApprovedChecker: e2eVCSClient,
+		WorkingDir:          workingDir,
+		Webhooks:            &mockWebhookSender{},
+		WorkingDirLocker:    locker,
+	}
+
+	dbUpdater := &events.DBUpdater{
+		DB: boltdb,
+	}
+
+	pullUpdater := &events.PullUpdater{
+		HidePrevCommandComments: false,
+		VCSClient:               e2eVCSClient,
+		MarkdownRenderer:        &events.MarkdownRenderer{},
+	}
+
+	autoMerger := &events.AutoMerger{
+		VCSClient:       e2eVCSClient,
+		GlobalAutomerge: false,
+	}
+
+	policyCheckCommandRunner := events.NewPolicyCheckCommandRunner(
+		dbUpdater,
+		pullUpdater,
+		e2eStatusUpdater,
+		projectCommandRunner,
+	)
+
+	planCommandRunner := events.NewPlanCommandRunner(
+		false,
+		e2eVCSClient,
+		&events.DefaultPendingPlanFinder{},
+		workingDir,
+		e2eStatusUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		dbUpdater,
+		pullUpdater,
+		policyCheckCommandRunner,
+		autoMerger,
+	)
+
+	applyCommandRunner := events.NewApplyCommandRunner(
+		e2eVCSClient,
+		false,
+		e2eStatusUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		autoMerger,
+		pullUpdater,
+		dbUpdater,
+		boltdb,
+	)
+
+	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(
+		e2eStatusUpdater,
+		projectCommandBuilder,
+		projectCommandRunner,
+		pullUpdater,
+		dbUpdater,
+	)
+
+	unlockCommandRunner := events.NewUnlockCommandRunner(
+		mocks.NewMockDeleteLockCommand(),
+		e2eVCSClient,
+	)
+
+	commentCommandRunnerByCmd := map[models.CommandName]events.CommentCommandRunner{
+		models.PlanCommand:            planCommandRunner,
+		models.ApplyCommand:           applyCommandRunner,
+		models.ApprovePoliciesCommand: approvePoliciesCommandRunner,
+		models.UnlockCommand:          unlockCommandRunner,
+	}
+
+	commandRunner := &events.DefaultCommandRunner{
+		EventParser:               eventParser,
+		VCSClient:                 e2eVCSClient,
+		GithubPullGetter:          e2eGithubGetter,
+		GitlabMergeRequestGetter:  e2eGitlabGetter,
+		Logger:                    logger,
+		StatsScope:                statsScope,
+		AllowForkPRs:              allowForkPRs,
+		AllowForkPRsFlag:          "allow-fork-prs",
+		CommentCommandRunnerByCmd: commentCommandRunnerByCmd,
+		Drainer:                   drainer,
 	}
 
 	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")

--- a/server/server.go
+++ b/server/server.go
@@ -465,32 +465,90 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	instrumentedProjectCmdRunner := &events.InstrumentedProjectCommandRunner{
 		ProjectCommandRunner: projectCommandRunner,
 	}
+
+	dbUpdater := &events.DBUpdater{
+		DB: boltdb,
+	}
+
+	pullUpdater := &events.PullUpdater{
+		HidePrevCommandComments: userConfig.HidePrevPlanComments,
+		VCSClient:               vcsClient,
+		MarkdownRenderer:        markdownRenderer,
+	}
+
+	autoMerger := &events.AutoMerger{
+		VCSClient:       vcsClient,
+		GlobalAutomerge: userConfig.Automerge,
+	}
+
+	policyCheckCommandRunner := events.NewPolicyCheckCommandRunner(
+		dbUpdater,
+		pullUpdater,
+		commitStatusUpdater,
+		instrumentedProjectCmdRunner,
+	)
+
+	planCommandRunner := events.NewPlanCommandRunner(
+		userConfig.SilenceVCSStatusNoPlans,
+		vcsClient,
+		pendingPlanFinder,
+		workingDir,
+		commitStatusUpdater,
+		projectCommandBuilder,
+		instrumentedProjectCmdRunner,
+		dbUpdater,
+		pullUpdater,
+		policyCheckCommandRunner,
+		autoMerger,
+	)
+
+	applyCommandRunner := events.NewApplyCommandRunner(
+		vcsClient,
+		userConfig.DisableApplyAll,
+		commitStatusUpdater,
+		projectCommandBuilder,
+		instrumentedProjectCmdRunner,
+		autoMerger,
+		pullUpdater,
+		dbUpdater,
+		boltdb,
+	)
+
+	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(
+		commitStatusUpdater,
+		projectCommandBuilder,
+		instrumentedProjectCmdRunner,
+		pullUpdater,
+		dbUpdater,
+	)
+
+	unlockCommandRunner := events.NewUnlockCommandRunner(
+		deleteLockCommand,
+		vcsClient,
+	)
+
+	commentCommandRunnerByCmd := map[models.CommandName]events.CommentCommandRunner{
+		models.PlanCommand:            planCommandRunner,
+		models.ApplyCommand:           applyCommandRunner,
+		models.ApprovePoliciesCommand: approvePoliciesCommandRunner,
+		models.UnlockCommand:          unlockCommandRunner,
+	}
+
 	commandRunner := &events.DefaultCommandRunner{
-		VCSClient:                vcsClient,
-		GithubPullGetter:         githubClient,
-		GitlabMergeRequestGetter: gitlabClient,
-		AzureDevopsPullGetter:    azuredevopsClient,
-		CommitStatusUpdater:      commitStatusUpdater,
-		EventParser:              eventParser,
-		MarkdownRenderer:         markdownRenderer,
-		Logger:                   logger,
-		StatsScope:               statsScope.Scope("cmd"),
-		AllowForkPRs:             userConfig.AllowForkPRs,
-		AllowForkPRsFlag:         config.AllowForkPRsFlag,
-		HidePrevPlanComments:     userConfig.HidePrevPlanComments,
-		SilenceForkPRErrors:      userConfig.SilenceForkPRErrors,
-		SilenceForkPRErrorsFlag:  config.SilenceForkPRErrorsFlag,
-		SilenceVCSStatusNoPlans:  userConfig.SilenceVCSStatusNoPlans,
-		DisableApplyAll:          userConfig.DisableApplyAll,
-		DisableAutoplan:          userConfig.DisableAutoplan,
-		ProjectCommandBuilder:    projectCommandBuilder,
-		ProjectCommandRunner:     instrumentedProjectCmdRunner,
-		WorkingDir:               workingDir,
-		PendingPlanFinder:        pendingPlanFinder,
-		DB:                       boltdb,
-		DeleteLockCommand:        deleteLockCommand,
-		GlobalAutomerge:          userConfig.Automerge,
-		Drainer:                  drainer,
+		VCSClient:                 vcsClient,
+		GithubPullGetter:          githubClient,
+		GitlabMergeRequestGetter:  gitlabClient,
+		AzureDevopsPullGetter:     azuredevopsClient,
+		CommentCommandRunnerByCmd: commentCommandRunnerByCmd,
+		EventParser:               eventParser,
+		Logger:                    logger,
+		StatsScope:                statsScope.Scope("cmd"),
+		AllowForkPRs:              userConfig.AllowForkPRs,
+		AllowForkPRsFlag:          config.AllowForkPRsFlag,
+		SilenceForkPRErrors:       userConfig.SilenceForkPRErrors,
+		SilenceForkPRErrorsFlag:   config.SilenceForkPRErrorsFlag,
+		DisableAutoplan:           userConfig.DisableAutoplan,
+		Drainer:                   drainer,
 	}
 	repoAllowlist, err := events.NewRepoAllowlistChecker(userConfig.RepoAllowlist)
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,13 +20,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/runatlantis/atlantis/server/events"
-	"github.com/runatlantis/atlantis/server/events/yaml/valid"
 
 	"github.com/gorilla/mux"
 	. "github.com/petergtz/pegomock"
@@ -49,35 +45,6 @@ func TestNewServer(t *testing.T) {
 }
 
 // todo: test what happens if we set different flags. The generated config should be different.
-func TestRepoConfig(t *testing.T) {
-	t.SkipNow()
-	tmpDir, err := ioutil.TempDir("", "")
-	Ok(t, err)
-
-	repoYaml := `
-repos:
-- id: "https://github.com/runatlantis/atlantis"
-`
-	expConfig := valid.GlobalCfg{
-		Repos: []valid.Repo{
-			{
-				ID: "https://github.com/runatlantis/atlantis",
-			},
-		},
-		Workflows: map[string]valid.Workflow{},
-	}
-	repoFileLocation := filepath.Join(tmpDir, "repos.yaml")
-	err = ioutil.WriteFile(repoFileLocation, []byte(repoYaml), 0600)
-	Ok(t, err)
-
-	s, err := server.NewServer(server.UserConfig{
-		DataDir:     tmpDir,
-		RepoConfig:  repoFileLocation,
-		AtlantisURL: "http://example.com",
-	}, server.Config{})
-	Ok(t, err)
-	Equals(t, expConfig, s.CommandRunner.ProjectCommandBuilder.(*events.DefaultProjectCommandBuilder).GlobalCfg)
-}
 
 func TestNewServer_InvalidAtlantisURL(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
Code flow as of now is complex and is pretty unreadable:
DefaultCommandRunner -> <Some>CommandRunner -> DefaultCommandRunner -> <some>CommandRunner

This PR aims to keep it at:
DefaultCommandRunner -> <someCommandRunner>