### PR TITLE
Revert "[ORCA-688] Clean up resources when Atlantis determines it sho…

### DIFF
--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -230,8 +230,6 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 	// Need to lock the workspace we're about to clone to.
 	workspace := DefaultWorkspace
 
-	var projCtxs []models.ProjectCommandContext
-
 	unlockFn, err := p.WorkingDirLocker.TryLock(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num, workspace)
 	if err != nil {
 		ctx.Log.Warn("workspace was locked")
@@ -245,13 +243,13 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		return nil, err
 	}
 
-	defer p.cleanWorkingDir(ctx, &projCtxs)
-
 	// Parse config file if it exists.
 	hasRepoCfg, err := p.ParserValidator.HasRepoCfg(repoDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "looking for %s file in %q", yaml.AtlantisYAMLFilename, repoDir)
 	}
+
+	var projCtxs []models.ProjectCommandContext
 
 	if hasRepoCfg {
 		// If there's a repo cfg then we'll use it to figure out which projects
@@ -312,20 +310,6 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 	return projCtxs, nil
 }
 
-// cleanWorkingDir ensures that we clean up after ourselves, if we have no project commands to run
-func (p *DefaultProjectCommandBuilder) cleanWorkingDir(ctx *CommandContext, projects *[]models.ProjectCommandContext) {
-	if len(*projects) > 0 {
-		return
-	}
-	// Delete the whole pull dir here since we don't have anything for atlantis to do.
-	err := p.WorkingDir.Delete(ctx.HeadRepo, ctx.Pull)
-	if err != nil {
-		ctx.Log.Warn("Unable to delete working directory")
-	}
-
-	ctx.Log.Debug("Deleted working directory")
-}
-
 // buildProjectPlanCommand builds a plan context for a single project.
 // cmd must be for only one project.
 func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *CommandContext, cmd *CommentCommand) ([]models.ProjectCommandContext, error) {
@@ -348,14 +332,12 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *CommandConte
 		return pcc, err
 	}
 
-	defer p.cleanWorkingDir(ctx, &pcc)
-
 	repoRelDir := DefaultRepoRelDir
 	if cmd.RepoRelDir != "" {
 		repoRelDir = cmd.RepoRelDir
 	}
 
-	pcc, err = p.buildProjectCommandCtx(
+	return p.buildProjectCommandCtx(
 		ctx,
 		models.PlanCommand,
 		cmd.ProjectName,
@@ -365,8 +347,6 @@ func (p *DefaultProjectCommandBuilder) buildProjectPlanCommand(ctx *CommandConte
 		workspace,
 		cmd.Verbose,
 	)
-
-	return pcc, err
 }
 
 // getCfg returns the atlantis.yaml config (if it exists) for this project. If

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -390,13 +390,6 @@ projects:
 					actCtxs, err = builder.BuildPlanCommands(&events.CommandContext{
 						Scope: scope,
 					}, &c.Cmd)
-
-					// Test that clean up occured only when there weren't ctxs returned or errors
-					if len(actCtxs) == 0 || err != nil {
-						workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
-					} else {
-						workingDir.VerifyWasCalled(Never()).Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
-					}
 				} else {
 					actCtxs, err = builder.BuildApplyCommands(&events.CommandContext{Scope: scope}, &c.Cmd)
 				}


### PR DESCRIPTION
…uldn't do anything. (#45)"

This reverts commit dbebea6cb23726c3737d2c0adce03077c5deb84b.

After doing some testing in staging, this functionally changes the way atlantis works since one error can nuke all previously planned roots and doesn't expose that to the user. Running atlantis apply would therefore not do anything even though it should apply all pending plans.