### PR TITLE
Handle /events in gateway mode

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -89,7 +89,7 @@ type VCSEventsController struct {
 
 type CommandExecutor interface {
 	ExecuteCommentCommand(request *http.Request, baseRepo models.Repo, maybeHeadRepo *models.Repo, maybePull *models.PullRequest, user models.User, pullNum int, cmd *events.CommentCommand, timestamp time.Time) HttpResponse
-	ExecuteAutoplanCommand(_ *http.Request, eventType models.PullRequestEventType, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, logger logging.SimpleLogging) HttpResponse
+	ExecuteAutoplanCommand(request *http.Request, eventType models.PullRequestEventType, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, logger logging.SimpleLogging) HttpResponse
 }
 
 type DefaultCommandExecutor struct {

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1079,15 +1079,17 @@ func setupE2E(t *testing.T, repoDir string) (events_controllers.VCSEventsControl
 	Ok(t, err)
 
 	ctrl := events_controllers.VCSEventsController{
-		TestingMode:   true,
-		CommandRunner: commandRunner,
-		PullCleaner: &events.PullClosedExecutor{
-			Locker:                   lockingClient,
-			VCSClient:                e2eVCSClient,
-			WorkingDir:               workingDir,
-			DB:                       boltdb,
-			PullClosedTemplate:       &events.PullClosedEventTemplate{},
-			LogStreamResourceCleaner: projectCmdOutputHandler,
+		CommandExecutor: &events_controllers.DefaultCommandExecutor{
+			CommandRunner: commandRunner,
+			PullCleaner: &events.PullClosedExecutor{
+				Locker:                   lockingClient,
+				VCSClient:                e2eVCSClient,
+				WorkingDir:               workingDir,
+				DB:                       boltdb,
+				PullClosedTemplate:       &events.PullClosedEventTemplate{},
+				LogStreamResourceCleaner: projectCmdOutputHandler,
+			},
+			TestingMode: true,
 		},
 		Logger:                       logger,
 		Scope:                        statsScope,

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -495,7 +495,6 @@ func TestPost_AzureDevopsPullRequestIgnoreEvent(t *testing.T) {
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "null")
 	e := events_controllers.VCSEventsController{
-		TestingMode:                     true,
 		Logger:                          logger,
 		Scope:                           scope,
 		ApplyDisabled:                   false,
@@ -504,11 +503,14 @@ func TestPost_AzureDevopsPullRequestIgnoreEvent(t *testing.T) {
 		AzureDevopsRequestValidator:     v,
 		Parser:                          p,
 		CommentParser:                   cp,
-		CommandRunner:                   cr,
-		PullCleaner:                     c,
 		SupportedVCSHosts:               []models.VCSHostType{models.AzureDevops},
 		RepoAllowlistChecker:            repoAllowlistChecker,
 		VCSClient:                       vcsmock,
+		CommandExecutor: &events_controllers.DefaultCommandExecutor{
+			CommandRunner: cr,
+			PullCleaner:   c,
+			TestingMode:   true,
+		},
 	}
 
 	event := `{
@@ -654,7 +656,9 @@ func TestPost_BBServerPullClosed(t *testing.T) {
 			logger := logging.NewNoopLogger(t)
 			scope, _, _ := metrics.NewLoggingScope(logger, "null")
 			ec := &events_controllers.VCSEventsController{
-				PullCleaner: pullCleaner,
+				CommandExecutor: &events_controllers.DefaultCommandExecutor{
+					PullCleaner: pullCleaner,
+				},
 				Parser: &events.EventParser{
 					BitbucketUser:      "bb-user",
 					BitbucketToken:     "bb-token",
@@ -785,20 +789,22 @@ func setup(t *testing.T) (events_controllers.VCSEventsController, *mocks.MockGit
 	logger := logging.NewNoopLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "null")
 	e := events_controllers.VCSEventsController{
-		TestingMode:                  true,
 		Logger:                       logger,
 		Scope:                        scope,
 		GithubRequestValidator:       v,
 		Parser:                       p,
 		CommentParser:                cp,
-		CommandRunner:                cr,
-		PullCleaner:                  c,
 		GithubWebhookSecret:          secret,
 		SupportedVCSHosts:            []models.VCSHostType{models.Github, models.Gitlab},
 		GitlabWebhookSecret:          secret,
 		GitlabRequestParserValidator: gl,
 		RepoAllowlistChecker:         repoAllowlistChecker,
 		VCSClient:                    vcsmock,
+		CommandExecutor: &events_controllers.DefaultCommandExecutor{
+			CommandRunner: cr,
+			PullCleaner:   c,
+			TestingMode:   true,
+		},
 	}
 	return e, v, gl, p, cr, c, vcsmock, cp
 }

--- a/server/controllers/events/gateway_command_executor.go
+++ b/server/controllers/events/gateway_command_executor.go
@@ -1,0 +1,77 @@
+package events
+
+import (
+	"bytes"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/aws/sns"
+	"net/http"
+	"time"
+)
+
+type GatewayCommandExecutor struct {
+	SNSWriter     sns.Writer
+	CommandRunner events.CommandRunner
+}
+
+func (g *GatewayCommandExecutor) ExecuteCommentCommand(request *http.Request, _ models.Repo, _ *models.Repo, _ *models.PullRequest, _ models.User, _ int, _ *events.CommentCommand, _ time.Time) HttpResponse {
+	err := g.SendToWorker(request)
+	if err != nil {
+		return HttpResponse{
+			body: err.Error(),
+			err: HttpError{
+				code: http.StatusBadRequest,
+				err:  err,
+			},
+		}
+	}
+	return HttpResponse{
+		body: "Processing...",
+	}
+}
+
+func (g *GatewayCommandExecutor) ExecuteAutoplanCommand(request *http.Request, eventType models.PullRequestEventType, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, _ time.Time, _ logging.SimpleLogging) HttpResponse {
+	var err error
+	var respBody string
+	switch eventType {
+	case models.OpenedPullEvent, models.UpdatedPullEvent:
+		// If the pull request was opened or updated, we perform a pseudo-autoplan to determine if tf changes exist.
+		// If they exist, then we will forward request to the worker.
+		if hasTerraformChanges := g.CommandRunner.RunPseudoAutoplanCommand(baseRepo, headRepo, pull, user); hasTerraformChanges {
+			if err = g.SendToWorker(request); err == nil {
+				respBody = "Processing..."
+			}
+		}
+	case models.ClosedPullEvent:
+		// If the pull request was closed, we route to worker to handle deleting locks.
+		err = g.SendToWorker(request)
+	case models.OtherPullEvent:
+		// Else we ignore the event.
+		respBody = "Ignoring non-actionable pull request event"
+	}
+	if err != nil {
+		return HttpResponse{
+			body: err.Error(),
+			err: HttpError{
+				code: http.StatusBadRequest,
+				err:  err,
+			},
+		}
+	}
+	return HttpResponse{
+		body: respBody,
+	}
+}
+
+func (g *GatewayCommandExecutor) SendToWorker(r *http.Request) error {
+	buffer := bytes.NewBuffer([]byte{})
+	if err := r.Write(buffer); err != nil {
+		return errors.Wrap(err, "Marshalling gateway request to buffer")
+	}
+	if err := g.SNSWriter.Write(buffer.Bytes()); err != nil {
+		return errors.Wrap(err, "Writing gateway message to sns topic")
+	}
+	return nil
+}

--- a/server/controllers/events/gateway_command_executor.go
+++ b/server/controllers/events/gateway_command_executor.go
@@ -20,9 +20,8 @@ type GatewayCommandExecutor struct {
 }
 
 func (g *GatewayCommandExecutor) ExecuteCommentCommand(request *http.Request, _ models.Repo, _ *models.Repo, _ *models.PullRequest, _ models.User, _ int, _ *events.CommentCommand, _ time.Time) HttpResponse {
-	err := g.SendToWorker(request)
-	if err != nil {
-		g.Logger.With("err", err).Warn("Failed to send comment request to Atlantis worker")
+	if err := g.SendToWorker(request); err != nil {
+		g.Logger.With("err", err).Warn("failed to send comment request to Atlantis worker")
 		return HttpResponse{
 			body: err.Error(),
 			err: HttpError{
@@ -38,47 +37,55 @@ func (g *GatewayCommandExecutor) ExecuteCommentCommand(request *http.Request, _ 
 
 func (g *GatewayCommandExecutor) ExecuteAutoplanCommand(request *http.Request, eventType models.PullRequestEventType, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, _ time.Time, _ logging.SimpleLogging) HttpResponse {
 	var err error
-	var respBody string
 	switch eventType {
 	case models.OpenedPullEvent, models.UpdatedPullEvent:
 		// If the pull request was opened or updated, we perform a pseudo-autoplan to determine if tf changes exist.
 		// If they exist, then we will forward request to the worker.
 		if hasTerraformChanges := g.CommandRunner.RunPseudoAutoplanCommand(baseRepo, headRepo, pull, user); hasTerraformChanges {
-			if err = g.SendToWorker(request); err == nil {
-				respBody = "Processing..."
+			if err = g.SendToWorker(request); err != nil {
+				g.Logger.With("err", err, "eventType", eventType).Warn("failed to send autoplan request to Atlantis worker")
+				return HttpResponse{
+					body: err.Error(),
+					err: HttpError{
+						code: http.StatusBadRequest,
+						err:  err,
+					},
+				}
+			}
+			return HttpResponse{
+				body: "Processing...",
 			}
 		}
 	case models.ClosedPullEvent:
 		// If the pull request was closed, we route to worker to handle deleting locks.
-		err = g.SendToWorker(request)
+		if err = g.SendToWorker(request); err != nil {
+			g.Logger.With("err", err, "eventType", eventType).Warn("failed to send autoplan request to Atlantis worker")
+			return HttpResponse{
+				body: err.Error(),
+				err: HttpError{
+					code: http.StatusBadRequest,
+					err:  err,
+				},
+			}
+		}
 	case models.OtherPullEvent:
 		// Else we ignore the event.
-		respBody = "Ignoring non-actionable pull request event"
-	}
-	if err != nil {
-		g.Logger.With("err", err, "eventType", eventType).Warn("Failed to send autoplan request to Atlantis worker")
 		return HttpResponse{
-			body: err.Error(),
-			err: HttpError{
-				code: http.StatusBadRequest,
-				err:  err,
-			},
+			body: "Ignoring non-actionable pull request event",
 		}
 	}
-	return HttpResponse{
-		body: respBody,
-	}
+	return HttpResponse{}
 }
 
 func (g *GatewayCommandExecutor) SendToWorker(r *http.Request) error {
 	buffer := bytes.NewBuffer([]byte{})
 	if err := r.Write(buffer); err != nil {
 		g.Scope.SubScope("send").Counter("failure").Inc(1)
-		return errors.Wrap(err, "Marshalling gateway request to buffer")
+		return errors.Wrap(err, "marshalling gateway request to buffer")
 	}
 	if err := g.SNSWriter.Write(buffer.Bytes()); err != nil {
 		g.Scope.SubScope("send").Counter("failure").Inc(1)
-		return errors.Wrap(err, "Writing gateway message to sns topic")
+		return errors.Wrap(err, "writing gateway message to sns topic")
 	}
 	g.Scope.SubScope("send").Counter("success").Inc(1)
 	return nil

--- a/server/controllers/events/gateway_command_executor_test.go
+++ b/server/controllers/events/gateway_command_executor_test.go
@@ -1,0 +1,125 @@
+package events
+
+import (
+	"errors"
+	. "github.com/petergtz/pegomock"
+	"github.com/runatlantis/atlantis/server/events/mocks"
+	"github.com/runatlantis/atlantis/server/events/mocks/matchers"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	sns_mocks "github.com/runatlantis/atlantis/server/lyft/aws/sns/mocks"
+	sns_matchers "github.com/runatlantis/atlantis/server/lyft/aws/sns/mocks/matchers"
+	. "github.com/runatlantis/atlantis/testing"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestExecuteCommentCommand_Success(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockCommandRunner := mocks.NewMockCommandRunner()
+	mockWriter := sns_mocks.NewMockWriter()
+	When(mockWriter.Write(sns_matchers.AnySliceOfByte())).ThenReturn(nil)
+	executor := GatewayCommandExecutor{
+		SNSWriter:     mockWriter,
+		CommandRunner: mockCommandRunner,
+	}
+	req := createExampleRequest(t)
+	resp := executor.ExecuteCommentCommand(req, models.Repo{}, nil, nil, models.User{}, 0, nil, time.Time{})
+	mockWriter.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
+	Assert(t, resp.err.code == 0, "response should have no error")
+	Assert(t, resp.body == "Processing...", "response should be processing")
+}
+
+func TestExecuteCommentCommand_Failure(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockCommandRunner := mocks.NewMockCommandRunner()
+	mockWriter := sns_mocks.NewMockWriter()
+	When(mockWriter.Write(sns_matchers.AnySliceOfByte())).ThenReturn(errors.New("marshal err"))
+	executor := GatewayCommandExecutor{
+		SNSWriter:     mockWriter,
+		CommandRunner: mockCommandRunner,
+	}
+	req := createExampleRequest(t)
+	resp := executor.ExecuteCommentCommand(req, models.Repo{}, nil, nil, models.User{}, 0, nil, time.Time{})
+	mockWriter.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
+	Assert(t, resp.err.code == 400, "response should have bad request error")
+	Assert(t, resp.body == "Writing gateway message to sns topic: marshal err", "response should be a marshal err")
+}
+
+func TestExecuteAutoplanCommand_OpenWithTerraformChanges(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWriter := sns_mocks.NewMockWriter()
+	When(mockWriter.Write(sns_matchers.AnySliceOfByte())).ThenReturn(nil)
+	mockCommandRunner := mocks.NewMockCommandRunner()
+	When(mockCommandRunner.RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())).ThenReturn(true)
+	executor := GatewayCommandExecutor{
+		SNSWriter:     mockWriter,
+		CommandRunner: mockCommandRunner,
+	}
+	req := createExampleRequest(t)
+	logger := logging.NewNoopLogger(t)
+
+	resp := executor.ExecuteAutoplanCommand(req, models.OpenedPullEvent, models.Repo{}, models.Repo{}, models.PullRequest{}, models.User{}, time.Time{}, logger)
+	mockWriter.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
+	mockCommandRunner.VerifyWasCalledOnce().RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())
+	Assert(t, resp.err.code == 0, "response should have no error")
+	Assert(t, resp.body == "Processing...", "response should be processing")
+}
+
+func TestExecuteAutoplanCommand_OpenWithoutTerraformChanges(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWriter := sns_mocks.NewMockWriter()
+	When(mockWriter.Write(sns_matchers.AnySliceOfByte())).ThenReturn(nil)
+	mockCommandRunner := mocks.NewMockCommandRunner()
+	When(mockCommandRunner.RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())).ThenReturn(false)
+	executor := GatewayCommandExecutor{
+		SNSWriter:     mockWriter,
+		CommandRunner: mockCommandRunner,
+	}
+	req := createExampleRequest(t)
+	logger := logging.NewNoopLogger(t)
+
+	resp := executor.ExecuteAutoplanCommand(req, models.OpenedPullEvent, models.Repo{}, models.Repo{}, models.PullRequest{}, models.User{}, time.Time{}, logger)
+	mockWriter.VerifyWasCalled(Never()).Write(sns_matchers.AnySliceOfByte())
+	mockCommandRunner.VerifyWasCalledOnce().RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())
+	Assert(t, resp.err.code == 0, "response should have no error")
+	Assert(t, resp.body == "", "response should be empty")
+}
+
+func TestExecuteAutoplanCommand_Close(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWriter := sns_mocks.NewMockWriter()
+	When(mockWriter.Write(sns_matchers.AnySliceOfByte())).ThenReturn(nil)
+	mockCommandRunner := mocks.NewMockCommandRunner()
+	When(mockCommandRunner.RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())).ThenReturn(false)
+	executor := GatewayCommandExecutor{
+		SNSWriter:     mockWriter,
+		CommandRunner: mockCommandRunner,
+	}
+	req := createExampleRequest(t)
+	logger := logging.NewNoopLogger(t)
+
+	resp := executor.ExecuteAutoplanCommand(req, models.ClosedPullEvent, models.Repo{}, models.Repo{}, models.PullRequest{}, models.User{}, time.Time{}, logger)
+	mockWriter.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
+	mockCommandRunner.VerifyWasCalled(Never()).RunPseudoAutoplanCommand(
+		matchers.AnyModelsRepo(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsUser())
+	Assert(t, resp.err.code == 0, "response should have no error")
+	Assert(t, resp.body == "", "response should be empty")
+}
+
+func createExampleRequest(t *testing.T) *http.Request {
+	url, err := url.Parse("http://www.atlantis.com")
+	assert.NoError(t, err)
+	req := &http.Request{
+		URL: url,
+	}
+	return req
+}

--- a/server/controllers/events/gateway_command_executor_test.go
+++ b/server/controllers/events/gateway_command_executor_test.go
@@ -54,7 +54,7 @@ func TestExecuteCommentCommand_Failure(t *testing.T) {
 	resp := executor.ExecuteCommentCommand(req, models.Repo{}, nil, nil, models.User{}, 0, nil, time.Time{})
 	mockWriter.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
 	Assert(t, resp.err.code == 400, "response should have bad request error")
-	Assert(t, resp.body == "Writing gateway message to sns topic: marshal err", "response should be a marshal err")
+	Assert(t, resp.body == "writing gateway message to sns topic: marshal err", "response should be a marshal err")
 	Assert(t, scope.Snapshot().Counters()["test.send.failure+"].Value() == 1, "should be a failed send")
 }
 

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -62,6 +62,11 @@ type ApplyCommandRunner struct {
 	silenceVCSStatusNoProjects bool
 }
 
+// PseudoRun is an unusued implementation here
+func (a *ApplyCommandRunner) PseudoRun(ctx *CommandContext) bool {
+	return false
+}
+
 func (a *ApplyCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 	var err error
 	baseRepo := ctx.Pull.BaseRepo

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -38,6 +38,11 @@ type ApprovePoliciesCommandRunner struct {
 	silenceVCSStatusNoProjects bool
 }
 
+// PseudoRun is an unusued implementation here
+func (a *ApprovePoliciesCommandRunner) PseudoRun(ctx *CommandContext) bool {
+	return false
+}
+
 func (a *ApprovePoliciesCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -147,7 +147,7 @@ func (c *DefaultCommandRunner) RunPseudoAutoplanCommand(baseRepo models.Repo, he
 	log := c.buildLogger(baseRepo.FullName, pull.Num)
 	defer c.logPanics(baseRepo, pull.Num, log)
 
-	scope := c.StatsScope.SubScope("autoplan")
+	scope := c.StatsScope.SubScope("pseudoautoplan")
 	timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
 	defer timer.Stop()
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -880,7 +880,7 @@ func TestRunPseudoAutoplanCommand_TerraformChanges(t *testing.T) {
 		}, nil)
 
 	containsTerraformChanges := ch.RunPseudoAutoplanCommand(fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
-	Assert(t, containsTerraformChanges == true, "should have")
+	Assert(t, containsTerraformChanges == true, "should have terraform changes")
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 }
 

--- a/server/events/gateway_command_runner.go
+++ b/server/events/gateway_command_runner.go
@@ -1,0 +1,1 @@
+package events

--- a/server/events/gateway_command_runner.go
+++ b/server/events/gateway_command_runner.go
@@ -1,1 +1,0 @@
-package events

--- a/server/events/mocks/mock_command_runner.go
+++ b/server/events/mocks/mock_command_runner.go
@@ -42,6 +42,21 @@ func (mock *MockCommandRunner) RunAutoplanCommand(baseRepo models.Repo, headRepo
 	pegomock.GetGenericMockFrom(mock).Invoke("RunAutoplanCommand", params, []reflect.Type{})
 }
 
+func (mock *MockCommandRunner) RunPseudoAutoplanCommand(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User) bool {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockCommandRunner().")
+	}
+	params := []pegomock.Param{baseRepo, headRepo, pull, user}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("RunPseudoAutoplanCommand", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
+	var ret0 bool
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+	}
+	return ret0
+}
+
 func (mock *MockCommandRunner) VerifyWasCalledOnce() *VerifierMockCommandRunner {
 	return &VerifierMockCommandRunner{
 		mock:                   mock,
@@ -168,6 +183,45 @@ func (c *MockCommandRunner_RunAutoplanCommand_OngoingVerification) GetAllCapture
 		_param4 = make([]time.Time, len(c.methodInvocations))
 		for u, param := range params[4] {
 			_param4[u] = param.(time.Time)
+		}
+	}
+	return
+}
+
+func (verifier *VerifierMockCommandRunner) RunPseudoAutoplanCommand(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User) *MockCommandRunner_RunPseudoAutoplanCommand_OngoingVerification {
+	params := []pegomock.Param{baseRepo, headRepo, pull, user}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RunPseudoAutoplanCommand", params, verifier.timeout)
+	return &MockCommandRunner_RunPseudoAutoplanCommand_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockCommandRunner_RunPseudoAutoplanCommand_OngoingVerification struct {
+	mock              *MockCommandRunner
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockCommandRunner_RunPseudoAutoplanCommand_OngoingVerification) GetCapturedArguments() (models.Repo, models.Repo, models.PullRequest, models.User) {
+	baseRepo, headRepo, pull, user := c.GetAllCapturedArguments()
+	return baseRepo[len(baseRepo)-1], headRepo[len(headRepo)-1], pull[len(pull)-1], user[len(user)-1]
+}
+
+func (c *MockCommandRunner_RunPseudoAutoplanCommand_OngoingVerification) GetAllCapturedArguments() (_param0 []models.Repo, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.User) {
+	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
+	if len(params) > 0 {
+		_param0 = make([]models.Repo, len(c.methodInvocations))
+		for u, param := range params[0] {
+			_param0[u] = param.(models.Repo)
+		}
+		_param1 = make([]models.Repo, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(models.Repo)
+		}
+		_param2 = make([]models.PullRequest, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(models.PullRequest)
+		}
+		_param3 = make([]models.User, len(c.methodInvocations))
+		for u, param := range params[3] {
+			_param3[u] = param.(models.User)
 		}
 	}
 	return

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -248,8 +248,10 @@ func (p *PlanCommandRunner) PseudoRun(ctx *CommandContext) bool {
 				ctx.Log.Warn("unable to update commit status: %s", err)
 			}
 		}
+		ctx.Scope.Counter("tf_projects_found").Inc(1)
 		return false
 	}
+	ctx.Scope.Counter("tf_projects_not_found").Inc(1)
 	return true
 }
 

--- a/server/events/unlock_command_runner.go
+++ b/server/events/unlock_command_runner.go
@@ -25,6 +25,11 @@ type UnlockCommandRunner struct {
 	SilenceNoProjects bool
 }
 
+// PseudoRun is an unusued implementation here
+func (u *UnlockCommandRunner) PseudoRun(ctx *CommandContext) bool {
+	return false
+}
+
 func (u *UnlockCommandRunner) Run(
 	ctx *CommandContext,
 	cmd *CommentCommand,

--- a/server/events/version_command_runner.go
+++ b/server/events/version_command_runner.go
@@ -28,6 +28,11 @@ type VersionCommandRunner struct {
 	silenceVCSStatusNoProjects bool
 }
 
+// PseudoRun is an unusued implementation here
+func (v *VersionCommandRunner) PseudoRun(ctx *CommandContext) bool {
+	return false
+}
+
 func (v *VersionCommandRunner) Run(ctx *CommandContext, cmd *CommentCommand) {
 	var err error
 	var projectCmds []models.ProjectCommandContext

--- a/server/server.go
+++ b/server/server.go
@@ -784,8 +784,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	eventsController := &events_controllers.VCSEventsController{
-		CommandRunner:                   featureAwareCommandRunner,
-		PullCleaner:                     pullClosedExecutor,
 		Parser:                          eventParser,
 		CommentParser:                   commentParser,
 		Logger:                          logger,
@@ -803,6 +801,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AzureDevopsWebhookBasicUser:     []byte(userConfig.AzureDevopsWebhookUser),
 		AzureDevopsWebhookBasicPassword: []byte(userConfig.AzureDevopsWebhookPassword),
 		AzureDevopsRequestValidator:     &events_controllers.DefaultAzureDevopsRequestValidator{},
+		CommandExecutor: &events_controllers.DefaultCommandExecutor{
+			CommandRunner: featureAwareCommandRunner,
+			PullCleaner:   pullClosedExecutor,
+		},
 	}
 	githubAppController := &controllers.GithubAppController{
 		AtlantisURL:         parsedURL,


### PR DESCRIPTION
Rather than re-implement most of the existing Post workflow logic like I intended, to reduce code duplication, I extracted out an interface called `CommandExecutor` (admittedly could be better named) that the `VCSEventsController` uses. This lets users change the behavior behind running auto/comment commands. 

PR also creates a Gateway implementation of this interface. Requests that don't need processing are returned immediately and requests that do are sent through SNS to the worker.