### PR TITLE
Delete temporarily generated clone by gateway

### DIFF
--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -79,6 +79,10 @@ func (r *AutoplanValidator) isValid(baseRepo models.Repo, headRepo models.Repo, 
 		if statusErr := r.CommitStatusUpdater.UpdateCombined(baseRepo, pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
 			ctx.Log.Warn("unable to update commit status: %s", statusErr)
 		}
+		// If error happened after clone was made, we should clean it up here too
+		if cloneErr := r.WorkingDir.Delete(baseRepo, pull); cloneErr != nil {
+			ctx.Log.With("err", cloneErr).Warn("unable to delete clone after autoplan failed")
+		}
 		r.PullUpdater.UpdatePull(ctx, events.AutoplanCommand{}, command.Result{Error: err})
 		return false, errors.Wrap(err, "Failed building autoplan commands")
 	}

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -43,6 +43,7 @@ type AutoplanValidator struct {
 	CommitStatusUpdater        events.CommitStatusUpdater
 	PrjCmdBuilder              events.ProjectPlanCommandBuilder
 	PullUpdater                *events.PullUpdater
+	WorkingDir                 events.WorkingDir
 }
 
 func (r *AutoplanValidator) isValid(baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User) (bool, error) {
@@ -80,6 +81,10 @@ func (r *AutoplanValidator) isValid(baseRepo models.Repo, headRepo models.Repo, 
 		}
 		r.PullUpdater.UpdatePull(ctx, events.AutoplanCommand{}, command.Result{Error: err})
 		return false, errors.Wrap(err, "Failed building autoplan commands")
+	}
+	// Delete repo clone generated to validate plan
+	if err := r.WorkingDir.Delete(baseRepo, pull); err != nil {
+		return false, errors.Wrap(err, "Failed deleting cloned repo")
 	}
 	if len(projectCmds) == 0 {
 		ctx.Log.Info("determined there was no project to run plan in")

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -63,6 +63,7 @@ func TestIsValid_DrainOngoing(t *testing.T) {
 	drainer.ShutdownBlocking()
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	Assert(t, containsTerraformChanges == false, "should be false when an error occurs")
+	workingDir.VerifyWasCalled(Never()).Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 }
 
 func TestIsValid_DeleteCloneError(t *testing.T) {
@@ -71,6 +72,7 @@ func TestIsValid_DeleteCloneError(t *testing.T) {
 	When(workingDir.Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn(errors.New("failed to delete clone"))
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	Assert(t, containsTerraformChanges == false, "should be false when an error occurs")
+	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 }
 
 func TestIsValid_ProjectBuilderError(t *testing.T) {
@@ -81,6 +83,7 @@ func TestIsValid_ProjectBuilderError(t *testing.T) {
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, fixtures.Pull.Num, "**Plan Error**\n```\nerr\n```\n", "plan")
 	Assert(t, containsTerraformChanges == false, "should be false when an error occurs")
+	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 }
 
 func TestIsValid_TerraformChanges(t *testing.T) {
@@ -106,6 +109,7 @@ func TestIsValid_TerraformChanges(t *testing.T) {
 		matchers.AnyModelsCommandName(),
 		AnyInt(),
 		AnyInt())
+	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 }
 
 func TestPullRequestHasTerraformChanges_NoTerraformChanges(t *testing.T) {
@@ -122,4 +126,5 @@ func TestPullRequestHasTerraformChanges_NoTerraformChanges(t *testing.T) {
 		matchers.AnyModelsCommandName(),
 		AnyInt(),
 		AnyInt())
+	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -883,6 +883,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		CommitStatusUpdater:           commitStatusUpdater,
 		PrjCmdBuilder:                 projectCommandBuilder,
 		PullUpdater:                   pullUpdater,
+		WorkingDir:                    workingDir,
 	}
 	gatewayEventsController := &gateway.VCSEventsController{
 		Logger:                 logger,


### PR DESCRIPTION
`PrjCmdBuilder` will build a repo clone to determine if any terraform plans need to be performed. Gateway shouldn't need to keep this clone around so we delete it after retrieving the data we need in the `AutoplanValidator`.