### PR TITLE
Fix IsKeyExist method in PartitionRegistry

### DIFF
--- a/server/handlers/project_command_output_handler.go
+++ b/server/handlers/project_command_output_handler.go
@@ -117,9 +117,9 @@ func NewAsyncProjectCommandOutputHandler(
 }
 
 func (p *AsyncProjectCommandOutputHandler) IsKeyExists(key string) bool {
-	p.receiverBuffersLock.RLock()
-	defer p.receiverBuffersLock.RUnlock()
-	_, ok := p.receiverBuffers[key]
+	p.projectOutputBuffersLock.RLock()
+	defer p.projectOutputBuffersLock.RUnlock()
+	_, ok := p.projectOutputBuffers[key]
 	return ok
 }
 


### PR DESCRIPTION
https://github.com/lyft/atlantis/pull/173 added check for whether a jobID exists in the partition registry. It should check for the job in the projectOutputBuffer instead of the receiverBuffer. 