### PR TITLE
Thread ctx through to the command runner.

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -110,7 +110,6 @@ func NewVCSEventsController(
 		vcsClient,
 		commandRunner,
 		logger,
-		legacyLogger,
 	)
 
 	// lazy map of resolver providers to their resolver
@@ -118,7 +117,7 @@ func NewVCSEventsController(
 	providerResolverInitializer := map[models.VCSHostType]func() RequestResolver{
 		models.Github: func() RequestResolver {
 			return github_request.NewHandler(
-				legacyLogger,
+				logger,
 				scope,
 				githubWebhookSecret,
 				commentHandler,

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -927,6 +927,8 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		PullStatusFetcher:             boltdb,
 		StaleCommandChecker:           staleCommandChecker,
+		Logger:                        ctxLogger,
+		LegacyLogger:                  logger,
 	}
 
 	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")
@@ -934,7 +936,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 
 	autoplanner := &handlers.Autoplanner{
 		CommandRunner: commandRunner,
-		Logger:        logger,
 	}
 
 	pullCleaner := &events.PullClosedExecutor{
@@ -966,7 +967,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		// Use synchronous handler for testing purposes
 		&handlers.CommandHandler{
 			CommandRunner: commandRunner,
-			Logger:        logger,
 		},
 		ctxLogger,
 	)
@@ -983,7 +983,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 	requestRouter := &events_controllers.RequestRouter{
 		Resolvers: []events_controllers.RequestResolver{
 			request.NewHandler(
-				logger,
+				ctxLogger,
 				statsScope,
 				nil,
 				commentHandler,

--- a/server/controllers/events/handlers/comment.go
+++ b/server/controllers/events/handlers/comment.go
@@ -28,14 +28,12 @@ func NewCommentEvent(
 	commentCreator commentCreator,
 	commandRunner events.CommandRunner,
 	logger logging.Logger,
-	legacyLogger logging.SimpleLogging,
 ) *CommentEvent {
 	return &CommentEvent{
 		commentParser: commentParser,
 		commandHandler: &asyncHandler{
 			commandHandler: &CommandHandler{
 				CommandRunner: commandRunner,
-				Logger:        legacyLogger,
 			},
 			logger: logger,
 		},
@@ -71,12 +69,11 @@ type commandHandler interface {
 
 type CommandHandler struct {
 	CommandRunner events.CommandRunner
-	Logger        logging.SimpleLogging
 }
 
 func (h *CommandHandler) Handle(ctx context.Context, _ *http.CloneableRequest, event event_types.Comment, command *command.Comment) error {
 	h.CommandRunner.RunCommentCommand(
-		h.Logger,
+		ctx,
 		event.BaseRepo,
 		event.MaybeHeadRepo,
 		event.MaybePull,

--- a/server/controllers/events/handlers/pull_request.go
+++ b/server/controllers/events/handlers/pull_request.go
@@ -18,12 +18,11 @@ type eventTypeHandler interface {
 
 type Autoplanner struct {
 	CommandRunner events.CommandRunner
-	Logger        logging.SimpleLogging
 }
 
 func (p *Autoplanner) Handle(ctx context.Context, _ *http.CloneableRequest, event event_types.PullRequest) error {
 	p.CommandRunner.RunAutoplanCommand(
-		p.Logger,
+		ctx,
 		event.Pull.BaseRepo,
 		event.Pull.HeadRepo,
 		event.Pull,
@@ -34,13 +33,19 @@ func (p *Autoplanner) Handle(ctx context.Context, _ *http.CloneableRequest, even
 	return nil
 }
 
-type AsyncAutoplanner struct {
-	Autoplanner *Autoplanner
+type asyncAutoplanner struct {
+	autoplanner *Autoplanner
+	logger      logging.Logger
 }
 
-func (p *AsyncAutoplanner) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.PullRequest) error {
-	go p.Autoplanner.Handle(ctx, request, event)
+func (p *asyncAutoplanner) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.PullRequest) error {
+	go func() {
+		err := p.autoplanner.Handle(ctx, request, event)
 
+		if err != nil {
+			p.logger.ErrorContext(ctx, err.Error())
+		}
+	}()
 	return nil
 }
 
@@ -64,8 +69,8 @@ func NewPullRequestEvent(
 	pullCleaner events.PullCleaner,
 	logger logging.Logger,
 	commandRunner events.CommandRunner) *PullRequestEvent {
-	asyncAutoplanner := &AsyncAutoplanner{
-		Autoplanner: &Autoplanner{
+	asyncAutoplanner := &asyncAutoplanner{
+		autoplanner: &Autoplanner{
 			CommandRunner: commandRunner,
 		},
 	}

--- a/server/controllers/events/handlers/pull_request.go
+++ b/server/controllers/events/handlers/pull_request.go
@@ -73,6 +73,7 @@ func NewPullRequestEvent(
 		autoplanner: &Autoplanner{
 			CommandRunner: commandRunner,
 		},
+		logger: logger,
 	}
 	return &PullRequestEvent{
 		RepoAllowlistChecker:    repoAllowlistChecker,

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -80,7 +80,7 @@ func (c *InstrumentedGithubClient) GetContents(owner, repo, branch, path string)
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Debug("fetched contents", map[string]interface{}{
-		logging.RepositoryKey: repo,
+		logging.RepositoryKey.String(): repo,
 	})
 
 	return contents, err
@@ -110,8 +110,8 @@ func (c *InstrumentedGithubClient) GetPullRequestFromName(repoName string, repoO
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Debug("fetched pull request", map[string]interface{}{
-		logging.RepositoryKey: fmt.Sprintf("%s/%s", repoOwner, repoName),
-		logging.PullNumKey:    strconv.Itoa(pullNum),
+		logging.RepositoryKey.String(): fmt.Sprintf("%s/%s", repoOwner, repoName),
+		logging.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 
 	return pull, err
@@ -213,8 +213,8 @@ func (c *InstrumentedClient) CreateComment(repo models.Repo, pullNum int, commen
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Debug("created pull request comment", map[string]interface{}{
-		logging.RepositoryKey: repo.FullName,
-		logging.PullNumKey:    strconv.Itoa(pullNum),
+		logging.RepositoryKey.String(): repo.FullName,
+		logging.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 	return nil
 }
@@ -236,8 +236,8 @@ func (c *InstrumentedClient) HidePrevCommandComments(repo models.Repo, pullNum i
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Debug("hid previous comments", map[string]interface{}{
-		logging.RepositoryKey: repo.FullName,
-		logging.PullNumKey:    strconv.Itoa(pullNum),
+		logging.RepositoryKey.String(): repo.FullName,
+		logging.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 	return nil
 
@@ -307,11 +307,11 @@ func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.Upd
 	// for now keeping this at info to debug weirdness we've been
 	// seeing with status api calls.
 	c.Logger.Info("updated vcs status", map[string]interface{}{
-		logging.RepositoryKey: request.Repo.FullName,
-		logging.PullNumKey:    strconv.Itoa(request.PullNum),
-		logging.SHAKey:        request.Ref,
-		"status-name":         request.StatusName,
-		"state":               request.State.String(),
+		logging.RepositoryKey.String(): request.Repo.FullName,
+		logging.PullNumKey.String():    strconv.Itoa(request.PullNum),
+		logging.SHAKey.String():        request.Ref,
+		"status-name":                  request.StatusName,
+		"state":                        request.State.String(),
 	})
 
 	executionSuccess.Inc(1)

--- a/server/logging/fields/repo.go
+++ b/server/logging/fields/repo.go
@@ -13,20 +13,20 @@ import (
 
 func Repo(repo models.Repo) map[string]interface{} {
 	return map[string]interface{}{
-		logging.RepositoryKey: repo.FullName,
+		logging.RepositoryKey.String(): repo.FullName,
 	}
 }
 
 func PullRequest(pull models.PullRequest) map[string]interface{} {
 	return map[string]interface{}{
-		logging.RepositoryKey: pull.BaseRepo.FullName,
-		logging.PullNumKey:    strconv.Itoa(pull.Num),
-		logging.SHAKey:        pull.HeadCommit,
+		logging.RepositoryKey.String(): pull.BaseRepo.FullName,
+		logging.PullNumKey.String():    strconv.Itoa(pull.Num),
+		logging.SHAKey.String():        pull.HeadCommit,
 	}
 }
 
 func PullRequestWithErr(pull models.PullRequest, err error) map[string]interface{} {
 	kv := PullRequest(pull)
-	kv[logging.Err] = err
+	kv[logging.Err.String()] = err
 	return kv
 }

--- a/server/logging/logger.go
+++ b/server/logging/logger.go
@@ -26,13 +26,19 @@ import (
 	"logur.dev/logur"
 )
 
+type ContextKey string
+
+func (c ContextKey) String() string {
+	return string(c)
+}
+
 const (
-	RequestIDKey  = "gh-request-id"
-	RepositoryKey = "repository"
-	SHAKey        = "sha"
-	PullNumKey    = "pull-num"
-	ProjectKey    = "project"
-	Err           = "err"
+	RequestIDKey  = ContextKey("gh-request-id")
+	RepositoryKey = ContextKey("repository")
+	SHAKey        = ContextKey("sha")
+	PullNumKey    = ContextKey("pull-num")
+	ProjectKey    = ContextKey("project")
+	Err           = ContextKey("err")
 )
 
 // Logger is the logging interface used throughout the code.
@@ -76,9 +82,9 @@ func NewLoggerFromLevel(lvl LogLevel) (*logger, error) {
 func extractFields(ctx context.Context) map[string]interface{} {
 	args := make(map[string]interface{})
 
-	for _, k := range []string{RequestIDKey, RepositoryKey, PullNumKey, ProjectKey, SHAKey} {
+	for _, k := range []ContextKey{RequestIDKey, RepositoryKey, PullNumKey, ProjectKey, SHAKey} {
 		if v, ok := ctx.Value(k).(string); ok {
-			args[k] = v
+			args[k.String()] = v
 		}
 	}
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -60,7 +60,7 @@ func NewVCSEventsController(
 	providerResolverInitializer := map[models.VCSHostType]func() events_controllers.RequestResolver{
 		models.Github: func() events_controllers.RequestResolver {
 			return request.NewHandler(
-				legacyLogger,
+				logger,
 				scope,
 				webhookSecret,
 				commentHandler,

--- a/server/server.go
+++ b/server/server.go
@@ -839,6 +839,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		StaleCommandChecker:           staleCommandChecker,
 		CommitStatusUpdater:           commitStatusUpdater,
 		Logger:                        ctxLogger,
+		LegacyLogger:                  logger,
 	}
 
 	forceApplyCommandRunner := &events.ForceApplyCommandRunner{

--- a/server/vcs/provider/github/request/handler_test.go
+++ b/server/vcs/provider/github/request/handler_test.go
@@ -87,8 +87,8 @@ func TestHandle_CommentEvent(t *testing.T) {
 	secret := "secret"
 	eventTimestamp := time.Now()
 
-	log := logging.NewNoopLogger(t)
-	scope, _, err := metrics.NewLoggingScope(log, "atlantis")
+	log := logging.NewNoopCtxLogger(t)
+	scope, _, err := metrics.NewLoggingScope(logging.NewNoopLogger(t), "atlantis")
 	assert.NoError(t, err)
 
 	rawRequest, err := http.NewRequestWithContext(
@@ -210,8 +210,8 @@ func TestHandle_PREvent(t *testing.T) {
 	secret := "secret"
 	eventTimestamp := time.Now()
 
-	log := logging.NewNoopLogger(t)
-	scope, _, err := metrics.NewLoggingScope(log, "atlantis")
+	log := logging.NewNoopCtxLogger(t)
+	scope, _, err := metrics.NewLoggingScope(logging.NewNoopLogger(t), "atlantis")
 	assert.NoError(t, err)
 
 	rawRequest, err := http.NewRequestWithContext(


### PR DESCRIPTION
this also adds request id, repo, pull to the ctx so that our logger can extract it.  As of this PR, both the legacy logger and new logger should log the correct fields.