### PR TITLE
Marshal gateway + more logging

### DIFF
--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/logging"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -12,8 +13,6 @@ import (
 )
 
 const (
-	msgSubScope = "msg"
-
 	ProcessMessageMetricName = "process"
 	ReceiveMessageMetricName = "receive"
 	DeleteMessageMetricName  = "delete"
@@ -27,16 +26,16 @@ type Worker struct {
 	Queue            Queue
 	QueueURL         string
 	MessageProcessor MessageProcessor
-	Scope            tally.Scope
+	Logger           logging.SimpleLogging
 	Context          context.Context
 }
 
-func NewGatewaySQSWorker(scope tally.Scope, queueURL string, postHandler VCSPostHandler, ctx context.Context) (*Worker, error) {
+func NewGatewaySQSWorker(scope tally.Scope, logger logging.SimpleLogging, queueURL string, postHandler VCSPostHandler, ctx context.Context) (*Worker, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading aws config for sqs worker")
 	}
-	scope = scope.SubScope("aws.sqs")
+	scope = scope.SubScope("aws.sqs.msg")
 	sqsQueueWrapper := &QueueWithStats{
 		Queue:    sqs.NewFromConfig(cfg),
 		Scope:    scope,
@@ -47,14 +46,15 @@ func NewGatewaySQSWorker(scope tally.Scope, queueURL string, postHandler VCSPost
 		VCSEventMessageProcessor: VCSEventMessageProcessor{
 			PostHandler: postHandler,
 		},
-		Scope: scope.SubScope(msgSubScope).SubScope(ProcessMessageMetricName),
+		Scope: scope.SubScope(ProcessMessageMetricName),
 	}
 
 	return &Worker{
 		Queue:            sqsQueueWrapper,
 		QueueURL:         queueURL,
 		MessageProcessor: handler,
-		Scope:            scope.SubScope(msgSubScope),
+		Logger:           logger,
+		Context:          ctx,
 	}, nil
 }
 
@@ -65,6 +65,7 @@ func (w *Worker) Work() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		w.Logger.Info("start processing sqs messages routine")
 		w.processMessage(messages)
 	}()
 	request := &sqs.ReceiveMessageInput{
@@ -72,6 +73,7 @@ func (w *Worker) Work() {
 		MaxNumberOfMessages: 10, //max number of batch-able messages
 		WaitTimeSeconds:     20, //max duration long polling
 	}
+	w.Logger.Info("start receiving sqs messages")
 	w.receiveMessages(messages, request)
 	wg.Wait()
 }
@@ -81,13 +83,16 @@ func (w *Worker) receiveMessages(messages chan types.Message, request *sqs.Recei
 		select {
 		case <-w.Context.Done():
 			close(messages)
+			w.Logger.Info("closed sqs messages channel")
 			return
 		default:
 			response, err := w.Queue.ReceiveMessage(w.Context, request)
 			if err != nil {
+				w.Logger.With("err", err).Err("unable to receive sqs message")
 				continue
 			}
 			for _, message := range response.Messages {
+				w.Logger.Err("sending received sqs message through messages channel")
 				messages <- message
 			}
 		}
@@ -99,6 +104,7 @@ func (w *Worker) processMessage(messages chan types.Message) {
 	for message := range messages {
 		err := w.MessageProcessor.ProcessMessage(message)
 		if err != nil {
+			w.Logger.With("err", err).Err("unable to process sqs message")
 			continue
 		}
 
@@ -107,5 +113,10 @@ func (w *Worker) processMessage(messages chan types.Message) {
 			QueueUrl:      &w.QueueURL,
 			ReceiptHandle: message.ReceiptHandle,
 		})
+		if err != nil {
+			// keep it as a warning since this is not a big deal unless this is occurring frequently since
+			// we'll have already processed the message.
+			w.Logger.With("err", err).Err("unable to delete processed sqs message")
+		}
 	}
 }

--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -3,13 +3,12 @@ package sqs
 import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/pkg/errors"
-	"github.com/runatlantis/atlantis/server/logging"
-	"sync"
-
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/uber-go/tally"
+	"sync"
 )
 
 const (

--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -85,7 +85,7 @@ func (w *Worker) receiveMessages(ctx context.Context, messages chan types.Messag
 		default:
 			response, err := w.Queue.ReceiveMessage(ctx, request)
 			if err != nil {
-				w.Logger.With("err", err).Err("unable to receive sqs message")
+				w.Logger.With("err", err).Warn("unable to receive sqs message")
 				continue
 			}
 			for _, message := range response.Messages {

--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -62,7 +62,7 @@ func (w *Worker) Work(ctx context.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w.Logger.Info("start processing sqs messages routine")
+		w.Logger.Info("start processing sqs messages")
 		w.processMessage(ctx, messages)
 	}()
 	request := &sqs.ReceiveMessageInput{
@@ -89,7 +89,6 @@ func (w *Worker) receiveMessages(ctx context.Context, messages chan types.Messag
 				continue
 			}
 			for _, message := range response.Messages {
-				w.Logger.Info("sending received sqs message through messages channel")
 				messages <- message
 			}
 		}
@@ -111,9 +110,7 @@ func (w *Worker) processMessage(ctx context.Context, messages chan types.Message
 			ReceiptHandle: message.ReceiptHandle,
 		})
 		if err != nil {
-			// keep it as a warning since this is not a big deal unless this is occurring frequently since
-			// we'll have already processed the message.
-			w.Logger.With("err", err).Err("unable to delete processed sqs message")
+			w.Logger.With("err", err).Warn("unable to delete processed sqs message")
 		}
 	}
 }

--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -2,9 +2,10 @@ package sqs
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/pkg/errors"
 	"sync"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/uber-go/tally"
@@ -27,14 +28,13 @@ type Worker struct {
 	QueueURL         string
 	MessageProcessor MessageProcessor
 	Scope            tally.Scope
+	Context          context.Context
 }
 
-// TODO: initialize SQS worker in server.go upon creation of worker/hybrid modes
-
-func NewGatewaySQSWorker(scope tally.Scope, queueURL string, postHandler VCSPostHandler) (*Worker, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background())
+func NewGatewaySQSWorker(scope tally.Scope, queueURL string, postHandler VCSPostHandler, ctx context.Context) (*Worker, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error loading aws config for sqs worker")
 	}
 	scope = scope.SubScope("aws.sqs")
 	sqsQueueWrapper := &QueueWithStats{
@@ -58,32 +58,32 @@ func NewGatewaySQSWorker(scope tally.Scope, queueURL string, postHandler VCSPost
 	}, nil
 }
 
-func (w *Worker) Work(ctx context.Context) {
+func (w *Worker) Work() {
 	messages := make(chan types.Message)
-	// Used to synchronize stopping message retrivial and processing
+	// Used to synchronize stopping message retrieval and processing
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w.processMessage(ctx, messages)
+		w.processMessage(messages)
 	}()
 	request := &sqs.ReceiveMessageInput{
 		QueueUrl:            &w.QueueURL,
 		MaxNumberOfMessages: 10, //max number of batch-able messages
 		WaitTimeSeconds:     20, //max duration long polling
 	}
-	w.receiveMessages(ctx, messages, request)
+	w.receiveMessages(messages, request)
 	wg.Wait()
 }
 
-func (w *Worker) receiveMessages(ctx context.Context, messages chan types.Message, request *sqs.ReceiveMessageInput) {
+func (w *Worker) receiveMessages(messages chan types.Message, request *sqs.ReceiveMessageInput) {
 	for {
 		select {
-		case <-ctx.Done():
+		case <-w.Context.Done():
 			close(messages)
 			return
 		default:
-			response, err := w.Queue.ReceiveMessage(ctx, request)
+			response, err := w.Queue.ReceiveMessage(w.Context, request)
 			if err != nil {
 				continue
 			}
@@ -94,7 +94,7 @@ func (w *Worker) receiveMessages(ctx context.Context, messages chan types.Messag
 	}
 }
 
-func (w *Worker) processMessage(ctx context.Context, messages chan types.Message) {
+func (w *Worker) processMessage(messages chan types.Message) {
 	// VisibilityTimeout is 30s, ideally enough time to "processMessage" < 10 messages (i.e. spin up goroutine for each)
 	for message := range messages {
 		err := w.MessageProcessor.ProcessMessage(message)
@@ -103,7 +103,7 @@ func (w *Worker) processMessage(ctx context.Context, messages chan types.Message
 		}
 
 		// Since we've successfully processed the message, let's go ahead and delete it from the queue
-		_, err = w.Queue.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+		_, err = w.Queue.DeleteMessage(w.Context, &sqs.DeleteMessageInput{
 			QueueUrl:      &w.QueueURL,
 			ReceiptHandle: message.ReceiptHandle,
 		})

--- a/server/lyft/aws/sqs/worker.go
+++ b/server/lyft/aws/sqs/worker.go
@@ -92,7 +92,7 @@ func (w *Worker) receiveMessages(messages chan types.Message, request *sqs.Recei
 				continue
 			}
 			for _, message := range response.Messages {
-				w.Logger.Err("sending received sqs message through messages channel")
+				w.Logger.Info("sending received sqs message through messages channel")
 				messages <- message
 			}
 		}

--- a/server/lyft/aws/sqs/worker_test.go
+++ b/server/lyft/aws/sqs/worker_test.go
@@ -88,12 +88,11 @@ func TestWorker_Success(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Logger:           logging.NewNoopLogger(t),
-		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work()
+		worker.Work(ctx)
 		wg.Done()
 	}()
 
@@ -127,12 +126,11 @@ func TestWorker_Error(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Logger:           logging.NewNoopLogger(t),
-		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work()
+		worker.Work(ctx)
 		wg.Done()
 	}()
 
@@ -173,12 +171,11 @@ func TestWorker_HandlerError(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Logger:           logging.NewNoopLogger(t),
-		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work()
+		worker.Work(ctx)
 		wg.Done()
 	}()
 

--- a/server/lyft/aws/sqs/worker_test.go
+++ b/server/lyft/aws/sqs/worker_test.go
@@ -87,11 +87,12 @@ func TestWorker_Success(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Scope:            testScope,
+		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work(ctx)
+		worker.Work()
 		wg.Done()
 	}()
 
@@ -125,11 +126,12 @@ func TestWorker_Error(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Scope:            testScope,
+		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work(ctx)
+		worker.Work()
 		wg.Done()
 	}()
 
@@ -170,11 +172,12 @@ func TestWorker_HandlerError(t *testing.T) {
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
 		Scope:            testScope,
+		Context:          ctx,
 	}
 
 	wg.Add(1)
 	go func() {
-		worker.Work(ctx)
+		worker.Work()
 		wg.Done()
 	}()
 

--- a/server/lyft/aws/sqs/worker_test.go
+++ b/server/lyft/aws/sqs/worker_test.go
@@ -5,6 +5,7 @@ import (
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	. "github.com/petergtz/pegomock"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/aws/sqs"
 	"github.com/runatlantis/atlantis/server/lyft/aws/sqs/mocks"
 	"github.com/runatlantis/atlantis/server/lyft/aws/sqs/mocks/matchers"
@@ -86,7 +87,7 @@ func TestWorker_Success(t *testing.T) {
 		Queue:            queue,
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
-		Scope:            testScope,
+		Logger:           logging.NewNoopLogger(t),
 		Context:          ctx,
 	}
 
@@ -125,7 +126,7 @@ func TestWorker_Error(t *testing.T) {
 		Queue:            queue,
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
-		Scope:            testScope,
+		Logger:           logging.NewNoopLogger(t),
 		Context:          ctx,
 	}
 
@@ -171,7 +172,7 @@ func TestWorker_HandlerError(t *testing.T) {
 		Queue:            queue,
 		QueueURL:         "testUrl",
 		MessageProcessor: handler,
-		Scope:            testScope,
+		Logger:           logging.NewNoopLogger(t),
 		Context:          ctx,
 	}
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -266,7 +266,7 @@ func (g *VCSEventsController) SendToWorker(r *http.Request, body []byte) error {
 	}
 	requestBuffer := bytes.NewBuffer([]byte{})
 	if err := copiedRequest.Write(requestBuffer); err != nil {
-		return errors.Wrap(err, "marshalling gateway request to buffer")
+		return errors.Wrap(err, "marshalling gateway request into buffer")
 	}
 	if err := g.SNSWriter.Write(requestBuffer.Bytes()); err != nil {
 		return errors.Wrap(err, "writing gateway request to SNS topic")

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -79,10 +79,10 @@ func (g *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 	var resp HttpResponse
 	switch event := event.(type) {
 	case *github.IssueCommentEvent:
-		resp = g.HandleGithubCommentEvent(event, r)
+		resp = g.HandleGithubCommentEvent(event, r, payload)
 		scope = scope.SubScope(fmt.Sprintf("comment.%s", *event.Action))
 	case *github.PullRequestEvent:
-		resp = g.HandleGithubPullRequestEvent(event, r)
+		resp = g.HandleGithubPullRequestEvent(event, r, payload)
 		scope = scope.SubScope(fmt.Sprintf("pr.%s", *event.Action))
 	default:
 		resp = HttpResponse{
@@ -103,7 +103,7 @@ func (g *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 
 // HandleGithubCommentEvent handles comment events from GitHub where Atlantis
 // commands can come from. It's exported to make testing easier.
-func (g *VCSEventsController) HandleGithubCommentEvent(event *github.IssueCommentEvent, r *http.Request) HttpResponse {
+func (g *VCSEventsController) HandleGithubCommentEvent(event *github.IssueCommentEvent, r *http.Request, payload []byte) HttpResponse {
 	if event.GetAction() != "created" {
 		return HttpResponse{
 			body: fmt.Sprintf("Ignoring comment event since action was not created"),
@@ -122,10 +122,10 @@ func (g *VCSEventsController) HandleGithubCommentEvent(event *github.IssueCommen
 	}
 	// We pass in nil for maybeHeadRepo because the head repo data isn't
 	// available in the GithubIssueComment event.
-	return g.handleCommentEvent(baseRepo, pullNum, event.Comment.GetBody(), models.Github, r)
+	return g.handleCommentEvent(baseRepo, pullNum, event.Comment.GetBody(), models.Github, r, payload)
 }
 
-func (g *VCSEventsController) handleCommentEvent(baseRepo models.Repo, pullNum int, comment string, vcsHost models.VCSHostType, r *http.Request) HttpResponse {
+func (g *VCSEventsController) handleCommentEvent(baseRepo models.Repo, pullNum int, comment string, vcsHost models.VCSHostType, r *http.Request, payload []byte) HttpResponse {
 	parseResult := g.CommentParser.Parse(comment, vcsHost)
 	if parseResult.Ignore {
 		truncated := comment
@@ -165,7 +165,7 @@ func (g *VCSEventsController) handleCommentEvent(baseRepo models.Repo, pullNum i
 			body: "Commenting back on pull request",
 		}
 	}
-	if err := g.SendToWorker(r); err != nil {
+	if err := g.SendToWorker(r, payload); err != nil {
 		g.Logger.With("err", err).Err("failed to send comment request to Atlantis worker")
 		return HttpResponse{
 			body: err.Error(),
@@ -180,7 +180,7 @@ func (g *VCSEventsController) handleCommentEvent(baseRepo models.Repo, pullNum i
 	}
 }
 
-func (g *VCSEventsController) HandleGithubPullRequestEvent(pullEvent *github.PullRequestEvent, r *http.Request) HttpResponse {
+func (g *VCSEventsController) HandleGithubPullRequestEvent(pullEvent *github.PullRequestEvent, r *http.Request, payload []byte) HttpResponse {
 	pull, pullEventType, baseRepo, headRepo, user, err := g.Parser.ParseGithubPullEvent(pullEvent)
 	if err != nil {
 		wrapped := errors.Wrapf(err, "Error parsing pull data: %s", err)
@@ -192,10 +192,10 @@ func (g *VCSEventsController) HandleGithubPullRequestEvent(pullEvent *github.Pul
 			},
 		}
 	}
-	return g.handlePullRequestEvent(baseRepo, headRepo, pull, user, pullEventType, r)
+	return g.handlePullRequestEvent(baseRepo, headRepo, pull, user, pullEventType, r, payload)
 }
 
-func (g *VCSEventsController) handlePullRequestEvent(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, eventType models.PullRequestEventType, request *http.Request) HttpResponse {
+func (g *VCSEventsController) handlePullRequestEvent(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, eventType models.PullRequestEventType, request *http.Request, payload []byte) HttpResponse {
 	if !g.RepoAllowlistChecker.IsAllowlisted(baseRepo.FullName, baseRepo.VCSHost.Hostname) {
 		// If the repo isn't allowlisted and we receive an opened pull request
 		// event we comment back on the pull request that the repo isn't
@@ -217,13 +217,13 @@ func (g *VCSEventsController) handlePullRequestEvent(baseRepo models.Repo, headR
 	case models.OpenedPullEvent, models.UpdatedPullEvent:
 		// If the pull request was opened or updated, we perform a pseudo-autoplan to determine if tf changes exist.
 		// If it exists, then we will forward request to the worker.
-		go g.handleOpenPullEvent(baseRepo, headRepo, pull, user, request)
+		go g.handleOpenPullEvent(baseRepo, headRepo, pull, user, request, payload)
 		return HttpResponse{
 			body: "Processing...",
 		}
 	case models.ClosedPullEvent:
 		// If the pull request was closed, we route to worker to handle deleting locks.
-		if err := g.SendToWorker(request); err != nil {
+		if err := g.SendToWorker(request, payload); err != nil {
 			return HttpResponse{
 				body: err.Error(),
 				err: HttpError{
@@ -241,26 +241,25 @@ func (g *VCSEventsController) handlePullRequestEvent(baseRepo models.Repo, headR
 	return HttpResponse{}
 }
 
-func (g *VCSEventsController) handleOpenPullEvent(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, request *http.Request) {
+func (g *VCSEventsController) handleOpenPullEvent(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, request *http.Request, payload []byte) {
 	if hasTerraformChanges := g.AutoplanValidator.InstrumentedIsValid(baseRepo, headRepo, pull, user); hasTerraformChanges {
-		if err := g.SendToWorker(request); err != nil {
+		if err := g.SendToWorker(request, payload); err != nil {
 			g.Logger.With("err", err).Err("failed to send autoplan request to Atlantis worker")
 		}
 	}
 }
 
-func (g *VCSEventsController) SendToWorker(r *http.Request) error {
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+func (g *VCSEventsController) SendToWorker(r *http.Request, body []byte) error {
+	err := r.Body.Close()
 	if err != nil {
-		return errors.Wrap(err, "rereading request body")
+		return errors.Wrap(err, "closing request body")
 	}
-	bodyBuffer := bytes.NewBuffer(bodyBytes)
+	bodyBuffer := bytes.NewBuffer(body)
 	copiedRequest := http.Request{
 		Method:           r.Method,
 		URL:              r.URL,
 		Header:           r.Header,
 		Body:             ioutil.NopCloser(bodyBuffer),
-		GetBody:          r.GetBody,
 		ContentLength:    r.ContentLength,
 		TransferEncoding: r.TransferEncoding,
 		Host:             r.Host,

--- a/server/lyft/gateway/events_controller_test.go
+++ b/server/lyft/gateway/events_controller_test.go
@@ -258,7 +258,7 @@ func TestPost_GithubCommentFailure(t *testing.T) {
 	w := httptest.NewRecorder()
 	e.Post(w, req)
 	sns.VerifyWasCalledOnce().Write(sns_matchers.AnySliceOfByte())
-	ResponseContains(t, w, http.StatusBadRequest, "marshalling gateway request to buffer: err")
+	ResponseContains(t, w, http.StatusBadRequest, "writing gateway request to SNS topic: err")
 }
 
 func TestPost_GithubIgnorePR(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -933,6 +933,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
 			logger.With("err", err).Err("unable to set up worker")
+			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
 		}
 		worker.Work()
@@ -940,6 +941,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
 		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
+			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for worker mode")
 		}
 		worker.Work()

--- a/server/server.go
+++ b/server/server.go
@@ -123,7 +123,7 @@ type Server struct {
 	ScheduledExecutorService      *scheduled.ExecutorService
 	ProjectCmdOutputHandler       jobs.ProjectCommandOutputHandler
 	LyftMode                      Mode
-	WorkerCancelFunc              context.CancelFunc
+	CancelWorker                  context.CancelFunc
 }
 
 // Config holds config for server that isn't passed in by the user.
@@ -973,7 +973,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		ScheduledExecutorService:      scheduledExecutorService,
 		ProjectCmdOutputHandler:       projectCmdOutputHandler,
 		LyftMode:                      lyftMode,
-		WorkerCancelFunc:              cancel,
+		CancelWorker:                  cancel,
 	}, nil
 }
 
@@ -1041,7 +1041,7 @@ func (s *Server) Start() error {
 	// Shutdown sqs polling. Any received messages being processed will either succeed/fail depending on if drainer started.
 	if s.LyftMode == Hybrid || s.LyftMode == Worker {
 		s.Logger.Warn("Received interrupt. Shutting down the sqs handler")
-		s.WorkerCancelFunc()
+		s.CancelWorker()
 	}
 
 	s.Logger.Warn("Received interrupt. Waiting for in-progress operations to complete")

--- a/server/server.go
+++ b/server/server.go
@@ -930,7 +930,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		logger.With("sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in gateway mode")
 	case Hybrid: // gateway eventsController handles POST, and SQS worker is set up to handle messages via default eventsController
 		vcsPostHandler = gatewayEventsController
-		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
+		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
 			logger.With("err", err).Err("unable to set up worker")
 			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
@@ -938,7 +938,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		worker.Work()
 		logger.With("queue", userConfig.LyftWorkerQueueURL, "sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in hybrid mode")
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
-		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
+		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "setting up sqs handler for worker mode")
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -930,18 +930,19 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		logger.With("sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in gateway mode")
 	case Hybrid: // gateway eventsController handles POST, and SQS worker is set up to handle messages via default eventsController
 		vcsPostHandler = gatewayEventsController
-		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController)
+		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
+			logger.With("err", err).Err("unable to set up worker")
 			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
 		}
-		worker.Work(ctx)
+		worker.Work()
 		logger.With("queue", userConfig.LyftWorkerQueueURL, "sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in hybrid mode")
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
-		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController)
+		worker, err := sqs.NewGatewaySQSWorker(statsScope, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "setting up sqs handler for worker mode")
 		}
-		worker.Work(ctx)
+		worker.Work()
 		logger.With("queue", userConfig.LyftWorkerQueueURL).Info("running Atlantis in worker mode")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -936,7 +936,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
 		}
-		worker.Work()
+		worker.Work(ctx)
 		logger.With("queue", userConfig.LyftWorkerQueueURL, "sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in hybrid mode")
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
 		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
@@ -944,7 +944,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for worker mode")
 		}
-		worker.Work()
+		worker.Work(ctx)
 		logger.With("queue", userConfig.LyftWorkerQueueURL).Info("running Atlantis in worker mode")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -936,7 +936,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
 		}
-		worker.Work(ctx)
+		go worker.Work(ctx)
 		logger.With("queue", userConfig.LyftWorkerQueueURL, "sns", userConfig.LyftGatewaySnsTopicArn).Info("running Atlantis in hybrid mode")
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
 		worker, err := sqs.NewGatewaySQSWorker(statsScope, logger, userConfig.LyftWorkerQueueURL, defaultEventsController, ctx)
@@ -944,7 +944,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			cancel()
 			return nil, errors.Wrapf(err, "setting up sqs handler for worker mode")
 		}
-		worker.Work(ctx)
+		go worker.Work(ctx)
 		logger.With("queue", userConfig.LyftWorkerQueueURL).Info("running Atlantis in worker mode")
 	}
 


### PR DESCRIPTION
Few things to change from testing gateway:

- Create a new `Body` field in `http.Request` prior to sending through `SNS` because original reader was already used with parsing the payload 
- Improve observability around worker
- Separate contexts from shutdown and worker routine (I misread the shutdown logic earlier and realized it's a timeout ctx, so the sqs routine needs its own context that will be canceled upon shutdown of atlantis). Also make sure worker is running in separate go routine