### PR TITLE
Remove all unnecessary silence flags.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -90,14 +90,11 @@ const (
 	RepoConfigFlag             = "repo-config"
 	RepoConfigJSONFlag         = "repo-config-json"
 	// RepoWhitelistFlag is deprecated for RepoAllowlistFlag.
-	RepoWhitelistFlag          = "repo-whitelist"
-	RepoAllowlistFlag          = "repo-allowlist"
-	RequireApprovalFlag        = "require-approval"
-	RequireSQUnlockedFlag      = "require-unlocked"
-	RequireMergeableFlag       = "require-mergeable"
-	SilenceAllowlistErrorsFlag = "silence-allowlist-errors"
-	// SilenceWhitelistErrorsFlag is deprecated for SilenceAllowlistErrorsFlag.
-	SilenceWhitelistErrorsFlag   = "silence-whitelist-errors"
+	RepoWhitelistFlag            = "repo-whitelist"
+	RepoAllowlistFlag            = "repo-allowlist"
+	RequireApprovalFlag          = "require-approval"
+	RequireSQUnlockedFlag        = "require-unlocked"
+	RequireMergeableFlag         = "require-mergeable"
 	SkipCloneNoChanges           = "skip-clone-no-changes"
 	SlackTokenFlag               = "slack-token"
 	SSLCertFileFlag              = "ssl-cert-file"
@@ -394,15 +391,6 @@ var boolFlags = map[string]boolFlag{
 	RequireSQUnlockedFlag: {
 		description:  "Require pull requests to be \"Unlocked\" before allowing the apply command to be run.",
 		defaultValue: false,
-	},
-	SilenceAllowlistErrorsFlag: {
-		description:  "Silences the posting of allowlist error comments.",
-		defaultValue: false,
-	},
-	SilenceWhitelistErrorsFlag: {
-		description:  "[Deprecated for --silence-allowlist-errors].",
-		defaultValue: false,
-		hidden:       true,
 	},
 	DisableMarkdownFoldingFlag: {
 		description:  "Toggle off folding in markdown output.",

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -56,7 +56,6 @@ var testFlags = map[string]interface{}{
 	ADWebhookPasswordFlag:        "ad-wh-pass",
 	ADWebhookUserFlag:            "ad-wh-user",
 	AtlantisURLFlag:              "url",
-	AllowForkPRsFlag:             true,
 	AllowRepoConfigFlag:          true,
 	AutomergeFlag:                true,
 	AutoplanFileListFlag:         "**/*.tf,**/*.yml",
@@ -91,10 +90,6 @@ var testFlags = map[string]interface{}{
 	RepoAllowlistFlag:            "github.com/runatlantis/atlantis",
 	RequireApprovalFlag:          true,
 	RequireMergeableFlag:         true,
-	SilenceNoProjectsFlag:        false,
-	SilenceForkPRErrorsFlag:      true,
-	SilenceAllowlistErrorsFlag:   true,
-	SilenceVCSStatusNoPlans:      true,
 	SkipCloneNoChanges:           true,
 	SlackTokenFlag:               "slack-token",
 	SSLCertFileFlag:              "cert-file",
@@ -733,31 +728,16 @@ func TestExecute_AllowAndWhitelist(t *testing.T) {
 	ErrEquals(t, "--repo-allowlist must be set for security purposes", err)
 }
 
-// Can't use both --silence-whitelist-errors and --silence-allowlist-errors
-func TestExecute_BothSilenceAllowAndWhitelistErrors(t *testing.T) {
-	c := setup(map[string]interface{}{
-		GHUserFlag:                 "user",
-		GHTokenFlag:                "token",
-		RepoAllowlistFlag:          "*",
-		SilenceWhitelistErrorsFlag: true,
-		SilenceAllowlistErrorsFlag: true,
-	}, t)
-	err := c.Execute()
-	ErrEquals(t, "both --silence-allowlist-errors and --silence-whitelist-errors cannot be set–use --silence-allowlist-errors", err)
-}
-
 // Test that we set the corresponding allow list values on the userConfig
 // struct if the deprecated whitelist flags are used.
 func TestExecute_RepoWhitelistDeprecation(t *testing.T) {
 	c := setup(map[string]interface{}{
-		GHUserFlag:                 "user",
-		GHTokenFlag:                "token",
-		RepoWhitelistFlag:          "*",
-		SilenceWhitelistErrorsFlag: true,
+		GHUserFlag:        "user",
+		GHTokenFlag:       "token",
+		RepoWhitelistFlag: "*",
 	}, t)
 	err := c.Execute()
 	Ok(t, err)
-	Equals(t, true, passedConfig.SilenceAllowlistErrors)
 	Equals(t, "*", passedConfig.RepoAllowlist)
 }
 

--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -65,9 +65,6 @@ type VCSEventsController struct {
 	// request validation is done.
 	GitlabWebhookSecret  []byte
 	RepoAllowlistChecker *events.RepoAllowlistChecker
-	// SilenceAllowlistErrors controls whether we write an error comment on
-	// pull requests from non-allowlisted repos.
-	SilenceAllowlistErrors bool
 	// SupportedVCSHosts is which VCS hosts Atlantis was configured upon
 	// startup to support.
 	SupportedVCSHosts []models.VCSHostType
@@ -726,10 +723,6 @@ func (e *VCSEventsController) respond(w http.ResponseWriter, lvl logging.LogLeve
 // commentNotAllowlisted comments on the pull request that the repo is not
 // allowlisted unless allowlist error comments are disabled.
 func (e *VCSEventsController) commentNotAllowlisted(baseRepo models.Repo, pullNum int) {
-	if e.SilenceAllowlistErrors {
-		return
-	}
-
 	errMsg := "```\nError: This repo is not allowlisted for Atlantis.\n```"
 	if err := e.VCSClient.CreateComment(baseRepo, pullNum, errMsg, ""); err != nil {
 		e.Logger.Errorf("unable to comment on pull request: %s", err)

--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -157,7 +157,7 @@ func (e *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	githubReqID := "X-Github-Delivery=" + r.Header.Get("X-Github-Delivery")
+	githubReqID := r.Header.Get("X-Github-Delivery")
 	logger := e.Logger.With("gh-request-id", githubReqID)
 	scope := e.Scope.SubScope("github.event")
 

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -653,7 +653,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 
 	// Set real dependencies here.
 	// TODO: aggregate some of this with that of server.go to minimize duplication
-	allowForkPRs := false
 	vcsClient := vcs.NewClientProxy(ghClient, nil, nil, nil, nil)
 	e2eStatusUpdater := &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: "atlantis"}}
 
@@ -707,7 +706,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 	drainer := &events.Drainer{}
 
 	parallelPoolSize := 1
-	silenceNoProjects := false
 
 	preWorkflowHooksCommandRunner := &events.DefaultPreWorkflowHooksCommandRunner{
 		VCSClient:             vcsClient,
@@ -856,12 +854,9 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		e2eStatusUpdater,
 		prjCmdRunner,
 		parallelPoolSize,
-		false,
 	)
 
 	planCommandRunner := events.NewPlanCommandRunner(
-		false,
-		false,
 		vcsClient,
 		&events.DefaultPendingPlanFinder{},
 		workingDir,
@@ -873,7 +868,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		policyCheckCommandRunner,
 		autoMerger,
 		parallelPoolSize,
-		silenceNoProjects,
 	)
 
 	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(
@@ -882,14 +876,11 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		prjCmdRunner,
 		pullUpdater,
 		dbUpdater,
-		silenceNoProjects,
-		false,
 	)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(
 		deleteLockCommand,
 		vcsClient,
-		silenceNoProjects,
 	)
 
 	versionCommandRunner := events.NewVersionCommandRunner(
@@ -897,7 +888,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		projectCommandBuilder,
 		prjCmdRunner,
 		parallelPoolSize,
-		silenceNoProjects,
 	)
 
 	var applyCommandRunner command.Runner
@@ -916,8 +906,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 			pullUpdater,
 			dbUpdater,
 			parallelPoolSize,
-			silenceNoProjects,
-			false,
 			e2ePullReqStatusFetcher,
 		)
 	}
@@ -936,8 +924,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		GithubPullGetter:              ghClient,
 		GlobalCfg:                     globalCfg,
 		StatsScope:                    statsScope,
-		AllowForkPRs:                  allowForkPRs,
-		AllowForkPRsFlag:              "allow-fork-prs",
 		CommentCommandRunnerByCmd:     commentCommandRunnerByCmd,
 		Drainer:                       drainer,
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -243,7 +243,6 @@ func TestPost_GitlabCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
 		SupportedVCSHosts:            []models.VCSHostType{models.Gitlab},
 		RepoAllowlistChecker:         &events.RepoAllowlistChecker{},
 		VCSClient:                    vcsClient,
-		SilenceAllowlistErrors:       true,
 	}
 	requestJSON, err := ioutil.ReadFile(filepath.Join("testfixtures", "gitlabMergeCommentEvent_notAllowlisted.json"))
 	Ok(t, err)
@@ -307,7 +306,6 @@ func TestPost_GithubCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
 		SupportedVCSHosts:      []models.VCSHostType{models.Github},
 		RepoAllowlistChecker:   &events.RepoAllowlistChecker{},
 		VCSClient:              vcsClient,
-		SilenceAllowlistErrors: true,
 	}
 	requestJSON, err := ioutil.ReadFile(filepath.Join("testfixtures", "githubIssueCommentEvent_notAllowlisted.json"))
 	Ok(t, err)

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -228,37 +228,6 @@ func TestPost_GitlabCommentNotAllowlisted(t *testing.T) {
 	vcsClient.VerifyWasCalledOnce().CreateComment(expRepo, 1, "```\nError: This repo is not allowlisted for Atlantis.\n```", "")
 }
 
-func TestPost_GitlabCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
-	t.Log("when the event is a gitlab comment from a repo that isn't allowlisted and we are silencing errors, do not comment with an error")
-	RegisterMockTestingT(t)
-	vcsClient := vcsmocks.NewMockClient()
-	logger := logging.NewNoopLogger(t)
-	scope, _, _ := metrics.NewLoggingScope(logger, "null")
-	e := events_controllers.VCSEventsController{
-		Logger:                       logger,
-		Scope:                        scope,
-		CommentParser:                &events.CommentParser{},
-		GitlabRequestParserValidator: &events_controllers.DefaultGitlabRequestParserValidator{},
-		Parser:                       &events.EventParser{},
-		SupportedVCSHosts:            []models.VCSHostType{models.Gitlab},
-		RepoAllowlistChecker:         &events.RepoAllowlistChecker{},
-		VCSClient:                    vcsClient,
-	}
-	requestJSON, err := ioutil.ReadFile(filepath.Join("testfixtures", "gitlabMergeCommentEvent_notAllowlisted.json"))
-	Ok(t, err)
-	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(requestJSON))
-	req.Header.Set(gitlabHeader, "Note Hook")
-	w := httptest.NewRecorder()
-	e.Post(w, req)
-
-	Equals(t, http.StatusForbidden, w.Result().StatusCode)
-	body, _ := ioutil.ReadAll(w.Result().Body)
-	exp := "Repo not allowlisted"
-	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-
-}
-
 func TestPost_GithubCommentNotAllowlisted(t *testing.T) {
 	t.Log("when the event is a github comment from a repo that isn't allowlisted we comment with an error")
 	RegisterMockTestingT(t)
@@ -289,37 +258,6 @@ func TestPost_GithubCommentNotAllowlisted(t *testing.T) {
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
 	expRepo, _ := models.NewRepo(models.Github, "baxterthehacker/public-repo", "https://github.com/baxterthehacker/public-repo.git", "", "")
 	vcsClient.VerifyWasCalledOnce().CreateComment(expRepo, 2, "```\nError: This repo is not allowlisted for Atlantis.\n```", "")
-}
-
-func TestPost_GithubCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
-	t.Log("when the event is a github comment from a repo that isn't allowlisted and we are silencing errors, do not comment with an error")
-	RegisterMockTestingT(t)
-	vcsClient := vcsmocks.NewMockClient()
-	logger := logging.NewNoopLogger(t)
-	scope, _, _ := metrics.NewLoggingScope(logger, "null")
-	e := events_controllers.VCSEventsController{
-		Logger:                 logger,
-		Scope:                  scope,
-		GithubRequestValidator: &events_controllers.DefaultGithubRequestValidator{},
-		CommentParser:          &events.CommentParser{},
-		Parser:                 &events.EventParser{},
-		SupportedVCSHosts:      []models.VCSHostType{models.Github},
-		RepoAllowlistChecker:   &events.RepoAllowlistChecker{},
-		VCSClient:              vcsClient,
-	}
-	requestJSON, err := ioutil.ReadFile(filepath.Join("testfixtures", "githubIssueCommentEvent_notAllowlisted.json"))
-	Ok(t, err)
-	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(requestJSON))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(githubHeader, "issue_comment")
-	w := httptest.NewRecorder()
-	e.Post(w, req)
-
-	Equals(t, http.StatusForbidden, w.Result().StatusCode)
-	body, _ := ioutil.ReadAll(w.Result().Body)
-	exp := "Repo not allowlisted"
-	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 }
 
 func TestPost_GitlabCommentResponse(t *testing.T) {

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -20,24 +20,20 @@ func NewApplyCommandRunner(
 	pullUpdater *PullUpdater,
 	dbUpdater *DBUpdater,
 	parallelPoolSize int,
-	SilenceNoProjects bool,
-	silenceVCSStatusNoProjects bool,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
 ) *ApplyCommandRunner {
 	return &ApplyCommandRunner{
-		vcsClient:                  vcsClient,
-		DisableApplyAll:            disableApplyAll,
-		locker:                     applyCommandLocker,
-		commitStatusUpdater:        commitStatusUpdater,
-		prjCmdBuilder:              prjCommandBuilder,
-		prjCmdRunner:               prjCmdRunner,
-		autoMerger:                 autoMerger,
-		pullUpdater:                pullUpdater,
-		dbUpdater:                  dbUpdater,
-		parallelPoolSize:           parallelPoolSize,
-		SilenceNoProjects:          SilenceNoProjects,
-		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
-		pullReqStatusFetcher:       pullReqStatusFetcher,
+		vcsClient:            vcsClient,
+		DisableApplyAll:      disableApplyAll,
+		locker:               applyCommandLocker,
+		commitStatusUpdater:  commitStatusUpdater,
+		prjCmdBuilder:        prjCommandBuilder,
+		prjCmdRunner:         prjCmdRunner,
+		autoMerger:           autoMerger,
+		pullUpdater:          pullUpdater,
+		dbUpdater:            dbUpdater,
+		parallelPoolSize:     parallelPoolSize,
+		pullReqStatusFetcher: pullReqStatusFetcher,
 	}
 }
 
@@ -53,12 +49,6 @@ type ApplyCommandRunner struct {
 	dbUpdater            *DBUpdater
 	parallelPoolSize     int
 	pullReqStatusFetcher vcs.PullReqStatusFetcher
-	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
-	// are found
-	SilenceNoProjects bool
-	// SilenceVCSStatusNoPlans is whether any plan should set commit status if no projects
-	// are found
-	silenceVCSStatusNoProjects bool
 }
 
 func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {
@@ -122,16 +112,14 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {
 	}
 
 	// If there are no projects to apply, don't respond to the PR and ignore
-	if len(projectCmds) == 0 && a.SilenceNoProjects {
+	if len(projectCmds) == 0 {
 		ctx.Log.Infof("determined there was no project to run apply in.")
-		if !a.silenceVCSStatusNoProjects {
-			// If there were no projects modified, we set successful commit statuses
-			// with 0/0 projects applied successfully because some users require
-			// the Atlantis status to be passing for all pull requests.
-			ctx.Log.Debugf("setting VCS status to success with no projects found")
-			if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
+		// If there were no projects modified, we set successful commit statuses
+		// with 0/0 projects applied successfully because some users require
+		// the Atlantis status to be passing for all pull requests.
+		ctx.Log.Debugf("setting VCS status to success with no projects found")
+		if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
 		}
 		return
 	}

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -111,19 +111,6 @@ func (a *ApplyCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {
 		return
 	}
 
-	// If there are no projects to apply, don't respond to the PR and ignore
-	if len(projectCmds) == 0 {
-		ctx.Log.Infof("determined there was no project to run apply in.")
-		// If there were no projects modified, we set successful commit statuses
-		// with 0/0 projects applied successfully because some users require
-		// the Atlantis status to be passing for all pull requests.
-		ctx.Log.Debugf("setting VCS status to success with no projects found")
-		if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
-			ctx.Log.Warnf("unable to update commit status: %s", err)
-		}
-		return
-	}
-
 	// Only run commands in parallel if enabled
 	var result command.Result
 	if a.isParallelEnabled(projectCmds) {

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -14,17 +14,13 @@ func NewApprovePoliciesCommandRunner(
 	prjCommandRunner ProjectApprovePoliciesCommandRunner,
 	pullUpdater *PullUpdater,
 	dbUpdater *DBUpdater,
-	SilenceNoProjects bool,
-	silenceVCSStatusNoProjects bool,
 ) *ApprovePoliciesCommandRunner {
 	return &ApprovePoliciesCommandRunner{
-		commitStatusUpdater:        commitStatusUpdater,
-		prjCmdBuilder:              prjCommandBuilder,
-		prjCmdRunner:               prjCommandRunner,
-		pullUpdater:                pullUpdater,
-		dbUpdater:                  dbUpdater,
-		SilenceNoProjects:          SilenceNoProjects,
-		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
+		commitStatusUpdater: commitStatusUpdater,
+		prjCmdBuilder:       prjCommandBuilder,
+		prjCmdRunner:        prjCommandRunner,
+		pullUpdater:         pullUpdater,
+		dbUpdater:           dbUpdater,
 	}
 }
 
@@ -34,10 +30,6 @@ type ApprovePoliciesCommandRunner struct {
 	dbUpdater           *DBUpdater
 	prjCmdBuilder       ProjectApprovePoliciesCommandBuilder
 	prjCmdRunner        ProjectApprovePoliciesCommandRunner
-	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
-	// are found
-	SilenceNoProjects          bool
-	silenceVCSStatusNoProjects bool
 }
 
 func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {
@@ -57,16 +49,14 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		return
 	}
 
-	if len(projectCmds) == 0 && a.SilenceNoProjects {
+	if len(projectCmds) == 0 {
 		ctx.Log.Infof("determined there was no project to run approve_policies in")
-		if !a.silenceVCSStatusNoProjects {
-			// If there were no projects modified, we set successful commit statuses
-			// with 0/0 projects approve_policies successfully because some users require
-			// the Atlantis status to be passing for all pull requests.
-			ctx.Log.Debugf("setting VCS status to success with no projects found")
-			if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
+		// If there were no projects modified, we set successful commit statuses
+		// with 0/0 projects approve_policies successfully because some users require
+		// the Atlantis status to be passing for all pull requests.
+		ctx.Log.Debugf("setting VCS status to success with no projects found")
+		if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
 		}
 		return
 	}

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -111,21 +111,9 @@ type DefaultCommandRunner struct {
 	EventParser              EventParsing
 	GlobalCfg                valid.GlobalCfg
 	StatsScope               tally.Scope
-	// AllowForkPRs controls whether we operate on pull requests from forks.
-	AllowForkPRs bool
 	// ParallelPoolSize controls the size of the wait group used to run
 	// parallel plans and applies (if enabled).
-	ParallelPoolSize int
-	// AllowForkPRsFlag is the name of the flag that controls fork PR's. We use
-	// this in our error message back to the user on a forked PR so they know
-	// how to enable this functionality.
-	AllowForkPRsFlag string
-	// SilenceForkPRErrors controls whether to comment on Fork PRs when AllowForkPRs = False
-	SilenceForkPRErrors bool
-	// SilenceForkPRErrorsFlag is the name of the flag that controls fork PR's. We use
-	// this in our error message back to the user on a forked PR so they know
-	// how to disable error comment
-	SilenceForkPRErrorsFlag       string
+	ParallelPoolSize              int
 	CommentCommandRunnerByCmd     map[command.Name]command.Runner
 	Drainer                       *Drainer
 	PreWorkflowHooksCommandRunner PreWorkflowHooksCommandRunner
@@ -345,12 +333,9 @@ func (c *DefaultCommandRunner) ensureValidRepoMetadata(
 }
 
 func (c *DefaultCommandRunner) validateCtxAndComment(ctx *command.Context) bool {
-	if !c.AllowForkPRs && ctx.HeadRepo.Owner != ctx.Pull.BaseRepo.Owner {
-		if c.SilenceForkPRErrors {
-			return false
-		}
+	if ctx.HeadRepo.Owner != ctx.Pull.BaseRepo.Owner {
 		ctx.Log.Infof("command was run on a fork pull request which is disallowed")
-		if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, fmt.Sprintf("Atlantis commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", c.AllowForkPRsFlag, c.SilenceForkPRErrorsFlag), ""); err != nil {
+		if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, "Atlantis commands can't be run on fork pull requests.", ""); err != nil {
 			ctx.Log.Errorf("unable to comment: %s", err)
 		}
 		return false

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -264,52 +264,6 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, commentMessage, "")
 }
 
-func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
-	t.Log("if a plan command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
-	vcsClient := setup(t)
-	log := logging.NewNoopLogger(t)
-	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
-	When(eventParsing.ParseGithubPull(&pull)).ThenReturn(modelPull, modelPull.BaseRepo, fixtures.GithubRepo, nil)
-	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
-
-	ch.RunCommentCommand(log, fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Plan}, time.Now())
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
-		matchers.AnyContextContext(),
-		matchers.AnyModelsRepo(),
-		matchers.AnyModelsPullRequest(),
-		matchers.EqModelsCommitStatus(models.SuccessCommitStatus),
-		matchers.EqModelsCommandName(command.Plan),
-		EqInt(0),
-		EqInt(0),
-	)
-}
-
-func TestRunCommentCommandApply_NoProjects_SilenceEnabled(t *testing.T) {
-	t.Log("if an apply command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
-	vcsClient := setup(t)
-	log := logging.NewNoopLogger(t)
-	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
-	When(eventParsing.ParseGithubPull(&pull)).ThenReturn(modelPull, modelPull.BaseRepo, fixtures.GithubRepo, nil)
-	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
-
-	ch.RunCommentCommand(log, fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Apply}, time.Now())
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-	commitUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
-		matchers.AnyContextContext(),
-		matchers.AnyModelsRepo(),
-		matchers.AnyModelsPullRequest(),
-		matchers.EqModelsCommitStatus(models.SuccessCommitStatus),
-		matchers.EqModelsCommandName(command.Apply),
-		EqInt(0),
-		EqInt(0),
-	)
-}
-
 func TestRunCommentCommandApprovePolicy_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if an approve_policy command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -315,19 +315,6 @@ func TestRunCommentCommandApprovePolicy_NoProjects_SilenceEnabled(t *testing.T) 
 	)
 }
 
-func TestRunCommentCommandUnlock_NoProjects_SilenceEnabled(t *testing.T) {
-	t.Log("if an unlock command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
-	vcsClient := setup(t)
-	log := logging.NewNoopLogger(t)
-	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
-	When(eventParsing.ParseGithubPull(&pull)).ThenReturn(modelPull, modelPull.BaseRepo, fixtures.GithubRepo, nil)
-
-	ch.RunCommentCommand(log, fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Unlock}, time.Now())
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-}
-
 func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	t.Log("if \"atlantis apply\" is run and this is disabled atlantis should" +
 		" comment saying that this is not allowed")

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -110,19 +110,15 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 	}
 
 	parallelPoolSize := 1
-	SilenceNoProjects := false
 	policyCheckCommandRunner = events.NewPolicyCheckCommandRunner(
 		dbUpdater,
 		pullUpdater,
 		commitUpdater,
 		projectCommandRunner,
 		parallelPoolSize,
-		false,
 	)
 
 	planCommandRunner = events.NewPlanCommandRunner(
-		false,
-		false,
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
@@ -134,7 +130,6 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		policyCheckCommandRunner,
 		autoMerger,
 		parallelPoolSize,
-		SilenceNoProjects,
 	)
 
 	pullReqStatusFetcher := lyft_vcs.NewSQBasedPullStatusFetcher(githubClient, vcs.NewLyftPullMergeabilityChecker("atlantis"))
@@ -150,8 +145,6 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		pullUpdater,
 		dbUpdater,
 		parallelPoolSize,
-		SilenceNoProjects,
-		false,
 		pullReqStatusFetcher,
 	)
 
@@ -161,14 +154,11 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		projectCommandRunner,
 		pullUpdater,
 		dbUpdater,
-		SilenceNoProjects,
-		false,
 	)
 
 	unlockCommandRunner = events.NewUnlockCommandRunner(
 		deleteLockCommand,
 		vcsClient,
-		SilenceNoProjects,
 	)
 
 	versionCommandRunner := events.NewVersionCommandRunner(
@@ -176,7 +166,6 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		projectCommandBuilder,
 		projectCommandRunner,
 		parallelPoolSize,
-		SilenceNoProjects,
 	)
 
 	commentCommandRunnerByCmd := map[command.Name]command.Runner{
@@ -205,8 +194,6 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		AzureDevopsPullGetter:         azuredevopsGetter,
 		GlobalCfg:                     globalCfg,
 		StatsScope:                    scope,
-		AllowForkPRs:                  false,
-		AllowForkPRsFlag:              "allow-fork-prs-flag",
 		Drainer:                       drainer,
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		PullStatusFetcher:             defaultBoltDB,
@@ -260,9 +247,6 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 		" comment saying that this is not allowed")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	// by default these are false so don't need to reset
-	ch.AllowForkPRs = false
-	ch.SilenceForkPRErrors = false
 	var pull github.PullRequest
 	modelPull := models.PullRequest{
 		BaseRepo: fixtures.GithubRepo,
@@ -276,7 +260,7 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	When(eventParsing.ParseGithubPull(&pull)).ThenReturn(modelPull, modelPull.BaseRepo, headRepo, nil)
 
 	ch.RunCommentCommand(log, fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, nil, time.Now())
-	commentMessage := fmt.Sprintf("Atlantis commands can't be run on fork pull requests. To enable, set --%s  or, to disable this message, set --%s", ch.AllowForkPRsFlag, ch.SilenceForkPRErrorsFlag)
+	commentMessage := "Atlantis commands can't be run on fork pull requests."
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, commentMessage, "")
 }
 
@@ -284,8 +268,6 @@ func TestRunCommentCommand_ForkPRDisabled_SilenceEnabled(t *testing.T) {
 	t.Log("if a command is run on a forked pull request and forks are disabled and we are silencing errors do not comment with error")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	ch.AllowForkPRs = false // by default it's false so don't need to reset
-	ch.SilenceForkPRErrors = true
 	var pull github.PullRequest
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
@@ -303,7 +285,6 @@ func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if a plan command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	planCommandRunner.SilenceNoProjects = true
 	var pull github.PullRequest
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
@@ -327,7 +308,6 @@ func TestRunCommentCommandApply_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if an apply command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	applyCommandRunner.SilenceNoProjects = true
 	var pull github.PullRequest
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
@@ -351,7 +331,6 @@ func TestRunCommentCommandApprovePolicy_NoProjects_SilenceEnabled(t *testing.T) 
 	t.Log("if an approve_policy command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	approvePoliciesCommandRunner.SilenceNoProjects = true
 	var pull github.PullRequest
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
@@ -375,7 +354,6 @@ func TestRunCommentCommandUnlock_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if an unlock command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)
 	log := logging.NewNoopLogger(t)
-	unlockCommandRunner.SilenceNoProjects = true
 	var pull github.PullRequest
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -264,23 +264,6 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, commentMessage, "")
 }
 
-func TestRunCommentCommand_ForkPRDisabled_SilenceEnabled(t *testing.T) {
-	t.Log("if a command is run on a forked pull request and forks are disabled and we are silencing errors do not comment with error")
-	vcsClient := setup(t)
-	log := logging.NewNoopLogger(t)
-	var pull github.PullRequest
-	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
-	When(githubGetter.GetPullRequest(fixtures.GithubRepo, fixtures.Pull.Num)).ThenReturn(&pull, nil)
-
-	headRepo := fixtures.GithubRepo
-	headRepo.FullName = "forkrepo/atlantis"
-	headRepo.Owner = "forkrepo"
-	When(eventParsing.ParseGithubPull(&pull)).ThenReturn(modelPull, modelPull.BaseRepo, headRepo, nil)
-
-	ch.RunCommentCommand(log, fixtures.GithubRepo, nil, nil, fixtures.User, fixtures.Pull.Num, nil, time.Now())
-	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-}
-
 func TestRunCommentCommandPlan_NoProjects_SilenceEnabled(t *testing.T) {
 	t.Log("if a plan command is run on a pull request and SilenceNoProjects is enabled and we are silencing all comments if the modified files don't have a matching project")
 	vcsClient := setup(t)

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -9,8 +9,6 @@ import (
 )
 
 func NewPlanCommandRunner(
-	silenceVCSStatusNoPlans bool,
-	silenceVCSStatusNoProjects bool,
 	vcsClient vcs.Client,
 	pendingPlanFinder PendingPlanFinder,
 	workingDir WorkingDir,
@@ -22,47 +20,34 @@ func NewPlanCommandRunner(
 	policyCheckCommandRunner *PolicyCheckCommandRunner,
 	autoMerger *AutoMerger,
 	parallelPoolSize int,
-	SilenceNoProjects bool,
 ) *PlanCommandRunner {
 	return &PlanCommandRunner{
-		silenceVCSStatusNoPlans:    silenceVCSStatusNoPlans,
-		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
-		vcsClient:                  vcsClient,
-		pendingPlanFinder:          pendingPlanFinder,
-		workingDir:                 workingDir,
-		commitStatusUpdater:        commitStatusUpdater,
-		prjCmdBuilder:              projectCommandBuilder,
-		prjCmdRunner:               projectCommandRunner,
-		dbUpdater:                  dbUpdater,
-		pullUpdater:                pullUpdater,
-		policyCheckCommandRunner:   policyCheckCommandRunner,
-		autoMerger:                 autoMerger,
-		parallelPoolSize:           parallelPoolSize,
-		SilenceNoProjects:          SilenceNoProjects,
+		vcsClient:                vcsClient,
+		pendingPlanFinder:        pendingPlanFinder,
+		workingDir:               workingDir,
+		commitStatusUpdater:      commitStatusUpdater,
+		prjCmdBuilder:            projectCommandBuilder,
+		prjCmdRunner:             projectCommandRunner,
+		dbUpdater:                dbUpdater,
+		pullUpdater:              pullUpdater,
+		policyCheckCommandRunner: policyCheckCommandRunner,
+		autoMerger:               autoMerger,
+		parallelPoolSize:         parallelPoolSize,
 	}
 }
 
 type PlanCommandRunner struct {
-	vcsClient vcs.Client
-	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
-	// are found
-	SilenceNoProjects bool
-	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
-	// are found
-	silenceVCSStatusNoPlans bool
-	// SilenceVCSStatusNoPlans is whether any plan should set commit status if no projects
-	// are found
-	silenceVCSStatusNoProjects bool
-	commitStatusUpdater        CommitStatusUpdater
-	pendingPlanFinder          PendingPlanFinder
-	workingDir                 WorkingDir
-	prjCmdBuilder              ProjectPlanCommandBuilder
-	prjCmdRunner               ProjectPlanCommandRunner
-	dbUpdater                  *DBUpdater
-	pullUpdater                *PullUpdater
-	policyCheckCommandRunner   *PolicyCheckCommandRunner
-	autoMerger                 *AutoMerger
-	parallelPoolSize           int
+	vcsClient                vcs.Client
+	commitStatusUpdater      CommitStatusUpdater
+	pendingPlanFinder        PendingPlanFinder
+	workingDir               WorkingDir
+	prjCmdBuilder            ProjectPlanCommandBuilder
+	prjCmdRunner             ProjectPlanCommandRunner
+	dbUpdater                *DBUpdater
+	pullUpdater              *PullUpdater
+	policyCheckCommandRunner *PolicyCheckCommandRunner
+	autoMerger               *AutoMerger
+	parallelPoolSize         int
 }
 
 func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
@@ -82,20 +67,18 @@ func (p *PlanCommandRunner) runAutoplan(ctx *command.Context) {
 
 	if len(projectCmds) == 0 {
 		ctx.Log.Infof("determined there was no project to run plan in")
-		if !(p.silenceVCSStatusNoPlans || p.silenceVCSStatusNoProjects) {
-			// If there were no projects modified, we set successful commit statuses
-			// with 0/0 projects planned/policy_checked/applied successfully because some users require
-			// the Atlantis status to be passing for all pull requests.
-			ctx.Log.Debugf("setting VCS status to success with no projects found")
-			if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
-			if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
-			if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
+		// If there were no projects modified, we set successful commit statuses
+		// with 0/0 projects planned/policy_checked/applied successfully because some users require
+		// the Atlantis status to be passing for all pull requests.
+		ctx.Log.Debugf("setting VCS status to success with no projects found")
+		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
+		}
+		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
+		}
+		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Apply, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
 		}
 		return
 	}
@@ -163,16 +146,14 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *command.Comment) {
 		return
 	}
 
-	if len(projectCmds) == 0 && p.SilenceNoProjects {
+	if len(projectCmds) == 0 {
 		ctx.Log.Infof("determined there was no project to run plan in")
-		if !p.silenceVCSStatusNoProjects {
-			// If there were no projects modified, we set successful commit statuses
-			// with 0/0 projects planned successfully because some users require
-			// the Atlantis status to be passing for all pull requests.
-			ctx.Log.Debugf("setting VCS status to success with no projects found")
-			if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
+		// If there were no projects modified, we set successful commit statuses
+		// with 0/0 projects planned successfully because some users require
+		// the Atlantis status to be passing for all pull requests.
+		ctx.Log.Debugf("setting VCS status to success with no projects found")
+		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
 		}
 		return
 	}

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -146,18 +146,6 @@ func (p *PlanCommandRunner) run(ctx *command.Context, cmd *command.Comment) {
 		return
 	}
 
-	if len(projectCmds) == 0 {
-		ctx.Log.Infof("determined there was no project to run plan in")
-		// If there were no projects modified, we set successful commit statuses
-		// with 0/0 projects planned successfully because some users require
-		// the Atlantis status to be passing for all pull requests.
-		ctx.Log.Debugf("setting VCS status to success with no projects found")
-		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, command.Plan, 0, 0); err != nil {
-			ctx.Log.Warnf("unable to update commit status: %s", err)
-		}
-		return
-	}
-
 	projectCmds, policyCheckCmds := p.partitionProjectCmds(ctx, projectCmds)
 
 	// Only run commands in parallel if enabled

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -13,15 +13,13 @@ func NewPolicyCheckCommandRunner(
 	commitStatusUpdater CommitStatusUpdater,
 	projectCommandRunner ProjectPolicyCheckCommandRunner,
 	parallelPoolSize int,
-	silenceVCSStatusNoProjects bool,
 ) *PolicyCheckCommandRunner {
 	return &PolicyCheckCommandRunner{
-		dbUpdater:                  dbUpdater,
-		pullUpdater:                pullUpdater,
-		commitStatusUpdater:        commitStatusUpdater,
-		prjCmdRunner:               projectCommandRunner,
-		parallelPoolSize:           parallelPoolSize,
-		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
+		dbUpdater:           dbUpdater,
+		pullUpdater:         pullUpdater,
+		commitStatusUpdater: commitStatusUpdater,
+		prjCmdRunner:        projectCommandRunner,
+		parallelPoolSize:    parallelPoolSize,
 	}
 }
 
@@ -31,22 +29,17 @@ type PolicyCheckCommandRunner struct {
 	commitStatusUpdater CommitStatusUpdater
 	prjCmdRunner        ProjectPolicyCheckCommandRunner
 	parallelPoolSize    int
-	// SilenceVCSStatusNoProjects is whether any plan should set commit status if no projects
-	// are found
-	silenceVCSStatusNoProjects bool
 }
 
 func (p *PolicyCheckCommandRunner) Run(ctx *command.Context, cmds []command.ProjectContext) {
 	if len(cmds) == 0 {
 		ctx.Log.Infof("no projects to run policy_check in")
-		if !p.silenceVCSStatusNoProjects {
-			// If there were no projects modified, we set successful commit statuses
-			// with 0/0 projects policy_checked successfully because some users require
-			// the Atlantis status to be passing for all pull requests.
-			ctx.Log.Debugf("setting VCS status to success with no projects found")
-			if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
-				ctx.Log.Warnf("unable to update commit status: %s", err)
-			}
+		// If there were no projects modified, we set successful commit statuses
+		// with 0/0 projects policy_checked successfully because some users require
+		// the Atlantis status to be passing for all pull requests.
+		ctx.Log.Debugf("setting VCS status to success with no projects found")
+		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+			ctx.Log.Warnf("unable to update commit status: %s", err)
 		}
 		return
 	}

--- a/server/events/unlock_command_runner.go
+++ b/server/events/unlock_command_runner.go
@@ -28,15 +28,10 @@ func (u *UnlockCommandRunner) Run(
 	pullNum := ctx.Pull.Num
 
 	vcsMessage := "All Atlantis locks for this PR have been unlocked and plans discarded"
-	numLocks, err := u.deleteLockCommand.DeleteLocksByPull(baseRepo.FullName, pullNum)
+	_, err := u.deleteLockCommand.DeleteLocksByPull(baseRepo.FullName, pullNum)
 	if err != nil {
 		vcsMessage = "Failed to delete PR locks"
 		ctx.Log.Errorf("failed to delete locks by pull %s", err.Error())
-	}
-
-	// if there are no locks to delete, no errors, and SilenceNoProjects is enabled, don't comment
-	if err == nil && numLocks == 0 {
-		return
 	}
 
 	if commentErr := u.vcsClient.CreateComment(baseRepo, pullNum, vcsMessage, command.Unlock.String()); commentErr != nil {

--- a/server/events/unlock_command_runner.go
+++ b/server/events/unlock_command_runner.go
@@ -8,21 +8,16 @@ import (
 func NewUnlockCommandRunner(
 	deleteLockCommand DeleteLockCommand,
 	vcsClient vcs.Client,
-	SilenceNoProjects bool,
 ) *UnlockCommandRunner {
 	return &UnlockCommandRunner{
 		deleteLockCommand: deleteLockCommand,
 		vcsClient:         vcsClient,
-		SilenceNoProjects: SilenceNoProjects,
 	}
 }
 
 type UnlockCommandRunner struct {
 	vcsClient         vcs.Client
 	deleteLockCommand DeleteLockCommand
-	// SilenceNoProjects is whether Atlantis should respond to PRs if no projects
-	// are found
-	SilenceNoProjects bool
 }
 
 func (u *UnlockCommandRunner) Run(
@@ -40,7 +35,7 @@ func (u *UnlockCommandRunner) Run(
 	}
 
 	// if there are no locks to delete, no errors, and SilenceNoProjects is enabled, don't comment
-	if err == nil && numLocks == 0 && u.SilenceNoProjects {
+	if err == nil && numLocks == 0 {
 		return
 	}
 

--- a/server/events/version_command_runner.go
+++ b/server/events/version_command_runner.go
@@ -9,14 +9,12 @@ func NewVersionCommandRunner(
 	prjCmdBuilder ProjectVersionCommandBuilder,
 	prjCmdRunner ProjectVersionCommandRunner,
 	parallelPoolSize int,
-	silenceVCSStatusNoProjects bool,
 ) *VersionCommandRunner {
 	return &VersionCommandRunner{
-		pullUpdater:                pullUpdater,
-		prjCmdBuilder:              prjCmdBuilder,
-		prjCmdRunner:               prjCmdRunner,
-		parallelPoolSize:           parallelPoolSize,
-		silenceVCSStatusNoProjects: silenceVCSStatusNoProjects,
+		pullUpdater:      pullUpdater,
+		prjCmdBuilder:    prjCmdBuilder,
+		prjCmdRunner:     prjCmdRunner,
+		parallelPoolSize: parallelPoolSize,
 	}
 }
 
@@ -25,9 +23,6 @@ type VersionCommandRunner struct {
 	prjCmdBuilder    ProjectVersionCommandBuilder
 	prjCmdRunner     ProjectVersionCommandRunner
 	parallelPoolSize int
-	// SilenceVCSStatusNoProjects is whether any plan should set commit status if no projects
-	// are found
-	silenceVCSStatusNoProjects bool
 }
 
 func (v *VersionCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -23,29 +23,11 @@ type AutoplanValidator struct {
 	PreWorkflowHooksCommandRunner events.PreWorkflowHooksCommandRunner
 	Drainer                       *events.Drainer
 	GlobalCfg                     valid.GlobalCfg
-	// AllowForkPRs controls whether we operate on pull requests from forks.
-	AllowForkPRs bool
-	// AllowForkPRsFlag is the name of the flag that controls fork PR's. We use
-	// this in our error message back to the user on a forked PR so they know
-	// how to enable this functionality.
-	AllowForkPRsFlag string
-	// SilenceForkPRErrors controls whether to comment on Fork PRs when AllowForkPRs = False
-	SilenceForkPRErrors bool
-	// SilenceForkPRErrorsFlag is the name of the flag that controls fork PR's. We use
-	// this in our error message back to the user on a forked PR so they know
-	// how to disable error comment
-	SilenceForkPRErrorsFlag string
-	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
-	// are found
-	SilenceVCSStatusNoPlans bool
-	// SilenceVCSStatusNoPlans is whether any plan should set commit status if no projects
-	// are found
-	SilenceVCSStatusNoProjects bool
-	CommitStatusUpdater        events.CommitStatusUpdater
-	PrjCmdBuilder              events.ProjectPlanCommandBuilder
-	PullUpdater                *events.PullUpdater
-	WorkingDir                 events.WorkingDir
-	WorkingDirLocker           events.WorkingDirLocker
+	CommitStatusUpdater           events.CommitStatusUpdater
+	PrjCmdBuilder                 events.ProjectPlanCommandBuilder
+	PullUpdater                   *events.PullUpdater
+	WorkingDir                    events.WorkingDir
+	WorkingDirLocker              events.WorkingDirLocker
 }
 
 const DefaultWorkspace = "default"
@@ -150,10 +132,7 @@ func (r *AutoplanValidator) logPanics(logger logging.SimpleLogging) {
 }
 
 func (r *AutoplanValidator) validateCtxAndComment(ctx *command.Context) bool {
-	if !r.AllowForkPRs && ctx.HeadRepo.Owner != ctx.Pull.BaseRepo.Owner {
-		if r.SilenceForkPRErrors {
-			return false
-		}
+	if ctx.HeadRepo.Owner != ctx.Pull.BaseRepo.Owner {
 		ctx.Log.Infof("command was run on a fork pull request which is disallowed")
 		return false
 	}

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -50,7 +50,6 @@ func setupAutoplan(t *testing.T) *vcsmocks.MockClient {
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		Drainer:                       drainer,
 		GlobalCfg:                     globalCfg,
-		AllowForkPRsFlag:              "allow-fork-prs-flag",
 		PullUpdater:                   pullUpdater,
 		PrjCmdBuilder:                 projectCommandBuilder,
 		CommitStatusUpdater:           commitStatusUpdater,

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -75,7 +75,7 @@ func (g *VCSEventsController) handleGithubPost(w http.ResponseWriter, r *http.Re
 		return
 	}
 	event, _ := github.ParseWebHook(github.WebHookType(r), payload)
-	githubReqID := "X-Github-Delivery=" + r.Header.Get("X-Github-Delivery")
+	githubReqID := r.Header.Get("X-Github-Delivery")
 	logger := g.Logger.With("gh-request-id", githubReqID)
 	scope := g.Scope.SubScope("github.event")
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -49,9 +49,6 @@ type VCSEventsController struct {
 	GithubWebhookSecret    []byte
 	GithubRequestValidator events_controllers.GithubRequestValidator
 	RepoAllowlistChecker   *events.RepoAllowlistChecker
-	// SilenceAllowlistErrors controls whether we write an error comment on
-	// pull requests from non-allowlisted repos.
-	SilenceAllowlistErrors bool
 	VCSClient              vcs.Client
 	SNSWriter              sns.Writer
 	AutoplanValidator      EventValidator
@@ -288,8 +285,5 @@ func (g *VCSEventsController) respond(w http.ResponseWriter, lvl logging.LogLeve
 // commentNotAllowlisted comments on the pull request that the repo is not
 // allowlisted unless allowlist error comments are disabled.
 func (g *VCSEventsController) commentNotAllowlisted(logger logging.SimpleLogging, baseRepo models.Repo, pullNum int) {
-	if g.SilenceAllowlistErrors {
-		return
-	}
 	logger.With("repository", baseRepo.FullName, "pull-num", pullNum).Errorf("This repo is not allowlisted for Atlantis")
 }

--- a/server/lyft/gateway/events_controller_test.go
+++ b/server/lyft/gateway/events_controller_test.go
@@ -118,35 +118,6 @@ func TestPost_GithubCommentNotAllowlisted(t *testing.T) {
 	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
 }
 
-func TestPost_GithubCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
-	t.Log("when the event is a github comment from a repo that isn't allowlisted and we are silencing errors, do not comment with an error")
-	RegisterMockTestingT(t)
-	vcsClient := vcsmocks.NewMockClient()
-	logger := logging.NewNoopLogger(t)
-	scope, _, _ := metrics.NewLoggingScope(logger, "null")
-	e := gateway.VCSEventsController{
-		Logger:                 logger,
-		Scope:                  scope,
-		GithubRequestValidator: &events_controllers.DefaultGithubRequestValidator{},
-		CommentParser:          &events.CommentParser{},
-		Parser:                 &events.EventParser{},
-		RepoAllowlistChecker:   &events.RepoAllowlistChecker{},
-		VCSClient:              vcsClient,
-	}
-	requestJSON, err := ioutil.ReadFile(filepath.Join("../../controllers/events/testfixtures", "githubIssueCommentEvent_notAllowlisted.json"))
-	Ok(t, err)
-	req, _ := http.NewRequest("GET", "", bytes.NewBuffer(requestJSON))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(gateway.GithubHeader, "issue_comment")
-	w := httptest.NewRecorder()
-	e.Post(w, req)
-
-	Equals(t, http.StatusForbidden, w.Result().StatusCode)
-	body, _ := ioutil.ReadAll(w.Result().Body)
-	exp := "Repo not allowlisted"
-	Assert(t, strings.Contains(string(body), exp), "exp %q to be contained in %q", exp, string(body))
-}
-
 func TestPost_GithubCommentResponse(t *testing.T) {
 	t.Log("when the event is a github comment that warrants a comment response we comment back")
 	e, v, _, p, _, _, vcsClient, cp, _, _ := setup(t)

--- a/server/lyft/gateway/events_controller_test.go
+++ b/server/lyft/gateway/events_controller_test.go
@@ -132,7 +132,6 @@ func TestPost_GithubCommentNotAllowlistedWithSilenceErrors(t *testing.T) {
 		Parser:                 &events.EventParser{},
 		RepoAllowlistChecker:   &events.RepoAllowlistChecker{},
 		VCSClient:              vcsClient,
-		SilenceAllowlistErrors: true,
 	}
 	requestJSON, err := ioutil.ReadFile(filepath.Join("../../controllers/events/testfixtures", "githubIssueCommentEvent_notAllowlisted.json"))
 	Ok(t, err)

--- a/server/server.go
+++ b/server/server.go
@@ -129,12 +129,10 @@ type Server struct {
 
 // Config holds config for server that isn't passed in by the user.
 type Config struct {
-	AllowForkPRsFlag        string
-	AtlantisURLFlag         string
-	AtlantisVersion         string
-	DefaultTFVersionFlag    string
-	RepoConfigJSONFlag      string
-	SilenceForkPRErrorsFlag string
+	AtlantisURLFlag      string
+	AtlantisVersion      string
+	DefaultTFVersionFlag string
+	RepoConfigJSONFlag   string
 }
 
 // WebhookConfig is nested within UserConfig. It's used to configure webhooks.
@@ -718,12 +716,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		commitStatusUpdater,
 		prjCmdRunner,
 		userConfig.ParallelPoolSize,
-		userConfig.SilenceVCSStatusNoProjects,
 	)
 
 	planCommandRunner := events.NewPlanCommandRunner(
-		userConfig.SilenceVCSStatusNoPlans,
-		userConfig.SilenceVCSStatusNoProjects,
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
@@ -735,7 +730,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		policyCheckCommandRunner,
 		autoMerger,
 		userConfig.ParallelPoolSize,
-		userConfig.SilenceNoProjects,
 	)
 
 	applyCommandRunner := events.NewApplyCommandRunner(
@@ -749,8 +743,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		pullUpdater,
 		dbUpdater,
 		userConfig.ParallelPoolSize,
-		userConfig.SilenceNoProjects,
-		userConfig.SilenceVCSStatusNoProjects,
 		pullReqStatusFetcher,
 	)
 
@@ -760,14 +752,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		prjCmdRunner,
 		pullUpdater,
 		dbUpdater,
-		userConfig.SilenceNoProjects,
-		userConfig.SilenceVCSStatusNoPlans,
 	)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(
 		deleteLockCommand,
 		vcsClient,
-		userConfig.SilenceNoProjects,
 	)
 
 	versionCommandRunner := events.NewVersionCommandRunner(
@@ -775,12 +764,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		projectCommandBuilder,
 		prjCmdRunner,
 		userConfig.ParallelPoolSize,
-		userConfig.SilenceNoProjects,
 	)
 
 	prPlanCommandRunner := events.NewPlanCommandRunner(
-		userConfig.SilenceVCSStatusNoPlans,
-		userConfig.SilenceVCSStatusNoProjects,
 		vcsClient,
 		pendingPlanFinder,
 		workingDir,
@@ -792,7 +778,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		policyCheckCommandRunner,
 		autoMerger,
 		userConfig.ParallelPoolSize,
-		userConfig.SilenceNoProjects,
 	)
 
 	prApprovePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(
@@ -801,8 +786,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		prPrjCmdRunner,
 		pullUpdater,
 		dbUpdater,
-		userConfig.SilenceNoProjects,
-		userConfig.SilenceVCSStatusNoPlans,
 	)
 
 	featuredPlanRunner := lyftCommands.NewPlatformModeFeatureRunner(
@@ -849,10 +832,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		EventParser:                   eventParser,
 		GlobalCfg:                     globalCfg,
 		StatsScope:                    cmdStatsScope,
-		AllowForkPRs:                  userConfig.AllowForkPRs,
-		AllowForkPRsFlag:              config.AllowForkPRsFlag,
-		SilenceForkPRErrors:           userConfig.SilenceForkPRErrors,
-		SilenceForkPRErrorsFlag:       config.SilenceForkPRErrorsFlag,
 		DisableAutoplan:               userConfig.DisableAutoplan,
 		Drainer:                       drainer,
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
@@ -957,12 +936,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		Drainer:                       drainer,
 		GlobalCfg:                     globalCfg,
-		AllowForkPRs:                  userConfig.AllowForkPRs,
-		AllowForkPRsFlag:              config.AllowForkPRsFlag,
-		SilenceForkPRErrors:           userConfig.SilenceForkPRErrors,
-		SilenceForkPRErrorsFlag:       config.SilenceForkPRErrorsFlag,
-		SilenceVCSStatusNoPlans:       userConfig.SilenceVCSStatusNoPlans,
-		SilenceVCSStatusNoProjects:    userConfig.SilenceVCSStatusNoProjects,
 		CommitStatusUpdater:           commitStatusUpdater,
 		PrjCmdBuilder:                 projectCommandBuilder,
 		PullUpdater:                   pullUpdater,
@@ -977,7 +950,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubWebhookSecret:    []byte(userConfig.GithubWebhookSecret),
 		GithubRequestValidator: &events_controllers.DefaultGithubRequestValidator{},
 		RepoAllowlistChecker:   repoAllowlist,
-		SilenceAllowlistErrors: userConfig.SilenceAllowlistErrors,
 		VCSClient:              vcsClient,
 		SNSWriter:              gatewaySnsWriter,
 		AutoplanValidator:      autoplanValidator,
@@ -995,7 +967,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GitlabRequestParserValidator:    &events_controllers.DefaultGitlabRequestParserValidator{},
 		GitlabWebhookSecret:             []byte(userConfig.GitlabWebhookSecret),
 		RepoAllowlistChecker:            repoAllowlist,
-		SilenceAllowlistErrors:          userConfig.SilenceAllowlistErrors,
 		SupportedVCSHosts:               supportedVCSHosts,
 		VCSClient:                       vcsClient,
 		BitbucketWebhookSecret:          []byte(userConfig.BitbucketWebhookSecret),

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -17,7 +17,6 @@ const (
 // The mapstructure tags correspond to flags in cmd/server.go and are used when
 // the config is parsed from a YAML file.
 type UserConfig struct {
-	AllowForkPRs               bool   `mapstructure:"allow-fork-prs"`
 	AllowRepoConfig            bool   `mapstructure:"allow-repo-config"`
 	AtlantisURL                string `mapstructure:"atlantis-url"`
 	Automerge                  bool   `mapstructure:"automerge"`
@@ -77,24 +76,12 @@ type UserConfig struct {
 	// RequireMergeable is whether to require pull requests to be mergeable before
 	// allowing terraform apply's to run.
 	RequireMergeable bool `mapstructure:"require-mergeable"`
-	// SilenceNoProjects is whether Atlantis should respond to a PR if no projects are found.
-	SilenceNoProjects bool `mapstructure:"silence-no-projects"`
 	// RequireUnDiverged is whether to require pull requests to rebase default branch before
 	// allowing terraform apply's to run.
 	RequireUnDiverged bool `mapstructure:"require-undiverged"`
 	// RequireSQUnlocked is whether to require pull requests to be unlocked before running
 	// terraform apply.
-	RequireSQUnlocked   bool `mapstructure:"require-unlocked"`
-	SilenceForkPRErrors bool `mapstructure:"silence-fork-pr-errors"`
-	// SilenceVCSStatusNoPlans is whether autoplan should set commit status if no plans
-	// are found.
-	SilenceVCSStatusNoPlans bool `mapstructure:"silence-vcs-status-no-plans"`
-	// SilenceVCSStatusNoProjects is whether autoplan should set commit status if no projects
-	// are found.
-	SilenceVCSStatusNoProjects bool `mapstructure:"silence-vcs-status-no-projects"`
-	SilenceAllowlistErrors     bool `mapstructure:"silence-allowlist-errors"`
-	// SilenceWhitelistErrors is deprecated in favour of SilenceAllowlistErrors
-	SilenceWhitelistErrors   bool            `mapstructure:"silence-whitelist-errors"`
+	RequireSQUnlocked        bool            `mapstructure:"require-unlocked"`
 	SkipCloneNoChanges       bool            `mapstructure:"skip-clone-no-changes"`
 	SlackToken               string          `mapstructure:"slack-token"`
 	SSLCertFile              string          `mapstructure:"ssl-cert-file"`


### PR DESCRIPTION
Also removes fork related flags.  

None of this is needed in our world and in general since we don't want to comment errors to PRs going forward, this just adds so much bloat.