### PR TITLE
WENGINES-4515 Github Client changes and adding feature flags

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -122,6 +122,7 @@ func NewGithubClient(hostname string, credentials GithubCredentials, logger logg
 	}, nil
 }
 
+// building internal client in its own constructor to inject StatusUpdater which uses this internal client
 func NewGithubInternalClient(hostName string, githubCredentials GithubCredentials) (*github.Client, error) {
 	transport, err := githubCredentials.Client()
 	if err != nil {

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -38,6 +38,11 @@ const (
 	maxCommentLength = 65536
 )
 
+// Copying over from github_status_updater.go to avoid import cycle
+type StatusUpdater interface {
+	UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error)
+}
+
 // allows for custom handling of github 404s
 type PullRequestNotFound struct {
 	Err error
@@ -49,6 +54,8 @@ func (p *PullRequestNotFound) Error() string {
 
 // GithubClient is used to perform GitHub actions.
 type GithubClient struct {
+	StatusUpdater
+
 	user                string
 	client              *github.Client
 	v4MutateClient      *graphql.Client
@@ -72,23 +79,17 @@ type GithubAppTemporarySecrets struct {
 }
 
 // NewGithubClient returns a valid GitHub client.
-func NewGithubClient(hostname string, credentials GithubCredentials, logger logging.SimpleLogging, mergeabilityChecker MergeabilityChecker) (*GithubClient, error) {
+func NewGithubClient(hostname string, credentials GithubCredentials, logger logging.SimpleLogging, mergeabilityChecker MergeabilityChecker, client *github.Client, statusUpdater StatusUpdater) (*GithubClient, error) {
 	transport, err := credentials.Client()
 	if err != nil {
 		return nil, errors.Wrap(err, "error initializing github authentication transport")
 	}
 
 	var graphqlURL string
-	var client *github.Client
 	if hostname == "github.com" {
-		client = github.NewClient(transport)
 		graphqlURL = "https://api.github.com/graphql"
 	} else {
-		apiURL := resolveGithubAPIURL(hostname)
-		client, err = github.NewEnterpriseClient(apiURL.String(), apiURL.String(), transport)
-		if err != nil {
-			return nil, err
-		}
+		apiURL := ResolveGithubAPIURL(hostname)
 		graphqlURL = fmt.Sprintf("https://%s/api/graphql", apiURL.Host)
 	}
 
@@ -117,7 +118,28 @@ func NewGithubClient(hostname string, credentials GithubCredentials, logger logg
 		ctx:                 context.Background(),
 		logger:              logger,
 		mergeabilityChecker: mergeabilityChecker,
+		StatusUpdater:       statusUpdater,
 	}, nil
+}
+
+func NewGithubInternalClient(hostName string, githubCredentials GithubCredentials) (*github.Client, error) {
+	transport, err := githubCredentials.Client()
+	if err != nil {
+		return nil, errors.Wrap(err, "error initializing github authentication transport")
+	}
+
+	var client *github.Client
+	if hostName == "github.com" {
+		client = github.NewClient(transport)
+	} else {
+		apiURL := ResolveGithubAPIURL(hostName)
+		client, err = github.NewEnterpriseClient(apiURL.String(), apiURL.String(), transport)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
 }
 
 func (g *GithubClient) GetRateLimits() (*github.RateLimits, error) {
@@ -404,39 +426,6 @@ func (g *GithubClient) GetRepoStatuses(repo models.Repo, pull models.PullRequest
 	}
 
 	return result, nil
-}
-
-// UpdateStatus updates the status badge on the pull request.
-// See https://github.com/blog/1227-commit-status-api.
-func (g *GithubClient) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
-	ghState := "error"
-	switch request.State {
-	case models.PendingCommitStatus:
-		ghState = "pending"
-	case models.SuccessCommitStatus:
-		ghState = "success"
-	case models.FailedCommitStatus:
-		ghState = "failure"
-	}
-
-	status := &github.RepoStatus{
-		State:       github.String(ghState),
-		Description: github.String(request.Description),
-		Context:     github.String(request.StatusName),
-		TargetURL:   &request.DetailsURL,
-	}
-
-	// TODO: For debug purposes, remove when implementing github checks
-	if request.StatusId == "" {
-		_, _, err := g.client.Repositories.CreateStatus(ctx, request.Repo.Owner, request.Repo.Name, request.Ref, status)
-		fmt.Printf("DEBUG: Creating status check: %v", status)
-		return "1", err
-	} else {
-		fmt.Printf("DEBUG: Updating status check for: %v", status)
-		_, _, err := g.client.Repositories.CreateStatus(ctx, request.Repo.Owner, request.Repo.Name, request.Ref, status)
-		return request.StatusId, err
-	}
-
 }
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.

--- a/server/events/vcs/github_client_internal_test.go
+++ b/server/events/vcs/github_client_internal_test.go
@@ -14,16 +14,23 @@
 package vcs
 
 import (
+	"context"
 	"testing"
 
+	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
 // If the hostname is github.com, should use normal BaseURL.
 func TestNewGithubClient_GithubCom(t *testing.T) {
+
 	mergeabilityChecker := NewPullMergeabilityChecker("atlantis")
-	client, err := NewGithubClient("github.com", &GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := NewGithubInternalClient("github.com", &GithubUserCredentials{"user", "pass"})
+	Ok(t, err)
+
+	var client *GithubClient
+	client, err = NewGithubClient("github.com", &GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	Equals(t, "https://api.github.com/", client.client.BaseURL.String())
 }
@@ -31,9 +38,19 @@ func TestNewGithubClient_GithubCom(t *testing.T) {
 // If the hostname is a non-github hostname should use the right BaseURL.
 func TestNewGithubClient_NonGithub(t *testing.T) {
 	mergeabilityChecker := NewPullMergeabilityChecker("atlantis")
-	client, err := NewGithubClient("example.com", &GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+
+	internalClient, err := NewGithubInternalClient("example.com", &GithubUserCredentials{"user", "pass"})
+	Ok(t, err)
+
+	client, err := NewGithubClient("example.com", &GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	Equals(t, "https://example.com/api/v3/", client.client.BaseURL.String())
 	// If possible in the future, test the GraphQL client's URL as well. But at the
 	// moment the shurcooL library doesn't expose it.
+}
+
+type mockStatusUpdater struct{}
+
+func (m *mockStatusUpdater) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
+	return "", nil
 }

--- a/server/events/vcs/github_client_lyft_test.go
+++ b/server/events/vcs/github_client_lyft_test.go
@@ -1,6 +1,7 @@
 package vcs_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/stretchr/testify/assert"
 )
@@ -161,7 +163,11 @@ func TestLyftGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 			testServerURL, err := url.Parse(testServer.URL)
 			assert.NoError(t, err)
 			mergeabilityChecker := vcs.NewLyftPullMergeabilityChecker("atlantis")
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+
+			internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+			assert.NoError(t, err)
+
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 			assert.NoError(t, err)
 			defer disableSSLVerification()()
 
@@ -184,4 +190,10 @@ func TestLyftGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 		})
 	}
 
+}
+
+type mockStatusUpdater struct{}
+
+func (m *mockStatusUpdater) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
+	return "", nil
 }

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
 	"github.com/shurcooL/githubv4"
@@ -65,7 +66,10 @@ func TestGithubClient_GetModifiedFiles(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logger, mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logger, mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -121,7 +125,10 @@ func TestGithubClient_GetModifiedFilesMovedFile(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -216,7 +223,10 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 	Ok(t, err)
 
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -306,7 +316,10 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	Ok(t, err)
 
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -373,7 +386,10 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
 			mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+			internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+			assert.NoError(t, err)
+
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -466,7 +482,10 @@ func TestGithubClient_PullIsApproved(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 
@@ -600,7 +619,10 @@ func TestGithubClient_PullIsMergeable(t *testing.T) {
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
 			mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+			internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+			assert.NoError(t, err)
+
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -747,7 +769,10 @@ func TestGithubClient_PullisMergeable_BlockedStatus(t *testing.T) {
 			testServerURL, err := url.Parse(testServer.URL)
 			Ok(t, err)
 			mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+			internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+			assert.NoError(t, err)
+
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 			Ok(t, err)
 			defer disableSSLVerification()()
 
@@ -779,7 +804,10 @@ func helper(str string) *string {
 
 func TestGithubClient_MarkdownPullLink(t *testing.T) {
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient("hostname", &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient("hostname", &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient("hostname", &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	pull := models.PullRequest{Num: 1}
 	s, _ := client.MarkdownPullLink(pull)
@@ -835,7 +863,10 @@ func TestGithubClient_SplitComments(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
 	Ok(t, err)
 	defer disableSSLVerification()()
 	pull := models.PullRequest{Num: 1}
@@ -894,7 +925,11 @@ func TestGithubClient_Retry404(t *testing.T) {
 	testServerURL, err := url.Parse(testServer.URL)
 	Ok(t, err)
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker)
+	internalClient, err := vcs.NewGithubInternalClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"})
+	assert.NoError(t, err)
+
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})
+
 	Ok(t, err)
 	defer disableSSLVerification()()
 	repo := models.Repo{

--- a/server/events/vcs/github_credentials.go
+++ b/server/events/vcs/github_credentials.go
@@ -177,11 +177,11 @@ func (c *GithubAppCredentials) getAPIURL() *url.URL {
 		return c.apiURL
 	}
 
-	c.apiURL = resolveGithubAPIURL(c.Hostname)
+	c.apiURL = ResolveGithubAPIURL(c.Hostname)
 	return c.apiURL
 }
 
-func resolveGithubAPIURL(hostname string) *url.URL {
+func ResolveGithubAPIURL(hostname string) *url.URL {
 	// If we're using github.com then we don't need to do any additional configuration
 	// for the client. It we're using Github Enterprise, then we need to manually
 	// set the base url for the API.

--- a/server/events/vcs/github_credentials_test.go
+++ b/server/events/vcs/github_credentials_test.go
@@ -18,7 +18,7 @@ func TestGithubClient_GetUser_AppSlug(t *testing.T) {
 	anonCreds := &vcs.GithubAnonymousCredentials{}
 	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
 
-	internalClient, err := vcs.NewGithubInternalClient(testServer, &vcs.GithubUserCredentials{"user", "pass"})
+	internalClient, err := vcs.NewGithubInternalClient(testServer, anonCreds)
 	assert.NoError(t, err)
 
 	anonClient, err := vcs.NewGithubClient(testServer, anonCreds, logging.NewNoopLogger(t), mergeabilityChecker, internalClient, &mockStatusUpdater{})

--- a/server/events/version_command_runner.go
+++ b/server/events/version_command_runner.go
@@ -18,6 +18,7 @@ func NewVersionCommandRunner(
 	}
 }
 
+// TODO: Checks output updater or use PullOutputUpdater?
 type VersionCommandRunner struct {
 	pullUpdater      *PullOutputUpdater
 	prjCmdBuilder    ProjectVersionCommandBuilder

--- a/server/lyft/feature/names.go
+++ b/server/lyft/feature/names.go
@@ -5,3 +5,4 @@ type Name string
 // list of feature names used in the code base. These must be kept in sync with any external config.
 const LogPersistence Name = "log-persistence"
 const PlatformMode Name = "platform-mode"
+const GithubChecks Name = "github-checks"

--- a/server/vcs/provider/github/github_status_updater.go
+++ b/server/vcs/provider/github/github_status_updater.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v31/github"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs/types"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+)
+
+// Interface to support status updates for PR Status Checks and Github Status Checks
+type StatusUpdater interface {
+	UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error)
+}
+
+// Defaults to pull status updater if checks is turned off
+type FeatureAwareStatusUpdater struct {
+	Pull             StatusUpdater
+	Check            StatusUpdater
+	FeatureAllocator feature.Allocator
+
+	// TODO: Replace with Logger
+	Logger logging.SimpleLogging
+}
+
+func (f *FeatureAwareStatusUpdater) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
+	shouldAllocate, err := f.FeatureAllocator.ShouldAllocate(feature.GithubChecks, "")
+	if err != nil {
+		f.Logger.Errorf("unable to allocate for feature: %s, error: %s", feature.LogPersistence, err)
+	}
+
+	if shouldAllocate {
+		return f.Check.UpdateStatus(ctx, request)
+	}
+	return f.Pull.UpdateStatus(ctx, request)
+}
+
+type PullStatusUpdater struct {
+	Client *github.Client
+}
+
+// UpdateStatus updates the status badge on the pull request.
+// See https://github.com/blog/1227-commit-status-api.
+func (g *PullStatusUpdater) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
+	ghState := "error"
+	switch request.State {
+	case models.PendingCommitStatus:
+		ghState = "pending"
+	case models.SuccessCommitStatus:
+		ghState = "success"
+	case models.FailedCommitStatus:
+		ghState = "failure"
+	}
+
+	status := &github.RepoStatus{
+		State:       github.String(ghState),
+		Description: github.String(request.Description),
+		Context:     github.String(request.StatusName),
+		TargetURL:   &request.DetailsURL,
+	}
+
+	// TODO: For debug purposes, remove when implementing github checks
+	if request.StatusId == "" {
+		_, _, err := g.Client.Repositories.CreateStatus(ctx, request.Repo.Owner, request.Repo.Name, request.Ref, status)
+		fmt.Printf("DEBUG: Creating status check: %v", status)
+		return "1", err
+	} else {
+		fmt.Printf("DEBUG: Updating status check for: %v", status)
+		_, _, err := g.Client.Repositories.CreateStatus(ctx, request.Repo.Owner, request.Repo.Name, request.Ref, status)
+		return request.StatusId, err
+	}
+}
+
+type ChecksStatusUpdater struct {
+	Client *github.Client
+}
+
+func (c *ChecksStatusUpdater) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
+	// TODO: Implement update status Github Checks
+	return "", nil
+}


### PR DESCRIPTION
In order to inject `StatusUpdater` based on server configuration, we refactor creation of internal client based on hostname into its own method `NewGithubInternalClient(). This allows for injecting `StatusUpdater` to github client since `StatusUpdater` uses the internal client. 

Finally, we add a repo level feature flag to both the `OutputUpdater` and `GithubStatusUpdater`, giving us the option to partially rollout github checks before rolling out to all repos.