### PR TITLE
[ORCA-554] Add support for limiting number of projects per PR.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -23,6 +23,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server"
+	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -70,6 +71,7 @@ const (
 	GitlabWebhookSecretFlag    = "gitlab-webhook-secret" // nolint: gosec
 	HidePrevPlanComments       = "hide-prev-plan-comments"
 	LogLevelFlag               = "log-level"
+	MaxProjectsPerPR           = "max-projects-per-pr"
 	StatsNamespace             = "stats-namespace"
 	AllowDraftPRs              = "allow-draft-prs"
 	PortFlag                   = "port"
@@ -346,6 +348,10 @@ var boolFlags = map[string]boolFlag{
 	},
 }
 var intFlags = map[string]intFlag{
+	MaxProjectsPerPR: {
+		description:  "Max number of projects to operate on in a given pull request.",
+		defaultValue: events.InfiniteProjectsPerPR,
+	},
 	PortFlag: {
 		description:  "Port to bind to.",
 		defaultValue: DefaultPort,
@@ -582,6 +588,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.TFEHostname == "" {
 		c.TFEHostname = DefaultTFEHostname
+	}
+	if c.MaxProjectsPerPR == 0 {
+		c.MaxProjectsPerPR = events.InfiniteProjectsPerPR
 	}
 }
 

--- a/server/events/size_limited_project_command_builder.go
+++ b/server/events/size_limited_project_command_builder.go
@@ -1,0 +1,48 @@
+package events
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type SizeLimitedProjectCommandBuilder struct {
+	Limit int
+	ProjectCommandBuilder
+}
+
+func (b *SizeLimitedProjectCommandBuilder) BuildAutoplanCommands(ctx *CommandContext) ([]models.ProjectCommandContext, error) {
+	projects, err := b.ProjectCommandBuilder.BuildAutoplanCommands(ctx)
+
+	if err != nil {
+		return projects, err
+	}
+
+	return projects, b.CheckAgainstLimit(projects)
+}
+
+func (b *SizeLimitedProjectCommandBuilder) BuildPlanCommands(ctx *CommandContext, comment *CommentCommand) ([]models.ProjectCommandContext, error) {
+	projects, err := b.ProjectCommandBuilder.BuildPlanCommands(ctx, comment)
+
+	if err != nil {
+		return projects, err
+	}
+
+	return projects, b.CheckAgainstLimit(projects)
+}
+
+func (b *SizeLimitedProjectCommandBuilder) CheckAgainstLimit(projects []models.ProjectCommandContext) error {
+	if b.Limit != InfiniteProjectsPerPR && len(projects) > b.Limit {
+		return errors.New(
+			fmt.Sprintf(
+				"Number of projects cannot exceed %d.  This can either be caused by:\n"+
+					"1) GH failure in recognizing the diff\n"+
+					"2) Pull Request batch is too large for the given Atlantis instance\n\n"+
+					"Please break this pull request into smaller batches and try again.",
+				b.Limit,
+			),
+		)
+	}
+	return nil
+}

--- a/server/events/size_limited_project_command_builder_test.go
+++ b/server/events/size_limited_project_command_builder_test.go
@@ -1,0 +1,143 @@
+package events_test
+
+import (
+	"testing"
+
+	. "github.com/petergtz/pegomock"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/mocks"
+	"github.com/runatlantis/atlantis/server/events/models"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestSizeLimitedProjectCommandBuilder_autoplan(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	delegate := mocks.NewMockProjectCommandBuilder()
+
+	ctx := &events.CommandContext{}
+
+	project1 := models.ProjectCommandContext{
+		ProjectName: "test1",
+	}
+
+	project2 := models.ProjectCommandContext{
+		ProjectName: "test2",
+	}
+
+	expectedResult := []models.ProjectCommandContext{project1, project2}
+
+	t.Run("Limit Defined and Breached", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 1,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
+
+		_, err := subject.BuildAutoplanCommands(ctx)
+
+		ErrEquals(t, `Number of projects cannot exceed 1.  This can either be caused by:
+1) GH failure in recognizing the diff
+2) Pull Request batch is too large for the given Atlantis instance
+
+Please break this pull request into smaller batches and try again.`, err)
+	})
+
+	t.Run("Limit defined and not breached", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 2,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
+
+		result, err := subject.BuildAutoplanCommands(ctx)
+
+		Ok(t, err)
+
+		Assert(t, len(result) == len(expectedResult), "size is expected")
+	})
+
+	t.Run("Limit not defined", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 events.InfiniteProjectsPerPR,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
+
+		result, err := subject.BuildAutoplanCommands(ctx)
+
+		Ok(t, err)
+
+		Assert(t, len(result) == len(expectedResult), "size is expected")
+	})
+}
+
+func TestSizeLimitedProjectCommandBuilder_planComment(t *testing.T) {
+	RegisterMockTestingT(t)
+
+	delegate := mocks.NewMockProjectCommandBuilder()
+
+	ctx := &events.CommandContext{}
+
+	comment := &events.CommentCommand{}
+
+	project1 := models.ProjectCommandContext{
+		ProjectName: "test1",
+	}
+
+	project2 := models.ProjectCommandContext{
+		ProjectName: "test2",
+	}
+
+	expectedResult := []models.ProjectCommandContext{project1, project2}
+
+	t.Run("Limit Defined and Breached", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 1,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
+
+		_, err := subject.BuildPlanCommands(ctx, comment)
+
+		ErrEquals(t, `Number of projects cannot exceed 1.  This can either be caused by:
+1) GH failure in recognizing the diff
+2) Pull Request batch is too large for the given Atlantis instance
+
+Please break this pull request into smaller batches and try again.`, err)
+	})
+
+	t.Run("Limit defined and not breached", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 2,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
+
+		result, err := subject.BuildPlanCommands(ctx, comment)
+
+		Ok(t, err)
+
+		Assert(t, len(result) == len(expectedResult), "size is expected")
+	})
+
+	t.Run("Limit not defined", func(t *testing.T) {
+		subject := &events.SizeLimitedProjectCommandBuilder{
+			Limit:                 events.InfiniteProjectsPerPR,
+			ProjectCommandBuilder: delegate,
+		}
+
+		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
+
+		result, err := subject.BuildPlanCommands(ctx, comment)
+
+		Ok(t, err)
+
+		Assert(t, len(result) == len(expectedResult), "size is expected")
+	})
+}

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -211,8 +211,6 @@ func (g *GithubClient) HidePrevCommandComments(repo models.Repo, pullNum int, co
 			continue
 		}
 		firstLine := strings.ToLower(body[0])
-		g.logger.Debug("Command Name: %s", command)
-		g.logger.Debug("First line: %s", firstLine)
 		if !strings.Contains(firstLine, strings.ToLower(command)) {
 			continue
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -403,7 +403,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		Drainer:               drainer,
 		PreWorkflowHookRunner: &runtime.PreWorkflowHookRunner{},
 	}
-	projectCommandBuilder := events.NewProjectCommandBuilder(
+	projectCommandBuilder := events.NewProjectCommandBuilderWithLimit(
 		policyChecksEnabled,
 		validator,
 		&events.DefaultProjectFinder{},
@@ -416,6 +416,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		userConfig.SkipCloneNoChanges,
 		statsScope,
 		logger,
+		userConfig.MaxProjectsPerPR,
 	)
 
 	showStepRunner, err := runtime.NewShowStepRunner(terraformClient, defaultTfVersion)

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -40,6 +40,7 @@ type UserConfig struct {
 	GitlabWebhookSecret        string `mapstructure:"gitlab-webhook-secret"`
 	HidePrevPlanComments       bool   `mapstructure:"hide-prev-plan-comments"`
 	LogLevel                   string `mapstructure:"log-level"`
+	MaxProjectsPerPR           int    `mapstructure:"max-projects-per-pr"`
 	StatsNamespace             string `mapstructure:"stats-namespace"`
 	PlanDrafts                 bool   `mapstructure:"allow-draft-prs"`
 	Port                       int    `mapstructure:"port"`


### PR DESCRIPTION
Adds the ability to specify via command args a max limit of projects per PR. This is meant for safety purposes to ensure that large monorepos don't completely hog resources and potentially bring the instance down.