### PR TITLE
Github Checks Interface Setup

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -829,7 +829,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		DB: boltdb,
 	}
 
-	pullUpdater := &events.PullUpdater{
+	pullUpdater := &events.DefaultPullUpdater{
 		HidePrevPlanComments: false,
 		VCSClient:            vcsClient,
 		MarkdownRenderer:     &events.MarkdownRenderer{},

--- a/server/controllers/github_app_controller.go
+++ b/server/controllers/github_app_controller.go
@@ -59,7 +59,7 @@ func (g *GithubAppController) ExchangeCode(w http.ResponseWriter, r *http.Reques
 
 	// TODO: unify this in a single inject.go file
 	mergeabilityChecker := vcs.NewLyftPullMergeabilityChecker(g.GithubStatusName)
-	client, err := vcs.NewGithubClient(g.GithubHostname, creds, g.Logger, mergeabilityChecker)
+	client, err := vcs.NewGithubClient(g.GithubHostname, creds, g.Logger, mergeabilityChecker, false)
 
 	if err != nil {
 		g.respond(w, logging.Error, http.StatusInternalServerError, "Failed to exchange code for github app: %s", err)

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -128,7 +128,7 @@ func (a *ApplyStepRunner) runRemoteApply(
 
 	// updateStatusF will update the commit status and log any error.
 	updateStatusF := func(status models.CommitStatus, url string) {
-		if _, err := a.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Apply, status, url); err != nil {
+		if _, err := a.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Apply, status, url, ""); err != nil {
 			prjCtx.Log.Errorf("unable to update status: %s", err)
 		}
 	}

--- a/server/core/runtime/apply_step_runner.go
+++ b/server/core/runtime/apply_step_runner.go
@@ -128,7 +128,7 @@ func (a *ApplyStepRunner) runRemoteApply(
 
 	// updateStatusF will update the commit status and log any error.
 	updateStatusF := func(status models.CommitStatus, url string) {
-		if err := a.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Apply, status, url); err != nil {
+		if _, err := a.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Apply, status, url); err != nil {
 			prjCtx.Log.Errorf("unable to update status: %s", err)
 		}
 	}

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -249,7 +249,7 @@ func (p *PlanStepRunner) runRemotePlan(
 
 	// updateStatusF will update the commit status and log any error.
 	updateStatusF := func(status models.CommitStatus, url string) {
-		if err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url); err != nil {
+		if _, err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url); err != nil {
 			prjCtx.Log.Errorf("unable to update status: %s", err)
 		}
 	}

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -249,7 +249,7 @@ func (p *PlanStepRunner) runRemotePlan(
 
 	// updateStatusF will update the commit status and log any error.
 	updateStatusF := func(status models.CommitStatus, url string) {
-		if _, err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url); err != nil {
+		if _, err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url, ""); err != nil {
 			prjCtx.Log.Errorf("unable to update status: %s", err)
 		}
 	}

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -49,7 +49,7 @@ type AsyncTFExec interface {
 // StatusUpdater brings the interface from CommitStatusUpdater into this package
 // without causing circular imports.
 type StatusUpdater interface {
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, output string) (string, error)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_runner.go Runner

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -49,7 +49,7 @@ type AsyncTFExec interface {
 // StatusUpdater brings the interface from CommitStatusUpdater into this package
 // without causing circular imports.
 type StatusUpdater interface {
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_runner.go Runner

--- a/server/events/apply_command_runner.go
+++ b/server/events/apply_command_runner.go
@@ -16,7 +16,7 @@ func NewApplyCommandRunner(
 	commitStatusUpdater CommitStatusUpdater,
 	prjCommandBuilder ProjectApplyCommandBuilder,
 	prjCmdRunner ProjectApplyCommandRunner,
-	pullUpdater *PullUpdater,
+	pullUpdater PullUpdater,
 	dbUpdater *DBUpdater,
 	parallelPoolSize int,
 	pullReqStatusFetcher vcs.PullReqStatusFetcher,
@@ -42,7 +42,7 @@ type ApplyCommandRunner struct {
 	commitStatusUpdater  CommitStatusUpdater
 	prjCmdBuilder        ProjectApplyCommandBuilder
 	prjCmdRunner         ProjectApplyCommandRunner
-	pullUpdater          *PullUpdater
+	pullUpdater          PullUpdater
 	dbUpdater            *DBUpdater
 	parallelPoolSize     int
 	pullReqStatusFetcher vcs.PullReqStatusFetcher

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -12,7 +12,7 @@ func NewApprovePoliciesCommandRunner(
 	commitStatusUpdater CommitStatusUpdater,
 	prjCommandBuilder ProjectApprovePoliciesCommandBuilder,
 	prjCommandRunner ProjectApprovePoliciesCommandRunner,
-	pullUpdater *PullUpdater,
+	pullUpdater PullUpdater,
 	dbUpdater *DBUpdater,
 ) *ApprovePoliciesCommandRunner {
 	return &ApprovePoliciesCommandRunner{
@@ -26,7 +26,7 @@ func NewApprovePoliciesCommandRunner(
 
 type ApprovePoliciesCommandRunner struct {
 	commitStatusUpdater CommitStatusUpdater
-	pullUpdater         *PullUpdater
+	pullUpdater         PullUpdater
 	dbUpdater           *DBUpdater
 	prjCmdBuilder       ProjectApprovePoliciesCommandBuilder
 	prjCmdRunner        ProjectApprovePoliciesCommandRunner

--- a/server/events/command/apply/runner.go
+++ b/server/events/command/apply/runner.go
@@ -5,14 +5,14 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
-func NewDisabledRunner(pullUpdater *events.PullUpdater) *DisabledRunner {
+func NewDisabledRunner(pullUpdater events.PullUpdater) *DisabledRunner {
 	return &DisabledRunner{
 		pullUpdater: pullUpdater,
 	}
 }
 
 type DisabledRunner struct {
-	pullUpdater *events.PullUpdater
+	pullUpdater events.PullUpdater
 }
 
 func (r *DisabledRunner) Run(ctx *command.Context, cmd *command.Comment) {

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -148,6 +148,9 @@ type ProjectContext struct {
 	PolicySets valid.PolicySets
 	// UUID for atlantis logs
 	JobID string
+
+	// Check Run ID
+	CheckRunId string
 }
 
 // ProjectCloneDir creates relative path to clone the repo to. If we are running

--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -18,48 +18,52 @@ type VCSStatusUpdater struct {
 }
 
 func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
-	src := d.TitleBuilder.Build(cmdName.String())
-	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
+	// src := d.TitleBuilder.Build(cmdName.String())
+	// descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
 
-	request := types.UpdateStatusRequest{
-		Repo:        repo,
-		PullNum:     pull.Num,
-		Ref:         pull.HeadCommit,
-		StatusName:  src,
-		State:       status,
-		Description: descrip,
-		DetailsURL:  "",
-	}
-	return d.Client.UpdateStatus(ctx, request)
+	// request := types.UpdateStatusRequest{
+	// 	Repo:        repo,
+	// 	PullNum:     pull.Num,
+	// 	Ref:         pull.HeadCommit,
+	// 	StatusName:  src,
+	// 	State:       status,
+	// 	Description: descrip,
+	// 	DetailsURL:  "",
+	// }
+	// _, err := d.Client.UpdateStatus(ctx, request, "")
+	// return err
+	return nil
 }
 
 func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
-	src := d.TitleBuilder.Build(cmdName.String())
-	cmdVerb := "unknown"
+	// src := d.TitleBuilder.Build(cmdName.String())
+	// cmdVerb := "unknown"
 
-	switch cmdName {
-	case Plan:
-		cmdVerb = "planned"
-	case PolicyCheck:
-		cmdVerb = "policies checked"
-	case Apply:
-		cmdVerb = "applied"
-	}
+	// switch cmdName {
+	// case Plan:
+	// 	cmdVerb = "planned"
+	// case PolicyCheck:
+	// 	cmdVerb = "policies checked"
+	// case Apply:
+	// 	cmdVerb = "applied"
+	// }
 
-	request := types.UpdateStatusRequest{
-		Repo:        repo,
-		PullNum:     pull.Num,
-		Ref:         pull.HeadCommit,
-		StatusName:  src,
-		State:       status,
-		Description: fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
-		DetailsURL:  "",
-	}
+	// request := types.UpdateStatusRequest{
+	// 	Repo:        repo,
+	// 	PullNum:     pull.Num,
+	// 	Ref:         pull.HeadCommit,
+	// 	StatusName:  src,
+	// 	State:       status,
+	// 	Description: fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
+	// 	DetailsURL:  "",
+	// }
 
-	return d.Client.UpdateStatus(ctx, request)
+	// _, err := d.Client.UpdateStatus(ctx, request, "")
+	// return err
+	return nil
 }
 
-func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error {
+func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error) {
 	projectID := projectCtx.ProjectName
 	if projectID == "" {
 		projectID = fmt.Sprintf("%s/%s", projectCtx.RepoRelDir, projectCtx.Workspace)
@@ -79,7 +83,7 @@ func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx Project
 		DetailsURL:  url,
 	}
 
-	return d.Client.UpdateStatus(ctx, request)
+	return d.Client.UpdateStatus(ctx, request, projectCtx.CheckRunId)
 }
 
 func (d *VCSStatusUpdater) statusDescription(status models.CommitStatus) string {

--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -10,60 +10,23 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 )
 
-// VCSStatusUpdater updates the status of a commit with the VCS host. We set
-// the status to signify whether the plan/apply succeeds.
-type VCSStatusUpdater struct {
+// GithubChecksStatusUpdater is used to update the github status checks
+type ChecksStatusUpdater struct {
 	Client       vcs.Client
 	TitleBuilder vcs.StatusTitleBuilder
 }
 
-func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
-	// src := d.TitleBuilder.Build(cmdName.String())
-	// descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
-
-	// request := types.UpdateStatusRequest{
-	// 	Repo:        repo,
-	// 	PullNum:     pull.Num,
-	// 	Ref:         pull.HeadCommit,
-	// 	StatusName:  src,
-	// 	State:       status,
-	// 	Description: descrip,
-	// 	DetailsURL:  "",
-	// }
-	// _, err := d.Client.UpdateStatus(ctx, request, "")
-	// return err
+func (d *ChecksStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
+	// No need to update combined status when using github checks
 	return nil
 }
 
-func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
-	// src := d.TitleBuilder.Build(cmdName.String())
-	// cmdVerb := "unknown"
-
-	// switch cmdName {
-	// case Plan:
-	// 	cmdVerb = "planned"
-	// case PolicyCheck:
-	// 	cmdVerb = "policies checked"
-	// case Apply:
-	// 	cmdVerb = "applied"
-	// }
-
-	// request := types.UpdateStatusRequest{
-	// 	Repo:        repo,
-	// 	PullNum:     pull.Num,
-	// 	Ref:         pull.HeadCommit,
-	// 	StatusName:  src,
-	// 	State:       status,
-	// 	Description: fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
-	// 	DetailsURL:  "",
-	// }
-
-	// _, err := d.Client.UpdateStatus(ctx, request, "")
-	// return err
+func (d *ChecksStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
+	// No need to update combined count status when using github checks
 	return nil
 }
 
-func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error) {
+func (d *ChecksStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, output string) (string, error) {
 	projectID := projectCtx.ProjectName
 	if projectID == "" {
 		projectID = fmt.Sprintf("%s/%s", projectCtx.RepoRelDir, projectCtx.Workspace)
@@ -72,7 +35,92 @@ func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx Project
 		ProjectName: projectID,
 	})
 
-	description := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
+	description := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), statusDescription(status))
+	request := types.UpdateStatusRequest{
+		Repo:        projectCtx.BaseRepo,
+		PullNum:     projectCtx.Pull.Num,
+		Ref:         projectCtx.Pull.HeadCommit,
+		StatusName:  statusName,
+		State:       status,
+		Description: description,
+		DetailsURL:  url,
+	}
+
+	// Only update output when output string is provided
+	if output != "" {
+		request.Output = types.JobOutput{
+			Title:   statusName,
+			Summary: description,
+			Text:    output,
+		}
+	}
+
+	return d.Client.UpdateStatus(ctx, request, projectCtx.CheckRunId)
+}
+
+// VCSStatusUpdater updates the status of a commit with the VCS host. We set
+// the status to signify whether the plan/apply succeeds.
+type VCSStatusUpdater struct {
+	Client       vcs.Client
+	TitleBuilder vcs.StatusTitleBuilder
+}
+
+func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
+	src := d.TitleBuilder.Build(cmdName.String())
+	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), statusDescription(status))
+
+	request := types.UpdateStatusRequest{
+		Repo:        repo,
+		PullNum:     pull.Num,
+		Ref:         pull.HeadCommit,
+		StatusName:  src,
+		State:       status,
+		Description: descrip,
+		DetailsURL:  "",
+	}
+	_, err := d.Client.UpdateStatus(ctx, request, "")
+	return err
+	return nil
+}
+
+func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
+	src := d.TitleBuilder.Build(cmdName.String())
+	cmdVerb := "unknown"
+
+	switch cmdName {
+	case Plan:
+		cmdVerb = "planned"
+	case PolicyCheck:
+		cmdVerb = "policies checked"
+	case Apply:
+		cmdVerb = "applied"
+	}
+
+	request := types.UpdateStatusRequest{
+		Repo:        repo,
+		PullNum:     pull.Num,
+		Ref:         pull.HeadCommit,
+		StatusName:  src,
+		State:       status,
+		Description: fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
+		DetailsURL:  "",
+	}
+
+	_, err := d.Client.UpdateStatus(ctx, request, "")
+	return err
+	return nil
+}
+
+func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, _ string) (string, error) {
+	projectID := projectCtx.ProjectName
+	if projectID == "" {
+		projectID = fmt.Sprintf("%s/%s", projectCtx.RepoRelDir, projectCtx.Workspace)
+	}
+	statusName := d.TitleBuilder.Build(cmdName.String(), vcs.StatusTitleOptions{
+		ProjectName: projectID,
+	})
+
+	description := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), statusDescription(status))
 	request := types.UpdateStatusRequest{
 		Repo:        projectCtx.BaseRepo,
 		PullNum:     projectCtx.Pull.Num,
@@ -86,7 +134,7 @@ func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx Project
 	return d.Client.UpdateStatus(ctx, request, projectCtx.CheckRunId)
 }
 
-func (d *VCSStatusUpdater) statusDescription(status models.CommitStatus) string {
+func statusDescription(status models.CommitStatus) string {
 	var description string
 	switch status {
 	case models.PendingCommitStatus:

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -57,7 +57,7 @@ var staleCommandChecker *mocks.MockStaleCommandChecker
 // these were all split out from default command runner in an effort to improve
 // readability however the tests were kept as is.
 var dbUpdater *events.DBUpdater
-var pullUpdater *events.PullUpdater
+var pullUpdater *events.DefaultPullUpdater
 var policyCheckCommandRunner *events.PolicyCheckCommandRunner
 var approvePoliciesCommandRunner *events.ApprovePoliciesCommandRunner
 var planCommandRunner *events.PlanCommandRunner
@@ -89,7 +89,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		DB: defaultBoltDB,
 	}
 
-	pullUpdater = &events.PullUpdater{
+	pullUpdater = &events.DefaultPullUpdater{
 		HidePrevPlanComments: false,
 		VCSClient:            vcsClient,
 		MarkdownRenderer:     &events.MarkdownRenderer{},

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -31,5 +31,5 @@ type CommitStatusUpdater interface {
 	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
 }

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -31,5 +31,5 @@ type CommitStatusUpdater interface {
 	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, output string) (string, error)
 }

--- a/server/events/plan_command_runner.go
+++ b/server/events/plan_command_runner.go
@@ -16,7 +16,7 @@ func NewPlanCommandRunner(
 	projectCommandBuilder ProjectPlanCommandBuilder,
 	projectCommandRunner ProjectPlanCommandRunner,
 	dbUpdater *DBUpdater,
-	pullUpdater *PullUpdater,
+	pullUpdater PullUpdater,
 	policyCheckCommandRunner *PolicyCheckCommandRunner,
 	parallelPoolSize int,
 ) *PlanCommandRunner {
@@ -42,7 +42,7 @@ type PlanCommandRunner struct {
 	prjCmdBuilder            ProjectPlanCommandBuilder
 	prjCmdRunner             ProjectPlanCommandRunner
 	dbUpdater                *DBUpdater
-	pullUpdater              *PullUpdater
+	pullUpdater              PullUpdater
 	policyCheckCommandRunner *PolicyCheckCommandRunner
 	parallelPoolSize         int
 }

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -9,7 +9,7 @@ import (
 
 func NewPolicyCheckCommandRunner(
 	dbUpdater *DBUpdater,
-	pullUpdater *PullUpdater,
+	pullUpdater PullUpdater,
 	commitStatusUpdater CommitStatusUpdater,
 	projectCommandRunner ProjectPolicyCheckCommandRunner,
 	parallelPoolSize int,
@@ -25,7 +25,7 @@ func NewPolicyCheckCommandRunner(
 
 type PolicyCheckCommandRunner struct {
 	dbUpdater           *DBUpdater
-	pullUpdater         *PullUpdater
+	pullUpdater         PullUpdater
 	commitStatusUpdater CommitStatusUpdater
 	prjCmdRunner        ProjectPolicyCheckCommandRunner
 	parallelPoolSize    int

--- a/server/events/project_command_output_wrapper.go
+++ b/server/events/project_command_output_wrapper.go
@@ -1,54 +1,114 @@
 package events
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-// ProjectOutputWrapper is a decorator that creates a new PR status check per project.
+//go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_project_job_url_generator.go ProjectJobURLGenerator
+
+// ProjectJobURLGenerator generates urls to view project's progress.
+type ProjectJobURLGenerator interface {
+	GenerateProjectJobURL(p command.ProjectContext) (string, error)
+}
+
+//go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_project_status_updater.go ProjectStatusUpdater
+
+type ProjectStatusUpdater interface {
+	// UpdateProject sets the commit status for the project represented by
+	// ctx.
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
+}
+
+// JobsEnabledProjectCommandRunner is a decorator that creates a new PR status check per project.
 // The status contains a url that outputs current progress of the terraform plan/apply command.
-type ProjectOutputWrapper struct {
+type JobsEnabledProjectCommandRunner struct {
 	ProjectCommandRunner
-	JobURLSetter JobURLSetter
-	JobCloser    JobCloser
+
+	JobUrlGenerator ProjectJobURLGenerator
+	StatusUpdater   CommitStatusUpdater
+	JobCloser       JobCloser
 }
 
-func (p *ProjectOutputWrapper) Plan(ctx command.ProjectContext) command.ProjectResult {
-	result := p.updateProjectPRStatus(command.Plan, ctx, p.ProjectCommandRunner.Plan)
-	p.JobCloser.CloseJob(ctx.JobID, ctx.BaseRepo)
-	return result
-}
+func (p *JobsEnabledProjectCommandRunner) Plan(ctx command.ProjectContext) command.ProjectResult {
+	// generate job URL and status Id
+	url, _ := p.JobUrlGenerator.GenerateProjectJobURL(ctx)
+	statusId, _ := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.PendingCommitStatus, url, "")
 
-func (p *ProjectOutputWrapper) Apply(ctx command.ProjectContext) command.ProjectResult {
-	result := p.updateProjectPRStatus(command.Apply, ctx, p.ProjectCommandRunner.Apply)
-	p.JobCloser.CloseJob(ctx.JobID, ctx.BaseRepo)
-	return result
-}
+	// Store check run id to update the check run when the operation is complete
+	ctx.CheckRunId = statusId
 
-func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, ctx command.ProjectContext, execute func(ctx command.ProjectContext) command.ProjectResult) command.ProjectResult {
-	// Create a PR status to track project's plan status. The status will
-	// include a link to view the progress of atlantis plan command in real
-	// time
-	checkRunId, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.PendingCommitStatus)
-	if err != nil {
-		ctx.Log.Errorf("updating project PR status", err)
-	}
+	result := p.ProjectCommandRunner.Plan(ctx)
 
-	ctx.CheckRunId = checkRunId
-	// ensures we are differentiating between project level command and overall command
-	result := execute(ctx)
-
+	// Update status to failed
 	if result.Error != nil || result.Failure != "" {
-		if _, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.FailedCommitStatus); err != nil {
+		if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.FailedCommitStatus, url, ""); err != nil {
 			ctx.Log.Errorf("updating project PR status", err)
 		}
 
 		return result
 	}
 
-	if _, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.SuccessCommitStatus); err != nil {
+	// Update status to success with the terraform output
+	if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.SuccessCommitStatus, url, result.PlanSuccess.TerraformOutput); err != nil {
 		ctx.Log.Errorf("updating project PR status", err)
 	}
 
+	// Close job
+	p.JobCloser.CloseJob(ctx.JobID, ctx.BaseRepo)
+	return result
+}
+
+func (p *JobsEnabledProjectCommandRunner) Apply(ctx command.ProjectContext) command.ProjectResult {
+	// generate job URL and status Id
+	url, _ := p.JobUrlGenerator.GenerateProjectJobURL(ctx)
+	statusId, _ := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.PendingCommitStatus, url, "")
+
+	// Store check run id to update the check run when the operation is complete
+	ctx.CheckRunId = statusId
+
+	result := p.ProjectCommandRunner.Apply(ctx)
+
+	// Update status to failed
+	if result.Error != nil || result.Failure != "" {
+		if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.FailedCommitStatus, url, ""); err != nil {
+			ctx.Log.Errorf("updating project PR status", err)
+		}
+
+		return result
+	}
+
+	// Update status to success with the terraform output
+	if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.SuccessCommitStatus, url, result.ApplySuccess); err != nil {
+		ctx.Log.Errorf("updating project PR status", err)
+	}
+
+	// Close job
+	p.JobCloser.CloseJob(ctx.JobID, ctx.BaseRepo)
+	return result
+}
+
+func (p *JobsEnabledProjectCommandRunner) PolicyCheck(ctx command.ProjectContext) command.ProjectResult {
+	statusId, _ := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.PendingCommitStatus, "", "")
+
+	ctx.CheckRunId = statusId
+
+	result := p.ProjectCommandRunner.PolicyCheck(ctx)
+
+	if result.Error != nil || result.Failure != "" {
+		if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.FailedCommitStatus, "", ""); err != nil {
+			ctx.Log.Errorf("updating project PR status", err)
+		}
+
+		return result
+	}
+
+	// Update status to success with the terraform output
+	if _, err := p.StatusUpdater.UpdateProject(context.TODO(), ctx, ctx.CommandName, models.SuccessCommitStatus, "", result.PolicyCheckSuccess.PolicyCheckOutput); err != nil {
+		ctx.Log.Errorf("updating project PR status", err)
+	}
 	return result
 }

--- a/server/events/project_command_output_wrapper.go
+++ b/server/events/project_command_output_wrapper.go
@@ -29,22 +29,24 @@ func (p *ProjectOutputWrapper) updateProjectPRStatus(commandName command.Name, c
 	// Create a PR status to track project's plan status. The status will
 	// include a link to view the progress of atlantis plan command in real
 	// time
-	if err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.PendingCommitStatus); err != nil {
+	checkRunId, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.PendingCommitStatus)
+	if err != nil {
 		ctx.Log.Errorf("updating project PR status", err)
 	}
 
+	ctx.CheckRunId = checkRunId
 	// ensures we are differentiating between project level command and overall command
 	result := execute(ctx)
 
 	if result.Error != nil || result.Failure != "" {
-		if err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.FailedCommitStatus); err != nil {
+		if _, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.FailedCommitStatus); err != nil {
 			ctx.Log.Errorf("updating project PR status", err)
 		}
 
 		return result
 	}
 
-	if err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.SuccessCommitStatus); err != nil {
+	if _, err := p.JobURLSetter.SetJobURLWithStatus(ctx, commandName, models.SuccessCommitStatus); err != nil {
 		ctx.Log.Errorf("updating project PR status", err)
 	}
 

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -97,7 +97,7 @@ type ProjectCommandRunner interface {
 type JobURLSetter interface {
 	// SetJobURLWithStatus sets the commit status for the project represented by
 	// ctx and updates the status with and url to a job.
-	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus) error
+	SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus) (string, error)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_job_closer.go JobCloser

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -264,7 +264,7 @@ func TestProjectOutputWrapper(t *testing.T) {
 			mockJobCloser := mocks.NewMockJobCloser()
 			mockProjectCommandRunner := mocks.NewMockProjectCommandRunner()
 
-			runner := &events.ProjectOutputWrapper{
+			runner := &events.JobsEnabledProjectCommandRunner{
 				JobURLSetter:         mockJobURLSetter,
 				JobCloser:            mockJobCloser,
 				ProjectCommandRunner: mockProjectCommandRunner,

--- a/server/events/pull_updater.go
+++ b/server/events/pull_updater.go
@@ -6,14 +6,23 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
-type PullUpdater struct {
+type PullUpdater interface {
+	UpdatePull(ctx *command.Context, cmd PullCommand, res command.Result)
+}
+
+// Used when using github checks to write operation output
+type NoopPullUpdater struct{}
+
+func (n *NoopPullUpdater) UpdatePull(ctx *command.Context, cmd PullCommand, res command.Result) {}
+
+type DefaultPullUpdater struct {
 	HidePrevPlanComments bool
 	VCSClient            vcs.Client
 	MarkdownRenderer     *MarkdownRenderer
 	GlobalCfg            valid.GlobalCfg
 }
 
-func (c *PullUpdater) UpdatePull(ctx *command.Context, cmd PullCommand, res command.Result) {
+func (c *DefaultPullUpdater) UpdatePull(ctx *command.Context, cmd PullCommand, res command.Result) {
 	// Log if we got any errors or failures.
 	if res.Error != nil {
 		ctx.Log.Errorf(res.Error.Error())

--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -229,7 +229,7 @@ func (g *AzureDevopsClient) GetPullRequest(repo models.Repo, num int) (*azuredev
 }
 
 // UpdateStatus updates the build status of a commit.
-func (g *AzureDevopsClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+func (g *AzureDevopsClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, _ string) (string, error) {
 	adState := azuredevops.GitError.String()
 	switch request.State {
 	case models.PendingCommitStatus:
@@ -257,19 +257,19 @@ func (g *AzureDevopsClient) UpdateStatus(ctx context.Context, request types.Upda
 	opts := azuredevops.PullRequestListOptions{}
 	source, resp, err := g.Client.PullRequests.Get(g.ctx, owner, project, request.PullNum, &opts)
 	if err != nil {
-		return errors.Wrap(err, "getting pull request")
+		return "", errors.Wrap(err, "getting pull request")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrapf(err, "http response code %d getting pull request", resp.StatusCode)
+		return "", errors.Wrapf(err, "http response code %d getting pull request", resp.StatusCode)
 	}
 	if source.GetSupportsIterations() {
 		opts := azuredevops.PullRequestIterationsListOptions{}
 		iterations, resp, err := g.Client.PullRequests.ListIterations(g.ctx, owner, project, repoName, request.PullNum, &opts)
 		if err != nil {
-			return errors.Wrap(err, "listing pull request iterations")
+			return "", errors.Wrap(err, "listing pull request iterations")
 		}
 		if resp.StatusCode != http.StatusOK {
-			return errors.Wrapf(err, "http response code %d listing pull request iterations", resp.StatusCode)
+			return "", errors.Wrapf(err, "http response code %d listing pull request iterations", resp.StatusCode)
 		}
 		for _, iteration := range iterations {
 			if sourceRef := iteration.GetSourceRefCommit(); sourceRef != nil {
@@ -281,18 +281,18 @@ func (g *AzureDevopsClient) UpdateStatus(ctx context.Context, request types.Upda
 		}
 		if iterationID := status.IterationID; iterationID != nil {
 			if !(*iterationID >= 1) {
-				return errors.New("supportsIterations was true but got invalid iteration ID or no matching iteration commit SHA was found")
+				return "", errors.New("supportsIterations was true but got invalid iteration ID or no matching iteration commit SHA was found")
 			}
 		}
 	}
 	_, resp, err = g.Client.PullRequests.CreateStatus(g.ctx, owner, project, repoName, request.PullNum, &status)
 	if err != nil {
-		return errors.Wrap(err, "creating pull request status")
+		return "", errors.Wrap(err, "creating pull request status")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrapf(err, "http response code %d creating pull request status", resp.StatusCode)
+		return "", errors.Wrapf(err, "http response code %d creating pull request status", resp.StatusCode)
 	}
-	return err
+	return "", err
 }
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.

--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -165,7 +165,7 @@ func (b *Client) PullIsMergeable(repo models.Repo, pull models.PullRequest) (boo
 }
 
 // UpdateStatus updates the status of a commit.
-func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, _ string) (string, error) {
 	bbState := "FAILED"
 	switch request.State {
 	case models.PendingCommitStatus:
@@ -193,10 +193,10 @@ func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusReq
 
 	path := fmt.Sprintf("%s/2.0/repositories/%s/commit/%s/statuses/build", b.BaseURL, repo.FullName, request.Ref)
 	if err != nil {
-		return errors.Wrap(err, "json encoding")
+		return "", errors.Wrap(err, "json encoding")
 	}
 	_, err = b.makeRequest("POST", path, bytes.NewBuffer(bodyBytes))
-	return err
+	return "", err
 }
 
 // MarkdownPullLink specifies the character used in a pull request comment.

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -215,7 +215,7 @@ func (b *Client) PullIsMergeable(repo models.Repo, pull models.PullRequest) (boo
 }
 
 // UpdateStatus updates the status of a commit.
-func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, _ string) (string, error) {
 	bbState := "FAILED"
 
 	switch request.State {
@@ -243,10 +243,10 @@ func (b *Client) UpdateStatus(ctx context.Context, request types.UpdateStatusReq
 
 	path := fmt.Sprintf("%s/rest/build-status/1.0/commits/%s", b.BaseURL, request.Ref)
 	if err != nil {
-		return errors.Wrap(err, "json encoding")
+		return "", errors.Wrap(err, "json encoding")
 	}
 	_, err = b.makeRequest("POST", path, bytes.NewBuffer(bodyBytes))
-	return err
+	return "", err
 }
 
 // MarkdownPullLink specifies the character used in a pull request comment.

--- a/server/events/vcs/client.go
+++ b/server/events/vcs/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	// change across runs.
 	// url is an optional link that users should click on for more information
 	// about this status.
-	UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error
+	UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, checkRunId string) (string, error)
 	MarkdownPullLink(pull models.PullRequest) (string, error)
 
 	// DownloadRepoConfigFile return `atlantis.yaml` content from VCS (which support fetch a single file from repository)

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -87,7 +87,7 @@ func (c *GithubCheckStatusUpdater) UpdateStatus(ctx context.Context, request typ
 	// If checkRunId is nil, it is a new check run
 	// If not nil, we update the existing check run
 
-	return "", nil
+	return "1234", nil
 }
 
 // GithubClient is used to perform GitHub actions.

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -232,7 +232,7 @@ func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest
 }
 
 // UpdateStatus updates the build status of a commit.
-func (g *GitlabClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+func (g *GitlabClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, _ string) (string, error) {
 	gitlabState := gitlab.Failed
 	switch request.State {
 	case models.PendingCommitStatus:
@@ -248,7 +248,7 @@ func (g *GitlabClient) UpdateStatus(ctx context.Context, request types.UpdateSta
 		Description: gitlab.String(request.Description),
 		TargetURL:   &request.DetailsURL,
 	})
-	return err
+	return "", err
 }
 
 func (g *GitlabClient) GetMergeRequest(repoFullName string, pullNum int) (*gitlab.MergeRequest, error) {

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -289,7 +289,7 @@ func (c *InstrumentedClient) PullIsMergeable(repo models.Repo, pull models.PullR
 	return mergeable, err
 }
 
-func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, checkRunId string) (string, error) {
 	scope := c.StatsScope.SubScope("update_status")
 
 	executionTime := scope.Timer(metrics.ExecutionTimeMetric).Start()
@@ -298,9 +298,10 @@ func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.Upd
 	executionSuccess := scope.Counter(metrics.ExecutionSuccessMetric)
 	executionError := scope.Counter(metrics.ExecutionErrorMetric)
 
-	if err := c.Client.UpdateStatus(ctx, request); err != nil {
+	checkRunId, err := c.Client.UpdateStatus(ctx, request, checkRunId)
+	if err != nil {
 		executionError.Inc(1)
-		return err
+		return checkRunId, err
 	}
 
 	//TODO: thread context and use related logging methods.
@@ -315,6 +316,6 @@ func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.Upd
 	})
 
 	executionSuccess.Inc(1)
-	return nil
+	return checkRunId, nil
 
 }

--- a/server/events/vcs/not_configured_vcs_client.go
+++ b/server/events/vcs/not_configured_vcs_client.go
@@ -43,8 +43,8 @@ func (a *NotConfiguredVCSClient) PullIsApproved(repo models.Repo, pull models.Pu
 func (a *NotConfiguredVCSClient) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
 	return false, a.err()
 }
-func (a *NotConfiguredVCSClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
-	return a.err()
+func (a *NotConfiguredVCSClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, _ string) (string, error) {
+	return "", a.err()
 }
 func (a *NotConfiguredVCSClient) MarkdownPullLink(pull models.PullRequest) (string, error) {
 	return "", a.err()

--- a/server/events/vcs/proxy.go
+++ b/server/events/vcs/proxy.go
@@ -75,8 +75,8 @@ func (d *ClientProxy) PullIsMergeable(repo models.Repo, pull models.PullRequest)
 	return d.clients[repo.VCSHost.Type].PullIsMergeable(repo, pull)
 }
 
-func (d *ClientProxy) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
-	return d.clients[request.Repo.VCSHost.Type].UpdateStatus(ctx, request)
+func (d *ClientProxy) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest, checkRunId string) (string, error) {
+	return d.clients[request.Repo.VCSHost.Type].UpdateStatus(ctx, request, checkRunId)
 }
 
 func (d *ClientProxy) MarkdownPullLink(pull models.PullRequest) (string, error) {

--- a/server/events/vcs/types/status.go
+++ b/server/events/vcs/types/status.go
@@ -11,4 +11,13 @@ type UpdateStatusRequest struct {
 	StatusName  string
 	Description string
 	DetailsURL  string
+
+	// Job Output
+	Output JobOutput
+}
+
+type JobOutput struct {
+	Title   string
+	Summary string
+	Text    string
 }

--- a/server/events/version_command_runner.go
+++ b/server/events/version_command_runner.go
@@ -5,7 +5,7 @@ import (
 )
 
 func NewVersionCommandRunner(
-	pullUpdater *PullUpdater,
+	pullUpdater PullUpdater,
 	prjCmdBuilder ProjectVersionCommandBuilder,
 	prjCmdRunner ProjectVersionCommandRunner,
 	parallelPoolSize int,
@@ -19,7 +19,7 @@ func NewVersionCommandRunner(
 }
 
 type VersionCommandRunner struct {
-	pullUpdater      *PullUpdater
+	pullUpdater      PullUpdater
 	prjCmdBuilder    ProjectVersionCommandBuilder
 	prjCmdRunner     ProjectVersionCommandRunner
 	parallelPoolSize int

--- a/server/jobs/job_url_setter.go
+++ b/server/jobs/job_url_setter.go
@@ -20,7 +20,7 @@ type ProjectJobURLGenerator interface {
 type ProjectStatusUpdater interface {
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) (string, error)
 }
 
 type JobURLSetter struct {
@@ -35,11 +35,11 @@ func NewJobURLSetter(projectJobURLGenerator ProjectJobURLGenerator, projectStatu
 	}
 }
 
-func (j *JobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus) error {
+func (j *JobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName command.Name, status models.CommitStatus) (string, error) {
 	url, err := j.projectJobURLGenerator.GenerateProjectJobURL(ctx)
 
 	if err != nil {
-		return err
+		return "", err
 	}
 	return j.projectStatusUpdater.UpdateProject(context.TODO(), ctx, cmdName, status, url)
 }

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var dbUpdater *events.DBUpdater
-var pullUpdater *events.PullUpdater
+var pullUpdater *events.DefaultPullUpdater
 var policyCheckCommandRunner *events.PolicyCheckCommandRunner
 var planCommandRunner *events.PlanCommandRunner
 var preWorkflowHooksCommandRunner events.PreWorkflowHooksCommandRunner

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -25,7 +25,7 @@ type AutoplanValidator struct {
 	GlobalCfg                     valid.GlobalCfg
 	CommitStatusUpdater           events.CommitStatusUpdater
 	PrjCmdBuilder                 events.ProjectPlanCommandBuilder
-	PullUpdater                   *events.PullUpdater
+	PullUpdater                   events.PullUpdater
 	WorkingDir                    events.WorkingDir
 	WorkingDirLocker              events.WorkingDirLocker
 }

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -34,7 +34,7 @@ func setupAutoplan(t *testing.T) *vcsmocks.MockClient {
 	workingDirLocker = mocks.NewMockWorkingDirLocker()
 	vcsClient := vcsmocks.NewMockClient()
 	drainer = &events.Drainer{}
-	pullUpdater := &events.PullUpdater{
+	pullUpdater := &events.DefaultPullUpdater{
 		HidePrevPlanComments: false,
 		VCSClient:            vcsClient,
 		MarkdownRenderer:     &events.MarkdownRenderer{},

--- a/server/server.go
+++ b/server/server.go
@@ -238,8 +238,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			githubAppEnabled = true
 		}
 
+		// TODO: Add server flags and feature flags
 		var err error
-		rawGithubClient, err = vcs.NewGithubClient(userConfig.GithubHostname, githubCredentials, logger, mergeabilityChecker)
+		rawGithubClient, err = vcs.NewGithubClient(userConfig.GithubHostname, githubCredentials, logger, mergeabilityChecker, false)
 		if err != nil {
 			return nil, err
 		}

--- a/server/wrappers/project_runners.go
+++ b/server/wrappers/project_runners.go
@@ -34,12 +34,14 @@ func (d *projectCommand) WithSync(
 // WithJobs adds streaming capabilities to terraform output. With it end user
 // can see their terraform command's execution in real time.
 func (d *projectCommand) WithJobs(
-	projectJobUrl events.JobURLSetter,
+	projectJobUrlGenerator events.ProjectJobURLGenerator,
+	projectStatusUpdater events.CommitStatusUpdater,
 	projectJobCloser events.JobCloser,
 ) *projectCommand {
-	d.ProjectCommandRunner = &events.ProjectOutputWrapper{
+	d.ProjectCommandRunner = &events.JobsEnabledProjectCommandRunner{
 		ProjectCommandRunner: d.ProjectCommandRunner,
-		JobURLSetter:         projectJobUrl,
+		JobUrlGenerator:      projectJobUrlGenerator,
+		StatusUpdater:        projectStatusUpdater,
 		JobCloser:            projectJobCloser,
 	}
 	return d


### PR DESCRIPTION
In this PR, we add support for using github checks in the plan, apply and policy check workflows. In order to minimize changes to the generic client interface, we use the `UpdateStatus()` method to update both the pull request status checks and github status checks based on the server configuration. 

In addition, we add a new implementation of `CommitStatusUpdater` that is configured to use the Github Status Checks to update project status instead of the default one - pull request status checks. 

TODO:

- [ ] Fix existing tests and add new tests
- [ ] Implement `GithubCheckStatusUpdater.UpdateStatus() `