### PR TITLE
Orca 4417 update repo config to allow platform mode overrides

### DIFF
--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -35,6 +35,8 @@ type Project struct {
 	Dir                       *string           `yaml:"dir,omitempty"`
 	Workspace                 *string           `yaml:"workspace,omitempty"`
 	Workflow                  *string           `yaml:"workflow,omitempty"`
+	PullRequestWorkflowName   *string           `yaml:"pull_request_workflow,omitempty"`
+	DeploymentWorkflowName    *string           `yaml:"deployment_workflow,omitempty"`
 	TerraformVersion          *string           `yaml:"terraform_version,omitempty"`
 	Autoplan                  *Autoplan         `yaml:"autoplan,omitempty"`
 	ApplyRequirements         []string          `yaml:"apply_requirements,omitempty"`
@@ -86,6 +88,8 @@ func (p Project) ToValid() valid.Project {
 	}
 
 	v.WorkflowName = p.Workflow
+	v.PullRequestWorkflowName = p.PullRequestWorkflowName
+	v.DeploymentWorkflowName = p.DeploymentWorkflowName
 	if p.TerraformVersion != nil {
 		v.TerraformVersion, _ = version.NewVersion(*p.TerraformVersion)
 	}

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -353,11 +353,10 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 func (g GlobalCfg) DefaultProjCfg(log logging.SimpleLogging, repoID string, repoRelDir string, workspace string) MergedProjectCfg {
 	log.Debug("building config based on server-side config")
 	repo := g.foldMatchingRepos(repoID)
-	return MergedProjectCfg{
+
+	mrgPrj := MergedProjectCfg{
 		ApplyRequirements:         repo.ApplyRequirements,
 		Workflow:                  *repo.Workflow,
-		PullRequestWorkflow:       *repo.PullRequestWorkflow,
-		DeploymentWorkflow:        *repo.DeploymentWorkflow,
 		RepoRelDir:                repoRelDir,
 		Workspace:                 workspace,
 		Name:                      "",
@@ -366,6 +365,12 @@ func (g GlobalCfg) DefaultProjCfg(log logging.SimpleLogging, repoID string, repo
 		PolicySets:                g.PolicySets,
 		DeleteSourceBranchOnMerge: *repo.DeleteSourceBranchOnMerge,
 	}
+
+	if g.PlatformModeEnabled() {
+		mrgPrj.PullRequestWorkflow = *repo.PullRequestWorkflow
+		mrgPrj.DeploymentWorkflow = *repo.DeploymentWorkflow
+	}
+	return mrgPrj
 }
 
 // foldMatchingRepos will return a pseudo repo instance that will iterate over

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -239,10 +239,30 @@ func (g GlobalCfg) PlatformModeEnabled() bool {
 // final config. It assumes that all configs have been validated.
 func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, proj Project, rCfg RepoCfg) MergedProjectCfg {
 	log.Debug("MergeProjectCfg started")
-	applyReqs, workflow, pullRequestWorkflow, deploymentWorkflow, allowedOverrides, allowCustomWorkflows, deleteSourceBranchOnMerge := g.getMatchingCfg(log, repoID)
+	var applyReqs []string
+	var workflow Workflow
+	var pullRequestWorkflow Workflow
+	var deploymentWorkflow Workflow
+	var allowCustomWorkflows bool
+	var deleteSourceBranchOnMerge bool
+
+	prjRepo := g.foldMatchingRepos(repoID)
+
+	applyReqs = prjRepo.ApplyRequirements
+	allowCustomWorkflows = *prjRepo.AllowCustomWorkflows
+	deleteSourceBranchOnMerge = *prjRepo.DeleteSourceBranchOnMerge
+	workflow = *prjRepo.Workflow
+
+	// PullRequestWorkflow and DeploymentWorkflow can only be defined when
+	// platform mode is enabled, otherwise it will be nil. We don't set default
+	// workflow in this case
+	if prjRepo.PullRequestWorkflow != nil && prjRepo.DeploymentWorkflow != nil {
+		pullRequestWorkflow = *prjRepo.PullRequestWorkflow
+		deploymentWorkflow = *prjRepo.DeploymentWorkflow
+	}
 
 	// If repos are allowed to override certain keys then override them.
-	for _, key := range allowedOverrides {
+	for _, key := range prjRepo.AllowedOverrides {
 		switch key {
 		case ApplyRequirementsKey:
 			if proj.ApplyRequirements != nil {
@@ -257,20 +277,33 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 				// define its own workflow. We also know that a workflow will
 				// exist with this name due to earlier validation.
 				name := *proj.WorkflowName
-				for k, v := range g.Workflows {
-					if k == name {
-						workflow = v
-					}
+				if w, ok := g.Workflows[name]; ok {
+					workflow = w
 				}
-				if allowCustomWorkflows {
-					for k, v := range rCfg.Workflows {
-						if k == name {
-							workflow = v
-						}
-					}
+
+				if w, ok := rCfg.Workflows[name]; allowCustomWorkflows && ok {
+					workflow = w
 				}
 				log.Debug("overriding server-defined %s with repo-specified workflow: %q", WorkflowKey, workflow.Name)
 			}
+		case PullRequestWorkflowKey:
+			if proj.PullRequestWorkflowName != nil {
+				name := *proj.PullRequestWorkflowName
+				if w, ok := g.PullRequestWorkflows[name]; ok {
+					pullRequestWorkflow = w
+				}
+			}
+
+			log.Debug("overriding server-defined %s with repo-specified pull_request_workflow: %q", PullRequestWorkflowKey, workflow.Name)
+		case DeploymentWorkflowKey:
+			if proj.DeploymentWorkflowName != nil {
+				name := *proj.DeploymentWorkflowName
+				if w, ok := g.DeploymentWorkflows[name]; ok {
+					deploymentWorkflow = w
+				}
+			}
+
+			log.Debug("overriding server-defined %s with repo-specified deployment_workflow: %q", DeploymentWorkflowKey, workflow.Name)
 		case DeleteSourceBranchOnMergeKey:
 			//We check whether the server configured value and repo-root level
 			//config is different. If it is then we change to the more granular.
@@ -289,8 +322,14 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 		log.Debug("MergeProjectCfg completed")
 	}
 
-	log.Debug("final settings: %s: [%s], %s: %s",
-		ApplyRequirementsKey, strings.Join(applyReqs, ","), WorkflowKey, workflow.Name)
+	if g.PlatformModeEnabled() {
+		log.Debug("final settings: %s: %s, %s: %s, %s: %s",
+			WorkflowKey, workflow.Name, DeploymentWorkflowKey, deploymentWorkflow.Name, PullRequestWorkflowKey, pullRequestWorkflow.Name)
+
+	} else {
+		log.Debug("final settings: %s: [%s], %s: %s",
+			ApplyRequirementsKey, strings.Join(applyReqs, ","), WorkflowKey, workflow.Name)
+	}
 
 	return MergedProjectCfg{
 		ApplyRequirements:         applyReqs,
@@ -313,186 +352,108 @@ func (g GlobalCfg) MergeProjectCfg(log logging.SimpleLogging, repoID string, pro
 // repo with id repoID. It is used when there is no repo config.
 func (g GlobalCfg) DefaultProjCfg(log logging.SimpleLogging, repoID string, repoRelDir string, workspace string) MergedProjectCfg {
 	log.Debug("building config based on server-side config")
-	applyReqs, workflow, pullRequestWorkflow, deploymentWorkflow, _, _, deleteSourceBranchOnMerge := g.getMatchingCfg(log, repoID)
+	repo := g.foldMatchingRepos(repoID)
 	return MergedProjectCfg{
-		ApplyRequirements:         applyReqs,
-		Workflow:                  workflow,
-		PullRequestWorkflow:       pullRequestWorkflow,
-		DeploymentWorkflow:        deploymentWorkflow,
+		ApplyRequirements:         repo.ApplyRequirements,
+		Workflow:                  *repo.Workflow,
+		PullRequestWorkflow:       *repo.PullRequestWorkflow,
+		DeploymentWorkflow:        *repo.DeploymentWorkflow,
 		RepoRelDir:                repoRelDir,
 		Workspace:                 workspace,
 		Name:                      "",
 		AutoplanEnabled:           DefaultAutoPlanEnabled,
 		TerraformVersion:          nil,
 		PolicySets:                g.PolicySets,
-		DeleteSourceBranchOnMerge: deleteSourceBranchOnMerge,
+		DeleteSourceBranchOnMerge: *repo.DeleteSourceBranchOnMerge,
 	}
+}
+
+// foldMatchingRepos will return a pseudo repo instance that will iterate over
+// the matching repositories and assign relevant fields if they're defined.
+// This means returned object will contain the last matching repo's value as a it's fields
+func (g GlobalCfg) foldMatchingRepos(repoID string) Repo {
+	foldedRepo := Repo{
+		AllowedWorkflows:            make([]string, 0),
+		AllowedPullRequestWorkflows: make([]string, 0),
+		AllowedDeploymentWorkflows:  make([]string, 0),
+		AllowedOverrides:            make([]string, 0),
+		ApplyRequirements:           make([]string, 0),
+	}
+
+	for _, repo := range g.Repos {
+		if repo.IDMatches(repoID) {
+			if repo.ApplyRequirements != nil {
+				foldedRepo.ApplyRequirements = repo.ApplyRequirements
+			}
+			if repo.Workflow != nil {
+				foldedRepo.Workflow = repo.Workflow
+			}
+			if repo.PullRequestWorkflow != nil {
+				foldedRepo.PullRequestWorkflow = repo.PullRequestWorkflow
+			}
+			if repo.DeploymentWorkflow != nil {
+				foldedRepo.DeploymentWorkflow = repo.DeploymentWorkflow
+			}
+			if repo.AllowedWorkflows != nil {
+				foldedRepo.AllowedWorkflows = repo.AllowedWorkflows
+			}
+			if repo.AllowedPullRequestWorkflows != nil {
+				foldedRepo.AllowedPullRequestWorkflows = repo.AllowedPullRequestWorkflows
+			}
+			if repo.AllowedDeploymentWorkflows != nil {
+				foldedRepo.AllowedDeploymentWorkflows = repo.AllowedDeploymentWorkflows
+			}
+			if repo.AllowedOverrides != nil {
+				foldedRepo.AllowedOverrides = repo.AllowedOverrides
+			}
+			if repo.AllowCustomWorkflows != nil {
+				foldedRepo.AllowCustomWorkflows = repo.AllowCustomWorkflows
+			}
+			if repo.DeleteSourceBranchOnMerge != nil {
+				foldedRepo.DeleteSourceBranchOnMerge = repo.DeleteSourceBranchOnMerge
+			}
+		}
+	}
+
+	return foldedRepo
 }
 
 // ValidateRepoCfg validates that rCfg for repo with id repoID is valid based
 // on our global config.
 func (g GlobalCfg) ValidateRepoCfg(rCfg RepoCfg, repoID string) error {
-
-	sliceContainsF := func(slc []string, str string) bool {
-		for _, s := range slc {
-			if s == str {
-				return true
-			}
-		}
-		return false
-	}
-	mapContainsF := func(m map[string]Workflow, key string) bool {
-		for k := range m {
-			if k == key {
-				return true
-			}
-		}
-		return false
-	}
+	repo := g.foldMatchingRepos(repoID)
 
 	// Check allowed overrides.
-	var allowedOverrides []string
-	for _, repo := range g.Repos {
-		if repo.IDMatches(repoID) {
-			if repo.AllowedOverrides != nil {
-				allowedOverrides = repo.AllowedOverrides
-			}
-		}
-	}
+	allowedOverrides := repo.AllowedOverrides
+
 	for _, p := range rCfg.Projects {
-		if p.WorkflowName != nil && !sliceContainsF(allowedOverrides, WorkflowKey) {
-			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", WorkflowKey, AllowedOverridesKey, WorkflowKey)
-		}
-		if p.ApplyRequirements != nil && !sliceContainsF(allowedOverrides, ApplyRequirementsKey) {
-			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", ApplyRequirementsKey, AllowedOverridesKey, ApplyRequirementsKey)
-		}
-		if p.DeleteSourceBranchOnMerge != nil && !sliceContainsF(allowedOverrides, DeleteSourceBranchOnMergeKey) {
-			return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", DeleteSourceBranchOnMergeKey, AllowedOverridesKey, DeleteSourceBranchOnMergeKey)
+		if err := p.CheckAllowedOverrides(allowedOverrides); err != nil {
+			return err
 		}
 	}
 
+	allowCustomWorkflows := *repo.AllowCustomWorkflows
 	// Check custom workflows.
-	var allowCustomWorkflows bool
-	for _, repo := range g.Repos {
-		if repo.IDMatches(repoID) {
-			if repo.AllowCustomWorkflows != nil {
-				allowCustomWorkflows = *repo.AllowCustomWorkflows
-			}
-		}
-	}
-
 	if len(rCfg.Workflows) > 0 && !allowCustomWorkflows {
 		return fmt.Errorf("repo config not allowed to define custom workflows: server-side config needs '%s: true'", AllowCustomWorkflowsKey)
 	}
 
-	// Check if the repo has set a workflow name that doesn't exist.
-	for _, p := range rCfg.Projects {
-		if p.WorkflowName != nil {
-			name := *p.WorkflowName
-			if !mapContainsF(rCfg.Workflows, name) && !mapContainsF(g.Workflows, name) {
-				return fmt.Errorf("workflow %q is not defined anywhere", name)
-			}
-		}
+	// Check if the repo has set a workflow name that doesn't exist and if workflow is allowed
+	if err := rCfg.ValidateWorkflows(g.Workflows, repo.AllowedWorkflows, allowCustomWorkflows); err != nil {
+		return err
 	}
 
-	// Check workflow is allowed
-	var allowedWorkflows []string
-	for _, repo := range g.Repos {
-		if repo.IDMatches(repoID) {
-
-			if repo.AllowedWorkflows != nil {
-				allowedWorkflows = repo.AllowedWorkflows
-			}
-		}
+	// Check if the repo has set a pull_request workflow name that doesn't exist and if workflow is allowed
+	if err := rCfg.ValidatePRWorkflows(g.PullRequestWorkflows, repo.AllowedPullRequestWorkflows); err != nil {
+		return err
 	}
 
-	for _, p := range rCfg.Projects {
-		// default is always allowed
-		if p.WorkflowName != nil && len(allowedWorkflows) != 0 {
-			name := *p.WorkflowName
-			if allowCustomWorkflows {
-				// If we allow CustomWorkflows we need to check that workflow name is defined inside repo and not global.
-				if mapContainsF(rCfg.Workflows, name) {
-					break
-				}
-			}
-
-			if !sliceContainsF(allowedWorkflows, name) {
-				return fmt.Errorf("workflow '%s' is not allowed for this repo", name)
-			}
-		}
+	// Check if the repo has set a deployment workflow name that doesn't exist and if workflow is allowed
+	if err := rCfg.ValidateDeploymentWorkflows(g.DeploymentWorkflows, repo.AllowedDeploymentWorkflows); err != nil {
+		return err
 	}
 
 	return nil
-}
-
-// getMatchingCfg returns the key settings for repoID.
-func (g GlobalCfg) getMatchingCfg(log logging.SimpleLogging, repoID string) (
-	applyReqs []string,
-	workflow Workflow,
-	pullRequestWorkflow Workflow,
-	deploymentWorkflow Workflow,
-	allowedOverrides []string,
-	allowCustomWorkflows bool,
-	deleteSourceBranchOnMerge bool,
-) {
-	toLog := make(map[string]string)
-	traceF := func(repoIdx int, repoID string, key string, val interface{}) string {
-		from := "default server config"
-		if repoIdx > 0 {
-			from = fmt.Sprintf("repos[%d], id: %s", repoIdx, repoID)
-		}
-		var valStr string
-		switch v := val.(type) {
-		case string:
-			valStr = fmt.Sprintf("%q", v)
-		case []string:
-			valStr = fmt.Sprintf("[%s]", strings.Join(v, ","))
-		case bool:
-			valStr = fmt.Sprintf("%t", v)
-		default:
-			valStr = "this is a bug"
-		}
-
-		return fmt.Sprintf("setting %s: %s from %s", key, valStr, from)
-	}
-
-	for i, repo := range g.Repos {
-		if repo.IDMatches(repoID) {
-			if repo.ApplyRequirements != nil {
-				toLog[ApplyRequirementsKey] = traceF(i, repo.IDString(), ApplyRequirementsKey, repo.ApplyRequirements)
-				applyReqs = repo.ApplyRequirements
-			}
-			if repo.Workflow != nil {
-				toLog[WorkflowKey] = traceF(i, repo.IDString(), WorkflowKey, repo.Workflow.Name)
-				workflow = *repo.Workflow
-			}
-			if repo.PullRequestWorkflow != nil {
-				toLog[PullRequestWorkflowKey] = traceF(i, repo.IDString(), PullRequestWorkflowKey, repo.PullRequestWorkflow.Name)
-				pullRequestWorkflow = *repo.PullRequestWorkflow
-			}
-			if repo.DeploymentWorkflow != nil {
-				toLog[DeploymentWorkflowKey] = traceF(i, repo.IDString(), DeploymentWorkflowKey, repo.DeploymentWorkflow.Name)
-				deploymentWorkflow = *repo.DeploymentWorkflow
-			}
-			if repo.AllowedOverrides != nil {
-				toLog[AllowedOverridesKey] = traceF(i, repo.IDString(), AllowedOverridesKey, repo.AllowedOverrides)
-				allowedOverrides = repo.AllowedOverrides
-			}
-			if repo.AllowCustomWorkflows != nil {
-				toLog[AllowCustomWorkflowsKey] = traceF(i, repo.IDString(), AllowCustomWorkflowsKey, *repo.AllowCustomWorkflows)
-				allowCustomWorkflows = *repo.AllowCustomWorkflows
-			}
-			if repo.DeleteSourceBranchOnMerge != nil {
-				toLog[DeleteSourceBranchOnMergeKey] = traceF(i, repo.IDString(), DeleteSourceBranchOnMergeKey, *repo.DeleteSourceBranchOnMerge)
-				deleteSourceBranchOnMerge = *repo.DeleteSourceBranchOnMerge
-			}
-		}
-	}
-	for _, l := range toLog {
-		log.Debug(l)
-	}
-	return
 }
 
 // MatchingRepo returns an instance of Repo which matches a given repoID.

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -386,7 +386,7 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				},
 			},
 			repoID: "github.com/owner/repo",
-			expErr: "workflow 'forbidden' is not allowed for this repo",
+			expErr: "workflow \"forbidden\" is not allowed for this repo",
 		},
 		"repo uses workflow that is defined server side but not allowed (without custom workflows)": {
 			gCfg: valid.GlobalCfg{
@@ -419,7 +419,7 @@ func TestGlobalCfg_ValidateRepoCfg(t *testing.T) {
 				},
 			},
 			repoID: "github.com/owner/repo",
-			expErr: "workflow 'forbidden' is not allowed for this repo",
+			expErr: "workflow \"forbidden\" is not allowed for this repo",
 		},
 		"repo uses workflow that is defined in both places with same name (without custom workflows)": {
 			gCfg: valid.GlobalCfg{
@@ -1024,28 +1024,21 @@ repos:
 			tmp, cleanup := TempDir(t)
 			defer cleanup()
 			var global valid.GlobalCfg
+			globalCfgArgs := valid.GlobalCfgArgs{
+				AllowRepoCfg:        false,
+				MergeableReq:        false,
+				ApprovedReq:         false,
+				UnDivergedReq:       false,
+				PlatformModeEnabled: c.platformMode,
+			}
+
 			if c.gCfg != "" {
 				path := filepath.Join(tmp, "config.yaml")
 				Ok(t, ioutil.WriteFile(path, []byte(c.gCfg), 0600))
 				var err error
-				globalCfgArgs := valid.GlobalCfgArgs{
-					AllowRepoCfg:        false,
-					MergeableReq:        false,
-					ApprovedReq:         false,
-					UnDivergedReq:       false,
-					PlatformModeEnabled: c.platformMode,
-				}
-
 				global, err = (&config.ParserValidator{}).ParseGlobalCfg(path, valid.NewGlobalCfgFromArgs(globalCfgArgs))
 				Ok(t, err)
 			} else {
-				globalCfgArgs := valid.GlobalCfgArgs{
-					AllowRepoCfg:        false,
-					MergeableReq:        false,
-					ApprovedReq:         false,
-					UnDivergedReq:       false,
-					PlatformModeEnabled: c.platformMode,
-				}
 				global = valid.NewGlobalCfgFromArgs(globalCfgArgs)
 			}
 

--- a/server/core/config/valid/project.go
+++ b/server/core/config/valid/project.go
@@ -1,0 +1,149 @@
+package valid
+
+import (
+	"fmt"
+
+	version "github.com/hashicorp/go-version"
+)
+
+const (
+	DefaultWorkflowType     = "default"
+	PullRequestWorkflowType = "pull_request"
+	DeploymentWorkflowType  = "deployment"
+)
+
+type Project struct {
+	Dir                       string
+	Workspace                 string
+	Name                      *string
+	WorkflowName              *string
+	PullRequestWorkflowName   *string
+	DeploymentWorkflowName    *string
+	TerraformVersion          *version.Version
+	Autoplan                  Autoplan
+	ApplyRequirements         []string
+	DeleteSourceBranchOnMerge *bool
+	Tags                      map[string]string
+}
+
+// GetName returns the name of the project or an empty string if there is no
+// project name.
+func (p Project) GetName() string {
+	if p.Name != nil {
+		return *p.Name
+	}
+	// TODO
+	// Upstream atlantis only requires project name to be set if there's more than one project
+	// with same dir and workspace. If a project name has not been set, we'll use the dir and
+	// workspace to build project key.
+	// Source: https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#reference
+	return ""
+}
+
+func (p Project) CheckAllowedOverrides(allowedOverrides []string) error {
+	if p.WorkflowName != nil && !sliceContains(allowedOverrides, WorkflowKey) {
+		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", WorkflowKey, AllowedOverridesKey, WorkflowKey)
+	}
+	if p.PullRequestWorkflowName != nil && !sliceContains(allowedOverrides, PullRequestWorkflowKey) {
+		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", PullRequestWorkflowKey, AllowedOverridesKey, PullRequestWorkflowKey)
+	}
+	if p.DeploymentWorkflowName != nil && !sliceContains(allowedOverrides, DeploymentWorkflowKey) {
+		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", DeploymentWorkflowKey, AllowedOverridesKey, DeploymentWorkflowKey)
+	}
+	if p.ApplyRequirements != nil && !sliceContains(allowedOverrides, ApplyRequirementsKey) {
+		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", ApplyRequirementsKey, AllowedOverridesKey, ApplyRequirementsKey)
+	}
+	if p.DeleteSourceBranchOnMerge != nil && !sliceContains(allowedOverrides, DeleteSourceBranchOnMergeKey) {
+		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", DeleteSourceBranchOnMergeKey, AllowedOverridesKey, DeleteSourceBranchOnMergeKey)
+	}
+
+	return nil
+}
+
+func (p Project) ValidateWorkflow(repoWorkflows map[string]Workflow, globalWorkflows map[string]Workflow) error {
+	if p.WorkflowName != nil {
+		name := *p.WorkflowName
+
+		if !mapContains(repoWorkflows, name) && !mapContains(globalWorkflows, name) {
+			return fmt.Errorf("workflow %q is not defined anywhere", name)
+		}
+	}
+
+	return nil
+}
+
+func (p Project) ValidatePRWorkflow(globalWorkflows map[string]Workflow) error {
+	if p.PullRequestWorkflowName != nil {
+		name := *p.PullRequestWorkflowName
+
+		if !mapContains(globalWorkflows, name) {
+			return fmt.Errorf("pull_request_workflow %q is not defined anywhere", name)
+		}
+	}
+
+	return nil
+}
+
+func (p Project) ValidateDeploymentWorkflow(globalWorkflows map[string]Workflow) error {
+	if p.DeploymentWorkflowName != nil {
+		name := *p.DeploymentWorkflowName
+
+		if !mapContains(globalWorkflows, name) {
+			return fmt.Errorf("deployment_workflow %q is not defined anywhere", name)
+		}
+	}
+
+	return nil
+}
+
+func (p Project) ValidateWorkflowAllowed(allowedWorkflows []string) error {
+	if p.WorkflowName != nil {
+		name := *p.WorkflowName
+
+		if !sliceContains(allowedWorkflows, name) {
+			return fmt.Errorf("workflow %q is not allowed for this repo", name)
+		}
+	}
+
+	return nil
+}
+
+func (p Project) ValidatePRWorkflowAllowed(allowedWorkflows []string) error {
+	if p.PullRequestWorkflowName != nil {
+		name := *p.PullRequestWorkflowName
+
+		if !sliceContains(allowedWorkflows, name) {
+			return fmt.Errorf("pull_request_workflow %q is not allowed for this repo", name)
+		}
+	}
+
+	return nil
+}
+
+func (p Project) ValidateDeploymentWorkflowAllowed(allowedWorkflows []string) error {
+	if p.DeploymentWorkflowName != nil {
+		name := *p.DeploymentWorkflowName
+
+		if !sliceContains(allowedWorkflows, name) {
+			return fmt.Errorf("deployment_workflow %q is not allowed for this repo", name)
+		}
+	}
+
+	return nil
+}
+
+// helper function to check if string is in array
+func sliceContains(slc []string, str string) bool {
+	for _, s := range slc {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+// helper function to check if map contains a key
+func mapContains(m map[string]Workflow, key string) bool {
+	_, ok := m[key]
+	return ok
+}

--- a/server/core/config/valid/project.go
+++ b/server/core/config/valid/project.go
@@ -40,7 +40,7 @@ func (p Project) GetName() string {
 	return ""
 }
 
-func (p Project) CheckAllowedOverrides(allowedOverrides []string) error {
+func (p Project) ValidateAllowedOverrides(allowedOverrides []string) error {
 	if p.WorkflowName != nil && !sliceContains(allowedOverrides, WorkflowKey) {
 		return fmt.Errorf("repo config not allowed to set '%s' key: server-side config needs '%s: [%s]'", WorkflowKey, AllowedOverridesKey, WorkflowKey)
 	}

--- a/server/core/config/valid/project_test.go
+++ b/server/core/config/valid/project_test.go
@@ -1,0 +1,393 @@
+package valid_test
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestProject_ValidateWorkflow(t *testing.T) {
+	defaultWorklfow := valid.Workflow{
+		Name: "default",
+	}
+	customWorkflow := valid.Workflow{
+		Name: "custom",
+	}
+	undefinedWorkflowName := "undefined"
+	cases := map[string]struct {
+		repoWorflows    map[string]valid.Workflow
+		globalWorkflows map[string]valid.Workflow
+		project         valid.Project
+		expErr          string
+	}{
+		"project with repo workflows": {
+			repoWorflows: map[string]valid.Workflow{
+				"custom": customWorkflow,
+			},
+			project: valid.Project{
+				WorkflowName: &customWorkflow.Name,
+			},
+		},
+		"failed validation with undefined workflow": {
+			repoWorflows: map[string]valid.Workflow{
+				"custom": customWorkflow,
+			},
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+			},
+			project: valid.Project{
+				WorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "workflow \"undefined\" is not defined anywhere",
+		},
+		"workflow defined in global config": {
+			repoWorflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+			},
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				WorkflowName: &customWorkflow.Name,
+			},
+		},
+		"missing workflow name is valid": {
+			repoWorflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+			},
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				WorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidateWorkflow(c.repoWorflows, c.globalWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_ValidateDeploymentWorkflow(t *testing.T) {
+	defaultWorklfow := valid.Workflow{
+		Name: "default",
+	}
+	customWorkflow := valid.Workflow{
+		Name: "custom",
+	}
+	undefinedWorkflowName := "undefined"
+	cases := map[string]struct {
+		globalWorkflows map[string]valid.Workflow
+		project         valid.Project
+		expErr          string
+	}{
+		"failed validation with undefined workflow": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+			},
+			project: valid.Project{
+				DeploymentWorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "deployment_workflow \"undefined\" is not defined anywhere",
+		},
+		"workflow defined in global config": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				DeploymentWorkflowName: &customWorkflow.Name,
+			},
+		},
+		"missing workflow name is valid": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				DeploymentWorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidateDeploymentWorkflow(c.globalWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_ValidatePRWorkflow(t *testing.T) {
+	defaultWorklfow := valid.Workflow{
+		Name: "default",
+	}
+	customWorkflow := valid.Workflow{
+		Name: "custom",
+	}
+	undefinedWorkflowName := "undefined"
+
+	cases := map[string]struct {
+		globalWorkflows map[string]valid.Workflow
+		project         valid.Project
+		expErr          string
+	}{
+		"failed validation with undefined workflow": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+			},
+			project: valid.Project{
+				PullRequestWorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "pull_request_workflow \"undefined\" is not defined anywhere",
+		},
+		"workflow defined in global config": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				PullRequestWorkflowName: &customWorkflow.Name,
+			},
+		},
+		"missing workflow name is valid": {
+			globalWorkflows: map[string]valid.Workflow{
+				"default": defaultWorklfow,
+				"custom":  customWorkflow,
+			},
+			project: valid.Project{
+				PullRequestWorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidatePRWorkflow(c.globalWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_ValidateWorkflowAllowed(t *testing.T) {
+	undefinedWorkflowName := "undefined"
+	customWorkflowName := "custom"
+
+	cases := map[string]struct {
+		allowedWorkflows []string
+		project          valid.Project
+		expErr           string
+	}{
+		"failed validation with undefined workflow": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				WorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "workflow \"undefined\" is not allowed for this repo",
+		},
+		"workflow is allowed": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				WorkflowName: &customWorkflowName,
+			},
+		},
+		"missing workflow name is valid": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				WorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidateWorkflowAllowed(c.allowedWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_ValidatePRWorkflowAllowed(t *testing.T) {
+	undefinedWorkflowName := "undefined"
+	customWorkflowName := "custom"
+
+	cases := map[string]struct {
+		allowedWorkflows []string
+		project          valid.Project
+		expErr           string
+	}{
+		"failed validation with undefined workflow": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				PullRequestWorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "pull_request_workflow \"undefined\" is not allowed for this repo",
+		},
+		"workflow is allowed": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				PullRequestWorkflowName: &customWorkflowName,
+			},
+		},
+		"missing workflow name is valid": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				PullRequestWorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidatePRWorkflowAllowed(c.allowedWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_ValidateDeploymentWorkflowAllowed(t *testing.T) {
+	undefinedWorkflowName := "undefined"
+	customWorkflowName := "custom"
+
+	cases := map[string]struct {
+		allowedWorkflows []string
+		project          valid.Project
+		expErr           string
+	}{
+		"failed validation with undefined workflow": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				DeploymentWorkflowName: &undefinedWorkflowName,
+			},
+			expErr: "deployment_workflow \"undefined\" is not allowed for this repo",
+		},
+		"workflow is allowed": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				DeploymentWorkflowName: &customWorkflowName,
+			},
+		},
+		"missing workflow name is valid": {
+			allowedWorkflows: []string{"custom"},
+			project: valid.Project{
+				DeploymentWorkflowName: nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.ValidateDeploymentWorkflowAllowed(c.allowedWorkflows)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}
+
+func TestProject_CheckAllowedOverrides(t *testing.T) {
+	workflowName := "custom"
+	deleteSourceBranch := true
+	cases := map[string]struct {
+		allowedOverrides []string
+		overrideKey      string
+		project          valid.Project
+		expErr           string
+	}{
+		"workflow is not allowed override": {
+			allowedOverrides: []string{},
+			project: valid.Project{
+				WorkflowName: &workflowName,
+			},
+			expErr: "repo config not allowed to set 'workflow' key: server-side config needs 'allowed_overrides: [workflow]'",
+		},
+		"pull_request_workflow is not allowed override": {
+			allowedOverrides: []string{},
+			project: valid.Project{
+				PullRequestWorkflowName: &workflowName,
+			},
+			expErr: "repo config not allowed to set 'pull_request_workflow' key: server-side config needs 'allowed_overrides: [pull_request_workflow]'",
+		},
+		"deployment_workflow is not allowed override": {
+			allowedOverrides: []string{},
+			project: valid.Project{
+				DeploymentWorkflowName: &workflowName,
+			},
+			expErr: "repo config not allowed to set 'deployment_workflow' key: server-side config needs 'allowed_overrides: [deployment_workflow]'",
+		},
+		"apply_requirements is not allowed override": {
+			allowedOverrides: []string{},
+			project: valid.Project{
+				ApplyRequirements: []string{"mergeable"},
+			},
+			expErr: "repo config not allowed to set 'apply_requirements' key: server-side config needs 'allowed_overrides: [apply_requirements]'",
+		},
+		"delete_source_branch_on_merge is not allowed override": {
+			allowedOverrides: []string{},
+			project: valid.Project{
+				DeleteSourceBranchOnMerge: &deleteSourceBranch,
+			},
+			expErr: "repo config not allowed to set 'delete_source_branch_on_merge' key: server-side config needs 'allowed_overrides: [delete_source_branch_on_merge]'",
+		},
+		"no errors when allowed override": {
+			allowedOverrides: []string{"apply_requirements", "deployment_workflow", "pull_request_workflow", "workflow", "delete_source_branch_on_merge"},
+			project: valid.Project{
+				DeleteSourceBranchOnMerge: &deleteSourceBranch,
+				ApplyRequirements:         []string{"mergeable"},
+				DeploymentWorkflowName:    &workflowName,
+				WorkflowName:              &workflowName,
+				PullRequestWorkflowName:   &workflowName,
+			},
+		},
+		"no errors if override attributes nil": {
+			allowedOverrides: []string{"apply_requirements", "deployment_workflow", "pull_request_workflow", "workflow", "delete_source_branch_on_merge"},
+			project: valid.Project{
+				DeleteSourceBranchOnMerge: nil,
+				ApplyRequirements:         nil,
+				DeploymentWorkflowName:    nil,
+				WorkflowName:              nil,
+				PullRequestWorkflowName:   nil,
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actErr := c.project.CheckAllowedOverrides(c.allowedOverrides)
+			if c.expErr == "" {
+				Ok(t, actErr)
+			} else {
+				ErrEquals(t, c.expErr, actErr)
+			}
+		})
+	}
+}

--- a/server/core/config/valid/project_test.go
+++ b/server/core/config/valid/project_test.go
@@ -314,7 +314,7 @@ func TestProject_ValidateDeploymentWorkflowAllowed(t *testing.T) {
 	}
 }
 
-func TestProject_CheckAllowedOverrides(t *testing.T) {
+func TestProject_ValidateAllowedOverrides(t *testing.T) {
 	workflowName := "custom"
 	deleteSourceBranch := true
 	cases := map[string]struct {
@@ -382,7 +382,7 @@ func TestProject_CheckAllowedOverrides(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			actErr := c.project.CheckAllowedOverrides(c.allowedOverrides)
+			actErr := c.project.ValidateAllowedOverrides(c.allowedOverrides)
 			if c.expErr == "" {
 				Ok(t, actErr)
 			} else {

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -66,6 +66,18 @@ func (r RepoCfg) FindProjectsByName(name string) []Project {
 	return ps
 }
 
+// ValidateAllowedOverrides iterates over projects and checks that each project
+// is only using allowed overrides defined in global config
+func (r RepoCfg) ValidateAllowedOverrides(allowedOverrides []string) error {
+	for _, p := range r.Projects {
+		if err := p.ValidateAllowedOverrides(allowedOverrides); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // validateWorkspaceAllowed returns an error if repoCfg defines projects in
 // repoRelDir but none of them use workspace. We want this to be an error
 // because if users have gone to the trouble of defining projects in repoRelDir

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	version "github.com/hashicorp/go-version"
 )
 
 // RepoCfg is the atlantis.yaml config after it's been parsed and validated.
@@ -16,8 +14,6 @@ type RepoCfg struct {
 	Version                   int
 	Projects                  []Project
 	Workflows                 map[string]Workflow
-	PullRequestWorkflows      map[string]Workflow
-	DeploymentWorkflows       map[string]Workflow
 	PolicySets                PolicySets
 	Automerge                 bool
 	ParallelApply             bool
@@ -100,30 +96,82 @@ func (r RepoCfg) ValidateWorkspaceAllowed(repoRelDir string, workspace string) e
 	)
 }
 
-type Project struct {
-	Dir                       string
-	Workspace                 string
-	Name                      *string
-	WorkflowName              *string
-	TerraformVersion          *version.Version
-	Autoplan                  Autoplan
-	ApplyRequirements         []string
-	DeleteSourceBranchOnMerge *bool
-	Tags                      map[string]string
+// ValidateWorkflows ensures that all projects with custom workflow
+// names exists either on repo level config or server level config
+// Additionally it validates that workflow is allowed to be defined
+func (r RepoCfg) ValidateWorkflows(
+	globalWorkflows map[string]Workflow,
+	allowedWorkflows []string,
+	allowCustomWorkflows bool,
+) error {
+	// Check if the repo has set a workflow name that doesn't exist.
+	for _, p := range r.Projects {
+		if err := p.ValidateWorkflow(r.Workflows, globalWorkflows); err != nil {
+			return err
+		}
+	}
+
+	if len(allowedWorkflows) == 0 {
+		return nil
+	}
+
+	// Check workflow is allowed
+	for _, p := range r.Projects {
+		if allowCustomWorkflows {
+			if err := p.ValidateWorkflow(r.Workflows, map[string]Workflow{}); err == nil {
+				break
+			}
+		}
+
+		if err := p.ValidateWorkflowAllowed(allowedWorkflows); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-// GetName returns the name of the project or an empty string if there is no
-// project name.
-func (p Project) GetName() string {
-	if p.Name != nil {
-		return *p.Name
+// ValidatePRWorkflows ensures that all projects with custom
+// pull_request workflow names exists either on server level config
+// Additionally it validates that workflow is allowed to be defined
+func (r RepoCfg) ValidatePRWorkflows(workflows map[string]Workflow, allowedWorkflows []string) error {
+	for _, p := range r.Projects {
+		if err := p.ValidatePRWorkflow(workflows); err != nil {
+			return err
+		}
 	}
-	// TODO
-	// Upstream atlantis only requires project name to be set if there's more than one project
-	// with same dir and workspace. If a project name has not been set, we'll use the dir and
-	// workspace to build project key.
-	// Source: https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#reference
-	return ""
+	if len(allowedWorkflows) == 0 {
+		return nil
+	}
+
+	for _, p := range r.Projects {
+		if err := p.ValidatePRWorkflowAllowed(allowedWorkflows); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateDeploymentWorkflows ensures that all projects with custom
+// deployment workflow names exists either on server level config
+// Additionally it validates that workflow is allowed to be defined
+func (r RepoCfg) ValidateDeploymentWorkflows(workflows map[string]Workflow, allowedWorkflows []string) error {
+	for _, p := range r.Projects {
+		if err := p.ValidateDeploymentWorkflow(workflows); err != nil {
+			return err
+		}
+	}
+
+	if len(allowedWorkflows) == 0 {
+		return nil
+	}
+
+	for _, p := range r.Projects {
+		if err := p.ValidateDeploymentWorkflowAllowed(allowedWorkflows); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type Autoplan struct {

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -152,6 +152,7 @@ func (r RepoCfg) ValidatePRWorkflows(workflows map[string]Workflow, allowedWorkf
 			return err
 		}
 	}
+
 	if len(allowedWorkflows) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Refactored `ValidateRepoCfg` and `MergeProjectCfg` to have less loops. Moved the loop that iterates over repos to aggregate matching repo configs into a single method that folds all repos into one. 
Tried to move most validations into their respective structs. This doesn't reduce overall complexity, but will reduce the mental overload with continuous loops and if checks.
For instance:
Checking if workflow if defined and allowed went from 
```go
        // Check if the repo has set a workflow name that doesn't exist.
	for _, p := range rCfg.Projects {
		if p.WorkflowName != nil {
			name := *p.WorkflowName
			if !mapContainsF(rCfg.Workflows, name) && !mapContainsF(g.Workflows, name) {
				return fmt.Errorf("workflow %q is not defined anywhere", name)
			}
		}
	}

	// Check workflow is allowed
	var allowedWorkflows []string
	for _, repo := range g.Repos {
		if repo.IDMatches(repoID) {

			if repo.AllowedWorkflows != nil {
				allowedWorkflows = repo.AllowedWorkflows
			}
		}
	}
```
to 
```go
        // Check if the repo has set a workflow name that doesn't exist and if workflow is allowed
	if err := rCfg.ValidateWorkflows(g.Workflows, repo.AllowedWorkflows, allowCustomWorkflows); err != nil {
		return err
	}
```
I can probably refactor even further, but had to stop because it was taking too long. 

On top of that added support to override pull_request and deployment workflows if they're allowed. Not adding custom workflow support for repo config.