### PR TITLE
Ensure policy check apply req fails if status not passed.

### DIFF
--- a/server/events/apply_requirement_handler.go
+++ b/server/events/apply_requirement_handler.go
@@ -24,7 +24,7 @@ func (a *AggregateApplyRequirements) ValidateProject(repoDir string, ctx models.
 			}
 		// this should come before mergeability check since mergeability is a superset of this check.
 		case valid.PoliciesPassedApplyReq:
-			if ctx.ProjectPlanStatus == models.ErroredPolicyCheckStatus {
+			if ctx.ProjectPlanStatus != models.PassedPolicyCheckStatus {
 				return "All policies must pass for project before running apply", nil
 			}
 		case raw.MergeableApplyRequirement:


### PR DESCRIPTION
This is addressing a security risk.  Ie. if there are 2 plans running and one fails. Someone can actually still apply -p the successful one without running through the policy checking step.

This should mitigate against that.