### PR TITLE
Remove no-color args and strip ansi for PRs.

### DIFF
--- a/server/events/runtime/apply_step_runner.go
+++ b/server/events/runtime/apply_step_runner.go
@@ -40,7 +40,7 @@ func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []stri
 
 	// TODO: Leverage PlanTypeStepRunnerDelegate here
 	if IsRemotePlan(contents) {
-		args := append(append([]string{"apply", "-input=false", "-no-color"}, extraArgs...), ctx.EscapedCommentArgs...)
+		args := append(append([]string{"apply", "-input=false"}, extraArgs...), ctx.EscapedCommentArgs...)
 		out, err = a.runRemoteApply(ctx, args, path, planPath, ctx.TerraformVersion, envs)
 		if err == nil {
 			out = a.cleanRemoteApplyOutput(out)
@@ -48,7 +48,7 @@ func (a *ApplyStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []stri
 	} else {
 		// NOTE: we need to quote the plan path because Bitbucket Server can
 		// have spaces in its repo owner names which is part of the path.
-		args := append(append(append([]string{"apply", "-input=false", "-no-color"}, extraArgs...), ctx.EscapedCommentArgs...), fmt.Sprintf("%q", planPath))
+		args := append(append(append([]string{"apply", "-input=false"}, extraArgs...), ctx.EscapedCommentArgs...), fmt.Sprintf("%q", planPath))
 		out, err = a.TerraformExecutor.RunCommandWithVersion(ctx, path, args, envs, ctx.TerraformVersion, ctx.Workspace)
 	}
 

--- a/server/events/runtime/init_step_runner.go
+++ b/server/events/runtime/init_step_runner.go
@@ -31,8 +31,6 @@ func (i *InitStepRunner) Run(ctx models.ProjectCommandContext, extraArgs []strin
 		terraformInitArgs = []string{}
 	}
 
-	terraformInitArgs = append(terraformInitArgs, "-no-color")
-
 	lockfilePath := filepath.Join(path, ".terraform.lock.hcl")
 	if MustConstraint("< 0.14.0").Check(tfVersion) || fileDoesNotExists(lockfilePath) {
 		terraformInitArgs = append(terraformInitArgs, "-upgrade")

--- a/server/events/runtime/plan_step_runner.go
+++ b/server/events/runtime/plan_step_runner.go
@@ -70,7 +70,7 @@ func (p *PlanStepRunner) isRemoteOpsErr(output string, err error) bool {
 // operations.
 func (p *PlanStepRunner) remotePlan(ctx models.ProjectCommandContext, extraArgs []string, path string, tfVersion *version.Version, planFile string, envs map[string]string) (string, error) {
 	argList := [][]string{
-		{"plan", "-input=false", "-refresh", "-no-color"},
+		{"plan", "-input=false", "-refresh"},
 		extraArgs,
 		ctx.EscapedCommentArgs,
 	}
@@ -140,11 +140,11 @@ func (p *PlanStepRunner) switchWorkspace(ctx models.ProjectCommandContext, path 
 	// To do this we can either select and catch the error or use list and then
 	// look for the workspace. Both commands take the same amount of time so
 	// that's why we're running select here.
-	_, err := p.TerraformExecutor.RunCommandWithVersion(ctx, path, []string{workspaceCmd, "select", "-no-color", ctx.Workspace}, envs, tfVersion, ctx.Workspace)
+	_, err := p.TerraformExecutor.RunCommandWithVersion(ctx, path, []string{workspaceCmd, "select", ctx.Workspace}, envs, tfVersion, ctx.Workspace)
 	if err != nil {
 		// If terraform workspace select fails we run terraform workspace
 		// new to create a new workspace automatically.
-		out, err := p.TerraformExecutor.RunCommandWithVersion(ctx, path, []string{workspaceCmd, "new", "-no-color", ctx.Workspace}, envs, tfVersion, ctx.Workspace)
+		out, err := p.TerraformExecutor.RunCommandWithVersion(ctx, path, []string{workspaceCmd, "new", ctx.Workspace}, envs, tfVersion, ctx.Workspace)
 		if err != nil {
 			return fmt.Errorf("%s: %s", err, out)
 		}
@@ -168,7 +168,7 @@ func (p *PlanStepRunner) buildPlanCmd(ctx models.ProjectCommandContext, extraArg
 	argList := [][]string{
 		// NOTE: we need to quote the plan filename because Bitbucket Server can
 		// have spaces in its repo owner names.
-		{"plan", "-input=false", "-refresh", "-no-color", "-out", fmt.Sprintf("%q", planFile)},
+		{"plan", "-input=false", "-refresh", "-out", fmt.Sprintf("%q", planFile)},
 		tfVars,
 		extraArgs,
 		ctx.EscapedCommentArgs,

--- a/server/events/terraform/ansi/strip.go
+++ b/server/events/terraform/ansi/strip.go
@@ -1,0 +1,13 @@
+package ansi
+
+import (
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+func Strip(str string) string {
+	return re.ReplaceAllString(str, "")
+}

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/runatlantis/atlantis/server/feature"
 	"github.com/runatlantis/atlantis/server/handlers"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/events/terraform/ansi"
 )
 
 var LogStreamingValidCmds = [...]string{"init", "plan", "apply"}
@@ -307,6 +308,9 @@ func (c *DefaultClient) RunCommandWithVersion(ctx models.ProjectCommandContext, 
 			lines = append(lines, line.Line)
 		}
 		output := strings.Join(lines, "\n")
+
+		// sanitize output by stripping out any ansi characters.
+		output = ansi.Strip(output)
 		return fmt.Sprintf("%s\n", output), err
 	}
 


### PR DESCRIPTION
Turns out it's super easy to strip out ansi coloring for PR output, so now we have native terraform highlighting for our streamed logs:

![image](https://user-images.githubusercontent.com/7416619/136148600-85c1bbf0-9c23-4fae-9e2b-44aa82ab2b44.png)
