### PR TITLE
Fix approve_policies comment formatting error

### DIFF
--- a/server/events/markdown_renderer.go
+++ b/server/events/markdown_renderer.go
@@ -336,7 +336,7 @@ var singleProjectVersionSuccessTmpl string
 //go:embed templates/singleProjectVersionUnsuccessful.tmpl
 var singleProjectVersionUnsuccessfulTmpl string
 
-//go:embed templates/singleProjectVersionUnsuccessful.tmpl
+//go:embed templates/approveAllProjects.tmpl
 var approveAllProjectsTmpl string
 
 //go:embed templates/multiProjectPlan.tmpl

--- a/server/events/markdown_renderer_test.go
+++ b/server/events/markdown_renderer_test.go
@@ -293,6 +293,13 @@ func TestRenderProjectResults(t *testing.T) {
 			"Ran Plan for 0 projects:\n\n\n\n",
 		},
 		{
+			"approve policies",
+			models.ApprovePoliciesCommand,
+			[]models.ProjectResult{},
+			models.Github,
+			"Approved Policies for 0 projects:\n\n\n\n",
+		},
+		{
 			"single successful plan",
 			models.PlanCommand,
 			[]models.ProjectResult{


### PR DESCRIPTION
The custom templating code was initially using the wrong template for approve_policies which was causing it to render strangely. We also didn't have any regression tests for the policy approval comment text so I've added a simple one. 