### PR TITLE
Add error checking to job url generator.

### DIFF
--- a/server/handlers/mocks/mock_project_job_url_generator.go
+++ b/server/handlers/mocks/mock_project_job_url_generator.go
@@ -25,19 +25,23 @@ func NewMockProjectJobURLGenerator(options ...pegomock.Option) *MockProjectJobUR
 func (mock *MockProjectJobURLGenerator) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockProjectJobURLGenerator) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockProjectJobURLGenerator) GenerateProjectJobURL(p models.ProjectCommandContext) string {
+func (mock *MockProjectJobURLGenerator) GenerateProjectJobURL(p models.ProjectCommandContext) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockProjectJobURLGenerator().")
 	}
 	params := []pegomock.Param{p}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GenerateProjectJobURL", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem()})
+	result := pegomock.GetGenericMockFrom(mock).Invoke("GenerateProjectJobURL", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 string
+	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
 			ret0 = result[0].(string)
 		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
 	}
-	return ret0
+	return ret0, ret1
 }
 
 func (mock *MockProjectJobURLGenerator) VerifyWasCalledOnce() *VerifierMockProjectJobURLGenerator {
@@ -47,14 +51,14 @@ func (mock *MockProjectJobURLGenerator) VerifyWasCalledOnce() *VerifierMockProje
 	}
 }
 
-func (mock *MockProjectJobURLGenerator) VerifyWasCalled(invocationCountMatcher pegomock.Matcher) *VerifierMockProjectJobURLGenerator {
+func (mock *MockProjectJobURLGenerator) VerifyWasCalled(invocationCountMatcher pegomock.InvocationCountMatcher) *VerifierMockProjectJobURLGenerator {
 	return &VerifierMockProjectJobURLGenerator{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
 	}
 }
 
-func (mock *MockProjectJobURLGenerator) VerifyWasCalledInOrder(invocationCountMatcher pegomock.Matcher, inOrderContext *pegomock.InOrderContext) *VerifierMockProjectJobURLGenerator {
+func (mock *MockProjectJobURLGenerator) VerifyWasCalledInOrder(invocationCountMatcher pegomock.InvocationCountMatcher, inOrderContext *pegomock.InOrderContext) *VerifierMockProjectJobURLGenerator {
 	return &VerifierMockProjectJobURLGenerator{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -62,7 +66,7 @@ func (mock *MockProjectJobURLGenerator) VerifyWasCalledInOrder(invocationCountMa
 	}
 }
 
-func (mock *MockProjectJobURLGenerator) VerifyWasCalledEventually(invocationCountMatcher pegomock.Matcher, timeout time.Duration) *VerifierMockProjectJobURLGenerator {
+func (mock *MockProjectJobURLGenerator) VerifyWasCalledEventually(invocationCountMatcher pegomock.InvocationCountMatcher, timeout time.Duration) *VerifierMockProjectJobURLGenerator {
 	return &VerifierMockProjectJobURLGenerator{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -72,7 +76,7 @@ func (mock *MockProjectJobURLGenerator) VerifyWasCalledEventually(invocationCoun
 
 type VerifierMockProjectJobURLGenerator struct {
 	mock                   *MockProjectJobURLGenerator
-	invocationCountMatcher pegomock.Matcher
+	invocationCountMatcher pegomock.InvocationCountMatcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
 }

--- a/server/handlers/mocks/mock_project_status_updater.go
+++ b/server/handlers/mocks/mock_project_status_updater.go
@@ -47,14 +47,14 @@ func (mock *MockProjectStatusUpdater) VerifyWasCalledOnce() *VerifierMockProject
 	}
 }
 
-func (mock *MockProjectStatusUpdater) VerifyWasCalled(invocationCountMatcher pegomock.Matcher) *VerifierMockProjectStatusUpdater {
+func (mock *MockProjectStatusUpdater) VerifyWasCalled(invocationCountMatcher pegomock.InvocationCountMatcher) *VerifierMockProjectStatusUpdater {
 	return &VerifierMockProjectStatusUpdater{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
 	}
 }
 
-func (mock *MockProjectStatusUpdater) VerifyWasCalledInOrder(invocationCountMatcher pegomock.Matcher, inOrderContext *pegomock.InOrderContext) *VerifierMockProjectStatusUpdater {
+func (mock *MockProjectStatusUpdater) VerifyWasCalledInOrder(invocationCountMatcher pegomock.InvocationCountMatcher, inOrderContext *pegomock.InOrderContext) *VerifierMockProjectStatusUpdater {
 	return &VerifierMockProjectStatusUpdater{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -62,7 +62,7 @@ func (mock *MockProjectStatusUpdater) VerifyWasCalledInOrder(invocationCountMatc
 	}
 }
 
-func (mock *MockProjectStatusUpdater) VerifyWasCalledEventually(invocationCountMatcher pegomock.Matcher, timeout time.Duration) *VerifierMockProjectStatusUpdater {
+func (mock *MockProjectStatusUpdater) VerifyWasCalledEventually(invocationCountMatcher pegomock.InvocationCountMatcher, timeout time.Duration) *VerifierMockProjectStatusUpdater {
 	return &VerifierMockProjectStatusUpdater{
 		mock:                   mock,
 		invocationCountMatcher: invocationCountMatcher,
@@ -72,7 +72,7 @@ func (mock *MockProjectStatusUpdater) VerifyWasCalledEventually(invocationCountM
 
 type VerifierMockProjectStatusUpdater struct {
 	mock                   *MockProjectStatusUpdater
-	invocationCountMatcher pegomock.Matcher
+	invocationCountMatcher pegomock.InvocationCountMatcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
 }

--- a/server/handlers/project_command_output_handler.go
+++ b/server/handlers/project_command_output_handler.go
@@ -31,7 +31,7 @@ type AsyncProjectCommandOutputHandler struct {
 
 // ProjectJobURLGenerator generates urls to view project's progress.
 type ProjectJobURLGenerator interface {
-	GenerateProjectJobURL(p models.ProjectCommandContext) string
+	GenerateProjectJobURL(p models.ProjectCommandContext) (string, error)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_project_status_updater.go ProjectStatusUpdater
@@ -126,7 +126,11 @@ func (p *AsyncProjectCommandOutputHandler) Clear(ctx models.ProjectCommandContex
 }
 
 func (p *AsyncProjectCommandOutputHandler) SetJobURLWithStatus(ctx models.ProjectCommandContext, cmdName models.CommandName, status models.CommitStatus) error {
-	url := p.projectJobURLGenerator.GenerateProjectJobURL(ctx)
+	url, err := p.projectJobURLGenerator.GenerateProjectJobURL(ctx)
+
+	if err != nil {
+		return err
+	}
 	return p.projectStatusUpdater.UpdateProject(ctx, cmdName, status, url)
 }
 


### PR DESCRIPTION
Fixes a bug where project name is nil and in general we should always be checking any errors and not panicking.