### PR TITLE
Fix issue with multiple request body reads.

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -52,11 +52,11 @@ const bitbucketServerRequestIDHeader = "X-Request-ID"
 const bitbucketServerSignatureHeader = "X-Hub-Signature"
 
 type commentEventHandler interface {
-	Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.Comment) error
+	Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.Comment) error
 }
 
 type prEventHandler interface {
-	Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.PullRequest) error
+	Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.PullRequest) error
 }
 
 func NewRequestResolvers(
@@ -155,11 +155,11 @@ func NewVCSEventsController(
 }
 
 type RequestHandler interface {
-	Handle(request *httputils.CloneableRequest) error
+	Handle(request *httputils.BufferedRequest) error
 }
 
 type RequestMatcher interface {
-	Matches(request *httputils.CloneableRequest) bool
+	Matches(request *httputils.BufferedRequest) bool
 }
 
 type RequestResolver interface {
@@ -174,7 +174,7 @@ type RequestRouter struct {
 
 func (p *RequestRouter) Route(w http.ResponseWriter, r *http.Request) {
 	// we do this to allow for multiple reads to the request body
-	request, err := httputils.NewCloneableRequest(r)
+	request, err := httputils.NewBufferedRequest(r)
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -407,7 +407,7 @@ func (e *VCSEventsController) HandleBitbucketCloudCommentEvent(w http.ResponseWr
 	}
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -440,7 +440,7 @@ func (e *VCSEventsController) HandleBitbucketServerCommentEvent(w http.ResponseW
 	}
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -476,7 +476,7 @@ func (e *VCSEventsController) handleBitbucketCloudPullRequestEvent(w http.Respon
 	//TODO: move this to the outer most function similar to github
 	lvl := logging.Debug
 
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -506,7 +506,7 @@ func (e *VCSEventsController) handleBitbucketServerPullRequestEvent(w http.Respo
 	e.Logger.Infof("identified event as type %q", pullEventType.String())
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -560,7 +560,7 @@ func (e *VCSEventsController) HandleGitlabCommentEvent(w http.ResponseWriter, ev
 	}
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -597,7 +597,7 @@ func (e *VCSEventsController) HandleGitlabMergeRequestEvent(w http.ResponseWrite
 	eventTimestamp := time.Now()
 
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -647,7 +647,7 @@ func (e *VCSEventsController) HandleAzureDevopsPullRequestCommentedEvent(w http.
 	}
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return
@@ -700,7 +700,7 @@ func (e *VCSEventsController) HandleAzureDevopsPullRequestEvent(w http.ResponseW
 	e.Logger.Infof("identified event as type %q", pullEventType.String())
 	eventTimestamp := time.Now()
 	lvl := logging.Debug
-	cloneableRequest, err := httputils.NewCloneableRequest(request)
+	cloneableRequest, err := httputils.NewBufferedRequest(request)
 	if err != nil {
 		e.respond(w, lvl, http.StatusInternalServerError, err.Error())
 		return

--- a/server/controllers/events/events_controller_test.go
+++ b/server/controllers/events/events_controller_test.go
@@ -304,12 +304,12 @@ func setup(t *testing.T) (events_controllers.VCSEventsController, *mocks.MockGit
 // atm.
 type noopPRHandler struct{}
 
-func (h noopPRHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.PullRequest) error {
+func (h noopPRHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.PullRequest) error {
 	return nil
 }
 
 type noopCommentHandler struct{}
 
-func (h noopCommentHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.Comment) error {
+func (h noopCommentHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.Comment) error {
 	return nil
 }

--- a/server/controllers/events/handlers/comment.go
+++ b/server/controllers/events/handlers/comment.go
@@ -64,14 +64,14 @@ func NewCommentEventWithCommandHandler(
 // commandHandler is the handler responsible for running a specific command
 // after it's been parsed from a comment.
 type commandHandler interface {
-	Handle(ctx context.Context, request *http.CloneableRequest, event event_types.Comment, command *command.Comment) error
+	Handle(ctx context.Context, request *http.BufferedRequest, event event_types.Comment, command *command.Comment) error
 }
 
 type CommandHandler struct {
 	CommandRunner events.CommandRunner
 }
 
-func (h *CommandHandler) Handle(ctx context.Context, _ *http.CloneableRequest, event event_types.Comment, command *command.Comment) error {
+func (h *CommandHandler) Handle(ctx context.Context, _ *http.BufferedRequest, event event_types.Comment, command *command.Comment) error {
 	h.CommandRunner.RunCommentCommand(
 		ctx,
 		event.BaseRepo,
@@ -90,7 +90,7 @@ type asyncHandler struct {
 	logger         logging.Logger
 }
 
-func (h *asyncHandler) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.Comment, command *command.Comment) error {
+func (h *asyncHandler) Handle(ctx context.Context, request *http.BufferedRequest, event event_types.Comment, command *command.Comment) error {
 	go func() {
 		err := h.commandHandler.Handle(ctx, request, event, command)
 
@@ -109,7 +109,7 @@ type CommentEvent struct {
 	logger               logging.Logger
 }
 
-func (h *CommentEvent) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.Comment) error {
+func (h *CommentEvent) Handle(ctx context.Context, request *http.BufferedRequest, event event_types.Comment) error {
 	comment := event.Comment
 	vcsHost := event.VCSHost
 	baseRepo := event.BaseRepo

--- a/server/controllers/events/handlers/comment_test.go
+++ b/server/controllers/events/handlers/comment_test.go
@@ -32,12 +32,12 @@ func (p *testCommentParser) Parse(comment string, vcsHost models.VCSHostType) ev
 
 type assertingCommentHandler struct {
 	expectedEvent   event_types.Comment
-	expectedRequest *httputils.CloneableRequest
+	expectedRequest *httputils.BufferedRequest
 	expectedCommand *command.Comment
 	t               *testing.T
 }
 
-func (h *assertingCommentHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.Comment, command *command.Comment) error {
+func (h *assertingCommentHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.Comment, command *command.Comment) error {
 	assert.Equal(h.t, h.expectedRequest, request)
 	assert.Equal(h.t, h.expectedEvent, event)
 	assert.Equal(h.t, h.expectedCommand, command)
@@ -57,7 +57,7 @@ func TestCommentHandler(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	request, err := httputils.NewCloneableRequest(rawRequest)
+	request, err := httputils.NewBufferedRequest(rawRequest)
 	assert.NoError(t, err)
 
 	event := event_types.Comment{}

--- a/server/controllers/events/handlers/pull_request.go
+++ b/server/controllers/events/handlers/pull_request.go
@@ -13,14 +13,14 @@ import (
 )
 
 type eventTypeHandler interface {
-	Handle(ctx context.Context, request *http.CloneableRequest, event event_types.PullRequest) error
+	Handle(ctx context.Context, request *http.BufferedRequest, event event_types.PullRequest) error
 }
 
 type Autoplanner struct {
 	CommandRunner events.CommandRunner
 }
 
-func (p *Autoplanner) Handle(ctx context.Context, _ *http.CloneableRequest, event event_types.PullRequest) error {
+func (p *Autoplanner) Handle(ctx context.Context, _ *http.BufferedRequest, event event_types.PullRequest) error {
 	p.CommandRunner.RunAutoplanCommand(
 		ctx,
 		event.Pull.BaseRepo,
@@ -38,7 +38,7 @@ type asyncAutoplanner struct {
 	logger      logging.Logger
 }
 
-func (p *asyncAutoplanner) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.PullRequest) error {
+func (p *asyncAutoplanner) Handle(ctx context.Context, request *http.BufferedRequest, event event_types.PullRequest) error {
 	go func() {
 		err := p.autoplanner.Handle(ctx, request, event)
 
@@ -54,7 +54,7 @@ type PullCleaner struct {
 	Logger      logging.Logger
 }
 
-func (c *PullCleaner) Handle(ctx context.Context, _ *http.CloneableRequest, event event_types.PullRequest) error {
+func (c *PullCleaner) Handle(ctx context.Context, _ *http.BufferedRequest, event event_types.PullRequest) error {
 	if err := c.PullCleaner.CleanUpPull(event.Pull.BaseRepo, event.Pull); err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ type PullRequestEvent struct {
 	ClosedPullEventHandler  eventTypeHandler
 }
 
-func (h *PullRequestEvent) Handle(ctx context.Context, request *http.CloneableRequest, event event_types.PullRequest) error {
+func (h *PullRequestEvent) Handle(ctx context.Context, request *http.BufferedRequest, event event_types.PullRequest) error {
 	pull := event.Pull
 	baseRepo := pull.BaseRepo
 	eventType := event.EventType

--- a/server/controllers/events/handlers/pull_request_test.go
+++ b/server/controllers/events/handlers/pull_request_test.go
@@ -16,11 +16,11 @@ import (
 
 type assertingPRHandler struct {
 	expectedEvent   event_types.PullRequest
-	expectedRequest *httputils.CloneableRequest
+	expectedRequest *httputils.BufferedRequest
 	t               *testing.T
 }
 
-func (h *assertingPRHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, event event_types.PullRequest) error {
+func (h *assertingPRHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, event event_types.PullRequest) error {
 	assert.Equal(h.t, h.expectedRequest, request)
 	assert.Equal(h.t, h.expectedEvent, event)
 
@@ -35,7 +35,7 @@ func TestPREventHandler(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	request, err := httputils.NewCloneableRequest(rawRequest)
+	request, err := httputils.NewBufferedRequest(rawRequest)
 	assert.NoError(t, err)
 
 	event := event_types.PullRequest{

--- a/server/http/request_test.go
+++ b/server/http/request_test.go
@@ -1,0 +1,60 @@
+package http_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	httputil "github.com/runatlantis/atlantis/server/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBody(t *testing.T) {
+	requestBody := "body"
+	rawRequest, err := http.NewRequest(http.MethodPost, "", io.NopCloser(bytes.NewBuffer([]byte(requestBody))))
+	assert.NoError(t, err)
+
+	subject, err := httputil.NewBufferedRequest(rawRequest)
+	assert.NoError(t, err)
+
+	// read first time
+	body, err := subject.GetBody()
+	assert.NoError(t, err)
+
+	payload1, err := ioutil.ReadAll(body)
+	assert.NoError(t, err)
+
+	// read second time
+	body, err = subject.GetBody()
+	assert.NoError(t, err)
+
+	payload2, err := ioutil.ReadAll(body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, payload1, payload2)
+}
+
+func TestGetRequest(t *testing.T) {
+	requestBody := "body"
+	rawRequest, err := http.NewRequest(http.MethodPost, "", io.NopCloser(bytes.NewBuffer([]byte(requestBody))))
+	assert.NoError(t, err)
+
+	subject1, err := httputil.NewBufferedRequest(rawRequest)
+	assert.NoError(t, err)
+
+	// read from raw request first
+	body := subject1.GetRequest().Body
+	payload1, err := ioutil.ReadAll(body)
+	assert.NoError(t, err)
+
+	// read from wrapper next
+	body, err = subject1.GetBody()
+	assert.NoError(t, err)
+
+	payload2, err := ioutil.ReadAll(body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, payload1, payload2)
+}

--- a/server/lyft/gateway/events/handlers/comment.go
+++ b/server/lyft/gateway/events/handlers/comment.go
@@ -23,10 +23,10 @@ type CommentEventWorkerProxy struct {
 	snsWriter Writer
 }
 
-func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.CloneableRequest, _ event.Comment, _ *command.Comment) error {
+func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, _ event.Comment, _ *command.Comment) error {
 	buffer := bytes.NewBuffer([]byte{})
 
-	if err := request.GetRequest().Write(buffer); err != nil {
+	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
 		return errors.Wrap(err, "writing request to buffer")
 	}
 

--- a/server/lyft/gateway/events/handlers/pull_request.go
+++ b/server/lyft/gateway/events/handlers/pull_request.go
@@ -41,7 +41,7 @@ type AsyncAutoplannerWorkerProxy struct {
 	logger logging.Logger
 }
 
-func (p *AsyncAutoplannerWorkerProxy) Handle(ctx context.Context, request *http.CloneableRequest, event event.PullRequest) error {
+func (p *AsyncAutoplannerWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event event.PullRequest) error {
 	go func() {
 		err := p.proxy.Handle(ctx, request, event)
 
@@ -59,7 +59,7 @@ type SynchronousAutoplannerWorkerProxy struct {
 	legacyLogger      logging.SimpleLogging
 }
 
-func (p *SynchronousAutoplannerWorkerProxy) Handle(ctx context.Context, request *http.CloneableRequest, event event.PullRequest) error {
+func (p *SynchronousAutoplannerWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event event.PullRequest) error {
 	if ok := p.autoplanValidator.InstrumentedIsValid(
 		p.legacyLogger,
 		event.Pull.BaseRepo,
@@ -90,10 +90,10 @@ type PullEventWorkerProxy struct {
 	logger    logging.Logger
 }
 
-func (p *PullEventWorkerProxy) Handle(ctx context.Context, request *http.CloneableRequest, event event.PullRequest) error {
+func (p *PullEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event event.PullRequest) error {
 	buffer := bytes.NewBuffer([]byte{})
 
-	if err := request.GetRequest().Write(buffer); err != nil {
+	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
 		return errors.Wrap(err, "writing request to buffer")
 	}
 

--- a/server/vcs/provider/github/request/handler_test.go
+++ b/server/vcs/provider/github/request/handler_test.go
@@ -20,11 +20,11 @@ import (
 // mocks/test implementations
 type assertingPRHandler struct {
 	expectedInput   event.PullRequest
-	expectedRequest *httputils.CloneableRequest
+	expectedRequest *httputils.BufferedRequest
 	t               *testing.T
 }
 
-func (h assertingPRHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, input event.PullRequest) error {
+func (h assertingPRHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, input event.PullRequest) error {
 	assert.Equal(h.t, h.expectedRequest, request)
 	assert.Equal(h.t, h.expectedInput, input)
 
@@ -33,11 +33,11 @@ func (h assertingPRHandler) Handle(ctx context.Context, request *httputils.Clone
 
 type assertingCommentEventHandler struct {
 	expectedInput   event.Comment
-	expectedRequest *httputils.CloneableRequest
+	expectedRequest *httputils.BufferedRequest
 	t               *testing.T
 }
 
-func (h assertingCommentEventHandler) Handle(ctx context.Context, request *httputils.CloneableRequest, input event.Comment) error {
+func (h assertingCommentEventHandler) Handle(ctx context.Context, request *httputils.BufferedRequest, input event.Comment) error {
 	assert.Equal(h.t, h.expectedRequest, request)
 	assert.Equal(h.t, h.expectedInput, input)
 	return nil
@@ -48,7 +48,7 @@ type testValidator struct {
 	returnedError   error
 }
 
-func (d testValidator) Validate(r *httputils.CloneableRequest, secret []byte) ([]byte, error) {
+func (d testValidator) Validate(r *httputils.BufferedRequest, secret []byte) ([]byte, error) {
 	return d.returnedPayload, d.returnedError
 }
 
@@ -75,7 +75,7 @@ type testParser struct {
 	returnedParseWebhookError error
 }
 
-func (e *testParser) Parse(r *httputils.CloneableRequest, payload []byte) (interface{}, error) {
+func (e *testParser) Parse(r *httputils.BufferedRequest, payload []byte) (interface{}, error) {
 	return e.returnedEvent, e.returnedParseWebhookError
 }
 
@@ -98,7 +98,7 @@ func TestHandle_CommentEvent(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	request, err := httputils.NewCloneableRequest(rawRequest)
+	request, err := httputils.NewBufferedRequest(rawRequest)
 	assert.NoError(t, err)
 
 	internalEvent := event.Comment{
@@ -221,7 +221,7 @@ func TestHandle_PREvent(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	request, err := httputils.NewCloneableRequest(rawRequest)
+	request, err := httputils.NewBufferedRequest(rawRequest)
 	assert.NoError(t, err)
 
 	internalEvent := event.PullRequest{

--- a/server/vcs/provider/github/request/parser.go
+++ b/server/vcs/provider/github/request/parser.go
@@ -6,11 +6,11 @@ import (
 )
 
 type webhookParser interface {
-	Parse(r *http.CloneableRequest, payload []byte) (interface{}, error)
+	Parse(r *http.BufferedRequest, payload []byte) (interface{}, error)
 }
 
 type parser struct{}
 
-func (e *parser) Parse(r *http.CloneableRequest, payload []byte) (interface{}, error) {
+func (e *parser) Parse(r *http.BufferedRequest, payload []byte) (interface{}, error) {
 	return github.ParseWebHook(github.WebHookType(r.GetRequest()), payload)
 }

--- a/server/vcs/provider/github/request/validator.go
+++ b/server/vcs/provider/github/request/validator.go
@@ -24,7 +24,7 @@ import (
 )
 
 type requestValidator interface {
-	Validate(r *http.CloneableRequest, secret []byte) ([]byte, error)
+	Validate(r *http.BufferedRequest, secret []byte) ([]byte, error)
 }
 
 // validator handles checking if GitHub requests are signed
@@ -35,14 +35,14 @@ type validator struct{}
 // If secret is not empty, it checks that the request was signed
 // by secret and returns an error if it was not.
 // If secret is empty, it does not check if the request was signed.
-func (d validator) Validate(r *http.CloneableRequest, secret []byte) ([]byte, error) {
+func (d validator) Validate(r *http.BufferedRequest, secret []byte) ([]byte, error) {
 	if len(secret) != 0 {
 		return d.validateAgainstSecret(r, secret)
 	}
 	return d.validateWithoutSecret(r)
 }
 
-func (d validator) validateAgainstSecret(r *http.CloneableRequest, secret []byte) ([]byte, error) {
+func (d validator) validateAgainstSecret(r *http.BufferedRequest, secret []byte) ([]byte, error) {
 	payload, err := github.ValidatePayload(r.GetRequest(), secret)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (d validator) validateAgainstSecret(r *http.CloneableRequest, secret []byte
 	return payload, nil
 }
 
-func (d validator) validateWithoutSecret(r *http.CloneableRequest) ([]byte, error) {
+func (d validator) validateWithoutSecret(r *http.BufferedRequest) ([]byte, error) {
 	switch ct := r.GetHeader("Content-Type"); ct {
 	case "application/json":
 		body, err := r.GetBody()


### PR DESCRIPTION
* Renamed `CloneableRequest` to `BufferedRequest`
* Created a field to store request body buffer
* Ensure `GetRequest()` clones a given request on the fly.