### PR TITLE
Change atlantis.env path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
             - ./:/atlantis/src
         # Contains the flags that atlantis uses in env var form
         env_file:
-            - ./atlantis.env
+            - ~/.atlantis.env


### PR DESCRIPTION
allows us to keep our env file indefinitely without polluting our repo git status.