### PR TITLE
Do not raise error when SQ status doesn't have tags defined

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -342,8 +342,7 @@ func (g *GithubClient) PullIsLocked(repo models.Repo, pull models.PullRequest, s
 			continue
 		}
 
-		// Submit queue status migth not have tags attached to it, in that case
-		// return false
+		// When Submit queue status does not have tags assume PR is not locked
 		if status.GetDescription() == "" {
 			return false, nil
 		}

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -342,6 +342,12 @@ func (g *GithubClient) PullIsLocked(repo models.Repo, pull models.PullRequest, s
 			continue
 		}
 
+		// Submit queue status migth not have tags attached to it, in that case
+		// return false
+		if status.GetDescription() == "" {
+			return false, nil
+		}
+
 		// Not using struct tags because there's no predefined schema for description.
 		description := make(map[string]interface{})
 		err := json.Unmarshal([]byte(status.GetDescription()), &description)

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -1145,3 +1145,32 @@ func TestGithubClient_PullIsLocked_WaitingKeyNotFound(t *testing.T) {
 	Ok(t, err)
 	Equals(t, false, locked)
 }
+
+func TestGithubClient_PullIsLocked_SQ_No_Tags(t *testing.T) {
+	client, err := vcs.NewGithubClient("temp", &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t))
+	Ok(t, err)
+
+	statuses := []*github.RepoStatus{
+		{
+			Context:     helper(vcs.SubmitQueueReadinessStatusContext),
+			Description: helper(""),
+		},
+	}
+
+	locked, err := client.PullIsLocked(models.Repo{
+		FullName:          "owner/repo",
+		Owner:             "owner",
+		Name:              "repo",
+		CloneURL:          "",
+		SanitizedCloneURL: "",
+		VCSHost: models.VCSHost{
+			Type:     models.Github,
+			Hostname: "github.com",
+		},
+	}, models.PullRequest{
+		Num:        1,
+		HeadCommit: "832812d4777ddc4197685c5a8f864eaf8a82d4ae",
+	}, statuses)
+	Ok(t, err)
+	Equals(t, false, locked)
+}


### PR DESCRIPTION
Returning false if submit queue's status doesn't have tags defined.