### PR TITLE
Fix pointer bug.

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -45,11 +45,11 @@ const (
 
 // allows for custom handling of github 404s
 type PullRequestNotFound struct {
-	err error
+	Err error
 }
 
 func (p *PullRequestNotFound) Error() string {
-	return "Pull request not found: " + p.err.Error()
+	return "Pull request not found: " + p.Err.Error()
 }
 
 // GithubClient is used to perform GitHub actions.
@@ -435,7 +435,7 @@ func (g *GithubClient) GetPullRequestFromName(repoName string, repoOwner string,
 
 	ghErr, ok := err.(*github.ErrorResponse)
 	if ok && ghErr.Response.StatusCode != 404 {
-		return pull, &PullRequestNotFound{err: err}
+		return pull, &PullRequestNotFound{Err: err}
 	}
 	return pull, err
 }

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -43,13 +43,12 @@ const (
 	LockValue                         = "lock"
 )
 
-
 // allows for custom handling of github 404s
 type PullRequestNotFound struct {
 	err error
 }
 
-func (p PullRequestNotFound) Error() string {
+func (p *PullRequestNotFound) Error() string {
 	return "Pull request not found: " + p.err.Error()
 }
 
@@ -436,7 +435,7 @@ func (g *GithubClient) GetPullRequestFromName(repoName string, repoOwner string,
 
 	ghErr, ok := err.(*github.ErrorResponse)
 	if ok && ghErr.Response.StatusCode != 404 {
-		return pull, PullRequestNotFound{err: err}
+		return pull, &PullRequestNotFound{err: err}
 	}
 	return pull, err
 }

--- a/server/events/working_dir_iterator.go
+++ b/server/events/working_dir_iterator.go
@@ -88,6 +88,8 @@ func (f *FileWorkDirIterator) ListCurrentWorkingDirPulls() ([]models.PullRequest
 			}
 
 			f.Log.Warn("%s/%s/#%d not found, %s", ownerName, repoName, pullNum, notFoundErr)
+
+			return nil
 		}
 
 		internalPull, _, _, err := f.EventParser.ParseGithubPull(pull)

--- a/server/events/working_dir_iterator_test.go
+++ b/server/events/working_dir_iterator_test.go
@@ -43,23 +43,13 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 	t.Run("pull not found", func(t *testing.T) {
 
-		pullNum := 1
-
-		expectedGithubPull := &github.PullRequest{
-			Number: &pullNum,
-		}
-		expectedInternalPull := models.PullRequest{
-			Num: pullNum,
-		}
-
 		baseDir, _ := ioutil.TempDir("", "atlantis-data")
 
 		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm)
 
 		pullNotFound := &vcs.PullRequestNotFound{Err: errors.New("error")}
 
-		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", 1)).ThenReturn(expectedGithubPull, pullNotFound)
-		pegomock.When(mockEventParser.ParseGithubPull(expectedGithubPull)).ThenReturn(expectedInternalPull, models.Repo{}, models.Repo{}, nil)
+		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", 1)).ThenReturn(nil, pullNotFound)
 
 		subject := &events.FileWorkDirIterator{
 			Log:          log,
@@ -71,10 +61,8 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 		pulls, err := subject.ListCurrentWorkingDirPulls()
 
 		assert.NoError(t, err)
-		assert.Len(t, pulls, 1)
-		assert.Contains(t, pulls, expectedInternalPull)
+		assert.Empty(t, pulls)
 	})
-
 
 	t.Run("1 pull returned", func(t *testing.T) {
 


### PR DESCRIPTION
We are casting to the pointer of `PullRequstNotFound`  [here](https://github.com/lyft/atlantis/blob/a9f3f72dc2896566f632d432ddc4a40285b098fb/server/events/working_dir_iterator.go#L84-L85)