### PR TITLE
Ensure std.out and std.err on console for logging ingestion

### DIFF
--- a/server/core/runtime/pre_workflow_hook_runner.go
+++ b/server/core/runtime/pre_workflow_hook_runner.go
@@ -48,7 +48,7 @@ func (wh DefaultPreWorkflowHookRunner) Run(ctx models.PreWorkflowHookCommandCont
 	err := cmd.Run()
 
 	if err != nil {
-		err = fmt.Errorf("%s: running %q in %q: \n%s", err, command, path, err)
+		err = fmt.Errorf("%s: running %q in %q", err, command, path)
 		ctx.Log.Debug("error: %s", err)
 		return "", err
 	}

--- a/server/core/runtime/pre_workflow_hook_runner_test.go
+++ b/server/core/runtime/pre_workflow_hook_runner_test.go
@@ -6,9 +6,6 @@ import (
 
 	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/core/runtime"
-	"github.com/runatlantis/atlantis/server/core/terraform/mocks"
-	matchers2 "github.com/runatlantis/atlantis/server/core/terraform/mocks/matchers"
-	"github.com/runatlantis/atlantis/server/events/mocks/matchers"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
@@ -21,40 +18,12 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		ExpErr  string
 	}{
 		{
-			Command: "",
-			ExpOut:  "",
-		},
-		{
 			Command: "echo hi",
-			ExpOut:  "hi\n",
-		},
-		{
-			Command: `printf \'your main.tf file does not provide default region.\\ncheck\'`,
-			ExpOut:  `'your`,
-		},
-		{
-			Command: `printf 'your main.tf file does not provide default region.\ncheck'`,
-			ExpOut:  "your main.tf file does not provide default region.\ncheck",
+			ExpOut:  "",
 		},
 		{
 			Command: "echo 'a",
 			ExpErr:  "exit status 2: running \"echo 'a\" in",
-		},
-		{
-			Command: "echo hi >> file && cat file",
-			ExpOut:  "hi\n",
-		},
-		{
-			Command: "lkjlkj",
-			ExpErr:  "exit status 127: running \"lkjlkj\" in",
-		},
-		{
-			Command: "echo base_repo_name=$BASE_REPO_NAME base_repo_owner=$BASE_REPO_OWNER head_repo_name=$HEAD_REPO_NAME head_repo_owner=$HEAD_REPO_OWNER head_branch_name=$HEAD_BRANCH_NAME head_commit=$HEAD_COMMIT base_branch_name=$BASE_BRANCH_NAME pull_num=$PULL_NUM pull_author=$PULL_AUTHOR",
-			ExpOut:  "base_repo_name=basename base_repo_owner=baseowner head_repo_name=headname head_repo_owner=headowner head_branch_name=add-feat head_commit=12345abcdef base_branch_name=master pull_num=2 pull_author=acme\n",
-		},
-		{
-			Command: "echo user_name=$USER_NAME",
-			ExpOut:  "user_name=acme-user\n",
 		},
 	}
 
@@ -64,9 +33,6 @@ func TestPreWorkflowHookRunner_Run(t *testing.T) {
 		Ok(t, err)
 
 		RegisterMockTestingT(t)
-		terraform := mocks.NewMockClient()
-		When(terraform.EnsureVersion(matchers.AnyPtrToLoggingSimpleLogger(), matchers2.AnyPtrToGoVersionVersion())).
-			ThenReturn(nil)
 
 		logger := logging.NewNoopLogger(t)
 


### PR DESCRIPTION
The output is just dropped here, however, if we log that output here, our json keys won't be parsed correctly since everything will be nested.
