### PR TITLE
Add tags to project structure in atlantis.yaml.

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/atlantis.yaml
@@ -1,0 +1,33 @@
+version: 3
+projects:
+- dir: .
+  workspace: default
+  workflow: default
+  tags:
+    foo: bar
+- dir: .
+  workspace: staging
+  workflow: staging
+  tags:
+    foo: bar
+workflows:
+  default:
+    # Only specify plan so should use default apply workflow.
+    plan:
+      steps:
+      - run: echo preinit
+      - init
+      - plan:
+          extra_args: [-var, var=fromconfig]
+      - run: echo postplan
+  staging:
+    plan:
+      steps:
+      - init
+      - plan:
+          extra_args: [-var-file, staging.tfvars]
+    apply:
+      steps:
+      - run: echo preapply
+      - apply
+      - run: echo postapply

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-all.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-all.txt
@@ -1,0 +1,43 @@
+Ran Apply for 2 projects:
+
+1. dir: `.` workspace: `default`
+1. dir: `.` workspace: `staging`
+
+### 1. dir: `.` workspace: `default`
+```diff
+null_resource.simple:
+null_resource.simple:
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+var = "fromconfig"
+workspace = "default"
+
+```
+
+---
+### 2. dir: `.` workspace: `staging`
+<details><summary>Show Output</summary>
+
+```diff
+preapply
+
+null_resource.simple:
+null_resource.simple:
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+var = "fromfile"
+workspace = "staging"
+
+postapply
+
+```
+</details>
+
+---
+

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-default.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-default.txt
@@ -1,0 +1,15 @@
+Ran Apply for dir: `.` workspace: `default`
+
+```diff
+null_resource.simple:
+null_resource.simple:
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+var = "fromconfig"
+workspace = "default"
+
+```
+

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-locked.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-locked.txt
@@ -1,0 +1,1 @@
+**Error:** Running `atlantis apply` is disabled.

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-staging.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-apply-staging.txt
@@ -1,0 +1,22 @@
+Ran Apply for dir: `.` workspace: `staging`
+
+<details><summary>Show Output</summary>
+
+```diff
+preapply
+
+null_resource.simple:
+null_resource.simple:
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+var = "fromfile"
+workspace = "staging"
+
+postapply
+
+```
+</details>
+

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-autoplan.txt
@@ -1,0 +1,79 @@
+Ran Plan for 2 projects:
+
+1. dir: `.` workspace: `default`
+1. dir: `.` workspace: `staging`
+
+### 1. dir: `.` workspace: `default`
+<details><summary>Show Output</summary>
+
+```diff
+preinit
+
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++ create
+
+Terraform will perform the following actions:
+
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
++ var       = "fromconfig"
++ workspace = "default"
+
+postplan
+
+```
+
+* :arrow_forward: To **apply** this plan, comment:
+    * `atlantis apply -d .`
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+    * `atlantis plan -d .`
+</details>
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+---
+### 2. dir: `.` workspace: `staging`
+<details><summary>Show Output</summary>
+
+```diff
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++ create
+
+Terraform will perform the following actions:
+
+  # null_resource.simple[0] will be created
++ resource "null_resource" "simple" {
+      + id = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
++ var       = "fromfile"
++ workspace = "staging"
+
+```
+
+* :arrow_forward: To **apply** this plan, comment:
+    * `atlantis apply -w staging`
+* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
+* :repeat: To **plan** this project again, comment:
+    * `atlantis plan -w staging`
+</details>
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+---
+* :fast_forward: To **apply** all unapplied plans from this pull request, comment:
+    * `atlantis apply`
+* :put_litter_in_its_place: To delete all plans and locks for the PR, comment:
+    * `atlantis unlock`

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-merge.txt
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/exp-output-merge.txt
@@ -1,0 +1,3 @@
+Locks and plans deleted for the projects and workspaces modified in this pull request:
+
+- dir: `.` workspaces: `default`, `staging`

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/main.tf
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/main.tf
@@ -1,0 +1,15 @@
+resource "null_resource" "simple" {
+  count = "1"
+}
+
+variable "var" {
+  default = "default"
+}
+
+output "var" {
+  value = var.var
+}
+
+output "workspace" {
+  value = terraform.workspace
+}

--- a/server/controllers/events/testfixtures/test-repos/simple-with-tags/staging.tfvars
+++ b/server/controllers/events/testfixtures/test-repos/simple-with-tags/staging.tfvars
@@ -1,0 +1,1 @@
+var= "fromfile"

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -396,6 +396,8 @@ type ProjectCommandContext struct {
 	// commands for this project. This can be set to nil in which case we will
 	// use the default Atlantis terraform version.
 	TerraformVersion *version.Version
+	// Configuration metadata for a given project.
+	Tags map[string]string
 	// User is the user that triggered this command.
 	User User
 	// Verbose is true when the user would like verbose output.

--- a/server/events/yaml/raw/project.go
+++ b/server/events/yaml/raw/project.go
@@ -31,14 +31,15 @@ var applyRequirements = map[string]bool{
 var supportedApplyReqs = buildSupportedApplyReqs()
 
 type Project struct {
-	Name                      *string   `yaml:"name,omitempty"`
-	Dir                       *string   `yaml:"dir,omitempty"`
-	Workspace                 *string   `yaml:"workspace,omitempty"`
-	Workflow                  *string   `yaml:"workflow,omitempty"`
-	TerraformVersion          *string   `yaml:"terraform_version,omitempty"`
-	Autoplan                  *Autoplan `yaml:"autoplan,omitempty"`
-	ApplyRequirements         []string  `yaml:"apply_requirements,omitempty"`
-	DeleteSourceBranchOnMerge *bool     `yaml:"delete_source_branch_on_merge,omitempty"`
+	Name                      *string           `yaml:"name,omitempty"`
+	Dir                       *string           `yaml:"dir,omitempty"`
+	Workspace                 *string           `yaml:"workspace,omitempty"`
+	Workflow                  *string           `yaml:"workflow,omitempty"`
+	TerraformVersion          *string           `yaml:"terraform_version,omitempty"`
+	Autoplan                  *Autoplan         `yaml:"autoplan,omitempty"`
+	ApplyRequirements         []string          `yaml:"apply_requirements,omitempty"`
+	DeleteSourceBranchOnMerge *bool             `yaml:"delete_source_branch_on_merge,omitempty"`
+	Tags                      map[string]string `yaml:"tags,omitempty"`
 }
 
 func (p Project) Validate() error {
@@ -97,6 +98,7 @@ func (p Project) ToValid() valid.Project {
 	// There are no default apply requirements.
 	v.ApplyRequirements = p.ApplyRequirements
 
+	v.Tags = p.Tags
 	v.Name = p.Name
 
 	if p.DeleteSourceBranchOnMerge != nil {

--- a/server/events/yaml/valid/repo_cfg.go
+++ b/server/events/yaml/valid/repo_cfg.go
@@ -107,6 +107,7 @@ type Project struct {
 	Autoplan                  Autoplan
 	ApplyRequirements         []string
 	DeleteSourceBranchOnMerge *bool
+	Tags                      map[string]string
 }
 
 // GetName returns the name of the project or an empty string if there is no


### PR DESCRIPTION
This allows us to effectively use atlantis.yaml as a form of persisting state from pre-workflow hooks -> main workflow.  We will be using this for tracking environments in Atlantis.

Only reason I added the test was to assert that parsing of tags indeed works. We will use the value of this in another PR entirely.