### PR TITLE
Do nothing when sns topic is not provided

### DIFF
--- a/server/lyft/aws/sns/writer.go
+++ b/server/lyft/aws/sns/writer.go
@@ -16,6 +16,10 @@ type Writer interface {
 	Write([]byte) error
 }
 
+func NewNoopWriter() Writer {
+	return &noopWriter{}
+}
+
 // NewWriterWithStats returns a new instance of Writer that will connect to the specifed
 // sns topic using the specified session
 func NewWriterWithStats(
@@ -30,7 +34,6 @@ func NewWriterWithStats(
 			topicArn: aws.String(topicArn),
 		},
 	}
-
 }
 
 type writer struct {
@@ -62,5 +65,11 @@ func (w *writerWithStats) Write(payload []byte) error {
 	}
 
 	w.scope.NewCounter(metrics.ExecutionSuccessMetric)
+	return nil
+}
+
+type noopWriter struct{}
+
+func (n *noopWriter) Write(payload []byte) error {
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -573,11 +573,17 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing new aws session")
 	}
 
-	snsWriter := sns.NewWriterWithStats(
-		session,
-		userConfig.LyftAuditJobsSnsTopicArn,
-		statsScope,
-	)
+	var snsWriter sns.Writer
+
+	if userConfig.LyftAuditJobsSnsTopicArn != "" {
+		snsWriter = sns.NewWriterWithStats(
+			session,
+			userConfig.LyftAuditJobsSnsTopicArn,
+			statsScope,
+		)
+	} else {
+		snsWriter = sns.NewNoopWriter()
+	}
 
 	auditProjectCmdRunner := &lyftDecorators.AuditProjectCommandWrapper{
 		SnsWriter:            snsWriter,


### PR DESCRIPTION
Created a `noopWriter` to mock out the sns writer if the sns topic was not passed in.