### PR TITLE
Add stats to global config.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,4 +134,7 @@ require (
 	github.com/uber-go/tally v3.4.3+incompatible
 )
 
-require github.com/onsi/ginkgo v1.14.0 // indirect
+require (
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/onsi/ginkgo v1.14.0 // indirect
+)

--- a/server/events/yaml/raw/global_cfg.go
+++ b/server/events/yaml/raw/global_cfg.go
@@ -15,7 +15,7 @@ type GlobalCfg struct {
 	Repos      []Repo              `yaml:"repos" json:"repos"`
 	Workflows  map[string]Workflow `yaml:"workflows" json:"workflows"`
 	PolicySets PolicySets          `yaml:"policies" json:"policies"`
-	Metrics    Metrics             `yaml:"metrics" json:"metrics"`
+	Metrics    Metrics            `yaml:"metrics" json:"metrics"`
 }
 
 // Repo is the raw schema for repos in the server-side repo config.

--- a/server/events/yaml/raw/global_cfg.go
+++ b/server/events/yaml/raw/global_cfg.go
@@ -15,6 +15,7 @@ type GlobalCfg struct {
 	Repos      []Repo              `yaml:"repos" json:"repos"`
 	Workflows  map[string]Workflow `yaml:"workflows" json:"workflows"`
 	PolicySets PolicySets          `yaml:"policies" json:"policies"`
+	Metrics    Metrics             `yaml:"metrics" json:"metrics"`
 }
 
 // Repo is the raw schema for repos in the server-side repo config.
@@ -33,7 +34,9 @@ type Repo struct {
 func (g GlobalCfg) Validate() error {
 	err := validation.ValidateStruct(&g,
 		validation.Field(&g.Repos),
-		validation.Field(&g.Workflows))
+		validation.Field(&g.Workflows),
+		validation.Field(&g.Metrics),
+	)
 	if err != nil {
 		return err
 	}
@@ -128,6 +131,7 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 		Repos:      repos,
 		Workflows:  workflows,
 		PolicySets: g.PolicySets.ToValid(),
+		Metrics:    g.Metrics.ToValid(),
 	}
 }
 

--- a/server/events/yaml/raw/metrics.go
+++ b/server/events/yaml/raw/metrics.go
@@ -17,13 +17,15 @@ type Statsd struct {
 
 func (s *Statsd) Validate() error {
 	return validation.ValidateStruct(s,
+		validation.Field(&s.Host, validation.Required),
+		validation.Field(&s.Port, validation.Required),
 		validation.Field(&s.Host, is.IP),
 		validation.Field(&s.Port, is.Int))
 }
 
 func (m Metrics) Validate() error {
 	return validation.ValidateStruct(&m,
-		validation.Field(&m.Statsd, validation.Required),
+		validation.Field(&m.Statsd),
 	)
 }
 
@@ -38,6 +40,5 @@ func (m Metrics) ToValid() valid.Metrics {
 		}
 	}
 
-	// theoretically should never hit this.
 	return valid.Metrics{}
 }

--- a/server/events/yaml/raw/metrics.go
+++ b/server/events/yaml/raw/metrics.go
@@ -1,0 +1,43 @@
+package raw
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/runatlantis/atlantis/server/events/yaml/valid"
+)
+
+type Metrics struct {
+	Statsd *Statsd `yaml:"statsd" json:"statsd"`
+}
+
+type Statsd struct {
+	Port string `yaml:"port" json:"port"`
+	Host string `yaml:"host" json:"host"`
+}
+
+func (s *Statsd) Validate() error {
+	return validation.ValidateStruct(s,
+		validation.Field(&s.Host, is.IP),
+		validation.Field(&s.Port, is.Int))
+}
+
+func (m Metrics) Validate() error {
+	return validation.ValidateStruct(&m,
+		validation.Field(&m.Statsd, validation.Required),
+	)
+}
+
+func (m Metrics) ToValid() valid.Metrics {
+	// we've already validated at this point
+	if m.Statsd != nil {
+		return valid.Metrics{
+			Statsd: &valid.Statsd{
+				Host: m.Statsd.Host,
+				Port: m.Statsd.Port,
+			},
+		}
+	}
+
+	// theoretically should never hit this.
+	return valid.Metrics{}
+}

--- a/server/events/yaml/raw/metrics_test.go
+++ b/server/events/yaml/raw/metrics_test.go
@@ -40,22 +40,54 @@ statsd:
 		assert.NoError(t, err)
 	})
 }
-func TestMetrics_Validate(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		subject := raw.Metrics{
-			Statsd: &raw.Statsd{
-				Host: "127.0.0.1",
-				Port: "8125",
-			},
-		}
+func TestMetrics_Validate_Success(t *testing.T) {
 
-		assert.NoError(t, subject.Validate())
-	})
-
-	errorCases := []struct {
+	cases := []struct {
 		description string
 		subject     raw.Metrics
 	}{
+		{
+			description: "success",
+			subject: raw.Metrics{
+				Statsd: &raw.Statsd{
+					Host: "127.0.0.1",
+					Port: "8125",
+				},
+			},
+		},
+		{
+			description: "missing stats",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.NoError(t, c.subject.Validate())
+		})
+	}
+
+}
+func TestMetrics_Validate_Error(t *testing.T) {
+	cases := []struct {
+		description string
+		subject     raw.Metrics
+	}{
+		{
+			description: "missing host",
+			subject: raw.Metrics{
+				Statsd: &raw.Statsd{
+					Port: "8125",
+				},
+			},
+		},
+		{
+			description: "missing port",
+			subject: raw.Metrics{
+				Statsd: &raw.Statsd{
+					Host: "127.0.0.1",
+				},
+			},
+		},
 		{
 			description: "invalid port",
 			subject: raw.Metrics{
@@ -76,7 +108,7 @@ func TestMetrics_Validate(t *testing.T) {
 		},
 	}
 
-	for _, c := range errorCases {
+	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			assert.Error(t, c.subject.Validate())
 		})

--- a/server/events/yaml/raw/metrics_test.go
+++ b/server/events/yaml/raw/metrics_test.go
@@ -1,0 +1,84 @@
+package raw_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/yaml/raw"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestMetrics_Unmarshal(t *testing.T) {
+	t.Run("yaml", func(t *testing.T) {
+
+		rawYaml := `
+statsd:
+  host: 127.0.0.1
+  port: 8125
+`
+
+		var result raw.Metrics
+
+		err := yaml.UnmarshalStrict([]byte(rawYaml), &result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		rawJSON := `
+{
+	"statsd": {
+		"host": "127.0.0.1",
+		"port": "8125"
+	}
+}		
+`
+
+		var result raw.Metrics
+
+		err := json.Unmarshal([]byte(rawJSON), &result)
+		assert.NoError(t, err)
+	})
+}
+func TestMetrics_Validate(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		subject := raw.Metrics{
+			Statsd: &raw.Statsd{
+				Host: "127.0.0.1",
+				Port: "8125",
+			},
+		}
+
+		assert.NoError(t, subject.Validate())
+	})
+
+	errorCases := []struct {
+		description string
+		subject     raw.Metrics
+	}{
+		{
+			description: "invalid port",
+			subject: raw.Metrics{
+				Statsd: &raw.Statsd{
+					Host: "127.0.0.1",
+					Port: "string",
+				},
+			},
+		},
+		{
+			description: "invalid host",
+			subject: raw.Metrics{
+				Statsd: &raw.Statsd{
+					Host: "127.0.1",
+					Port: "8125",
+				},
+			},
+		},
+	}
+
+	for _, c := range errorCases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.Error(t, c.subject.Validate())
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -197,12 +197,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		}
 	}
 
-	// TODO: move this to yaml in a followup
-	globalCfg.Metrics.Statsd = &valid.Statsd{
-		Host: "127.0.0.1",
-		Port: "8125",
-	}
-
 	statsScope, closer, err := metrics.NewScope(globalCfg.Metrics, logger, userConfig.StatsNamespace)
 
 	if err != nil {


### PR DESCRIPTION
This allows us to supply metrics objects through the global config. 