### PR TITLE
Log Streaming Bug Fix

### DIFF
--- a/server/handlers/project_command_output_handler.go
+++ b/server/handlers/project_command_output_handler.go
@@ -201,10 +201,10 @@ func (p *AsyncProjectCommandOutputHandler) CleanUp(pull string) {
 	delete(p.projectOutputBuffers, pull)
 	p.projectOutputBuffersLock.Unlock()
 
+	// Only delete the pull record from receiver buffers.
+	// WS channel will be closed when the user closes the browser tab
+	// in closeHanlder().
 	p.receiverBuffersLock.Lock()
-	for ch := range p.receiverBuffers[pull] {
-		close(ch)
-	}
 	delete(p.receiverBuffers, pull)
 	p.receiverBuffersLock.Unlock()
 }


### PR DESCRIPTION
Currently, we close any remaining ws channels during resource cleanup. However, if a log-streaming browser tab is closed after a PR is closed, we attempt to close an already closed channel which causes panic. So, we leave the responsibility of closing ws channels to the closeHandler() to avoid closing a channel more than once. 