### PR TITLE
fix: terraform version loading should use GetAny

### DIFF
--- a/server/core/terraform/terraform_client.go
+++ b/server/core/terraform/terraform_client.go
@@ -316,7 +316,7 @@ func (l *VersionLoader) loadVersion(v *version.Version, destPath string) (runtim
 	binURL := fmt.Sprintf("%s_%s_%s.zip", urlPrefix, runtime.GOOS, runtime.GOARCH)
 	checksumURL := fmt.Sprintf("%s_SHA256SUMS", urlPrefix)
 	fullSrcURL := fmt.Sprintf("%s?checksum=file:%s", binURL, checksumURL)
-	if err := l.downloader.GetFile(destPath, fullSrcURL); err != nil {
+	if err := l.downloader.GetAny(destPath, fullSrcURL); err != nil {
 		return runtime_models.LocalFilePath(""), errors.Wrapf(err, "downloading terraform version %s at %q", v.String(), fullSrcURL)
 	}
 

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -77,7 +77,7 @@ func TestVersionLoader_buildsURL(t *testing.T) {
 		When(mockDownloader.GetAny(EqString(destPath), EqString(fullURL))).ThenReturn(nil)
 		binPath, err := subject.loadVersion(v, destPath)
 
-		mockDownloader.VerifyWasCalledOnce().GetFile(EqString(destPath), EqString(fullURL))
+		mockDownloader.VerifyWasCalledOnce().GetAny(EqString(destPath), EqString(fullURL))
 
 		Ok(t, err)
 

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -2,6 +2,8 @@ package terraform
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -16,6 +18,7 @@ import (
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	fmocks "github.com/runatlantis/atlantis/server/lyft/feature/mocks"
 	. "github.com/runatlantis/atlantis/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 // Test that it executes successfully
@@ -58,7 +61,7 @@ func TestDefaultClient_Synchronous_RunCommandWithVersion(t *testing.T) {
 	Equals(t, "hello\n", out)
 }
 
-func TestVersionLoader(t *testing.T) {
+func TestVersionLoader_buildsURL(t *testing.T) {
 	v, _ := version.NewVersion("0.15.0")
 
 	destPath := "some/path"
@@ -74,7 +77,7 @@ func TestVersionLoader(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		When(mockDownloader.GetFile(EqString(destPath), EqString(fullURL))).ThenReturn(nil)
+		When(mockDownloader.GetAny(EqString(destPath), EqString(fullURL))).ThenReturn(nil)
 		binPath, err := subject.loadVersion(v, destPath)
 
 		mockDownloader.VerifyWasCalledOnce().GetFile(EqString(destPath), EqString(fullURL))
@@ -86,7 +89,7 @@ func TestVersionLoader(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 
-		When(mockDownloader.GetFile(EqString(destPath), EqString(fullURL))).ThenReturn(fmt.Errorf("err"))
+		When(mockDownloader.GetAny(EqString(destPath), EqString(fullURL))).ThenReturn(fmt.Errorf("err"))
 		_, err := subject.loadVersion(v, destPath)
 
 		Assert(t, err != nil, "err is expected")

--- a/server/core/terraform/terraform_client_internal_test.go
+++ b/server/core/terraform/terraform_client_internal_test.go
@@ -2,8 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -18,7 +16,6 @@ import (
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	fmocks "github.com/runatlantis/atlantis/server/lyft/feature/mocks"
 	. "github.com/runatlantis/atlantis/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test that it executes successfully


### PR DESCRIPTION
GetAny expects a directory destination not GetFile. This was failing the version lookup in staging. Just tested this locally and should work.