### PR TITLE
Add project level markdown renderer

### DIFF
--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -77,18 +77,17 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 		})
 
 		// Description is a required field
-		var description string
+		description := fmt.Sprintf("**Project**: `%s` **Dir**: `%s` **Workspace**: `%s`", projectResult.ProjectName, projectResult.RepoRelDir, projectResult.Workspace)
+
 		var state models.CommitStatus
 		if projectResult.Error != nil || projectResult.Failure != "" {
-			description = fmt.Sprintf("%s failed for %s", strings.Title(projectResult.Command.String()), projectResult.ProjectName)
 			state = models.FailedCommitStatus
 		} else {
-			description = fmt.Sprintf("%s succeeded for %s", strings.Title(projectResult.Command.String()), projectResult.ProjectName)
 			state = models.SuccessCommitStatus
 		}
 
 		// TODO: Make the mark down rendered project specific
-		output := c.MarkdownRenderer.Render(res, cmd.CommandName(), ctx.Pull.BaseRepo)
+		output := c.MarkdownRenderer.RenderProject(projectResult, cmd.CommandName(), ctx.Pull.BaseRepo)
 		updateStatusReq := types.UpdateStatusRequest{
 			Repo:        ctx.HeadRepo,
 			Ref:         ctx.Pull.HeadCommit,

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -86,7 +86,6 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 			state = models.SuccessCommitStatus
 		}
 
-		// TODO: Make the mark down rendered project specific
 		output := c.MarkdownRenderer.RenderProject(projectResult, cmd.CommandName(), ctx.Pull.BaseRepo)
 		updateStatusReq := types.UpdateStatusRequest{
 			Repo:        ctx.HeadRepo,

--- a/server/vcs/markdown/markdown_renderer.go
+++ b/server/vcs/markdown/markdown_renderer.go
@@ -67,7 +67,7 @@ type projectResultTmplData struct {
 	Rendered    string
 }
 
-// Render formats the data into a markdown string.
+// Render formats the data into a markdown string for a command.
 // nolint: interfacer
 func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo models.Repo) string {
 	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
@@ -84,6 +84,19 @@ func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo mod
 		return m.renderTemplate(template.Must(template.New("").Parse(failureWithLogTmpl)), failureData{res.Failure, common})
 	}
 	return m.renderProjectResults(res.ProjectResults, common, baseRepo)
+}
+
+// RenderProject formats the data into a markdown string for a project
+func (m *Renderer) RenderProject(prjRes command.ProjectResult, cmdName command.Name, baseRepo models.Repo) string {
+	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
+	common := commonData{
+		Command:                  commandStr,
+		DisableApplyAll:          m.DisableApplyAll || m.DisableApply,
+		DisableApply:             m.DisableApply,
+		EnableDiffMarkdownFormat: m.EnableDiffMarkdownFormat,
+	}
+	template, templateData := m.TemplateResolver.ResolveProject(prjRes, baseRepo, common)
+	return m.renderTemplate(template, templateData)
 }
 
 func (m *Renderer) renderProjectResults(results []command.ProjectResult, common commonData, baseRepo models.Repo) string {

--- a/server/vcs/markdown/markdown_renderer.go
+++ b/server/vcs/markdown/markdown_renderer.go
@@ -70,7 +70,7 @@ type projectResultTmplData struct {
 // Render formats the data into a markdown string for a command.
 // nolint: interfacer
 func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo models.Repo) string {
-	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
+	commandStr := strings.Title(strings.ReplaceAll(cmdName.String(), "_", " "))
 	common := commonData{
 		Command:                  commandStr,
 		DisableApplyAll:          m.DisableApplyAll || m.DisableApply,
@@ -88,12 +88,10 @@ func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo mod
 }
 
 // RenderProject formats the data into a markdown string for a project
-// This method relies on the underlying methods used by Render() so skipping tests since it's indirectly tested using the existing tests for Render()
 func (m *Renderer) RenderProject(prjRes command.ProjectResult, cmdName command.Name, baseRepo models.Repo) string {
-	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
+	commandStr := strings.Title(strings.ReplaceAll(cmdName.String(), "_", " "))
 	common := commonData{
 		Command:                  commandStr,
-		DisableApplyAll:          m.DisableApplyAll || m.DisableApply,
 		DisableApply:             m.DisableApply,
 		EnableDiffMarkdownFormat: m.EnableDiffMarkdownFormat,
 	}

--- a/server/vcs/markdown/markdown_renderer.go
+++ b/server/vcs/markdown/markdown_renderer.go
@@ -87,6 +87,7 @@ func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo mod
 }
 
 // RenderProject formats the data into a markdown string for a project
+// This method relies on the underlying methods used by Render() so skipping tests since it's indirectly tested using the existing tests for Render()
 func (m *Renderer) RenderProject(prjRes command.ProjectResult, cmdName command.Name, baseRepo models.Repo) string {
 	commandStr := strings.Title(strings.Replace(cmdName.String(), "_", " ", -1))
 	common := commonData{

--- a/server/vcs/markdown/markdown_renderer.go
+++ b/server/vcs/markdown/markdown_renderer.go
@@ -83,7 +83,8 @@ func (m *Renderer) Render(res command.Result, cmdName command.Name, baseRepo mod
 	if res.Failure != "" {
 		return m.renderTemplate(template.Must(template.New("").Parse(failureWithLogTmpl)), failureData{res.Failure, common})
 	}
-	return m.renderProjectResults(res.ProjectResults, common, baseRepo)
+
+	return m.renderProjectResults(res.ProjectResults, common, cmdName, baseRepo)
 }
 
 // RenderProject formats the data into a markdown string for a project
@@ -100,17 +101,15 @@ func (m *Renderer) RenderProject(prjRes command.ProjectResult, cmdName command.N
 	return m.renderTemplate(template, templateData)
 }
 
-func (m *Renderer) renderProjectResults(results []command.ProjectResult, common commonData, baseRepo models.Repo) string {
+func (m *Renderer) renderProjectResults(results []command.ProjectResult, common commonData, cmdName command.Name, baseRepo models.Repo) string {
 	// render project results
 	var prjResultTmplData []projectResultTmplData
 	for _, result := range results {
-		template, templateData := m.TemplateResolver.ResolveProject(result, baseRepo, common)
-		renderedOutput := m.renderTemplate(template, templateData)
 		prjResultTmplData = append(prjResultTmplData, projectResultTmplData{
 			Workspace:   result.Workspace,
 			RepoRelDir:  result.RepoRelDir,
 			ProjectName: result.ProjectName,
-			Rendered:    renderedOutput,
+			Rendered:    m.RenderProject(result, cmdName, baseRepo),
 		})
 	}
 

--- a/server/vcs/markdown/template_resolver.go
+++ b/server/vcs/markdown/template_resolver.go
@@ -113,6 +113,15 @@ func (t *TemplateResolver) ResolveProject(result command.ProjectResult, baseRepo
 	var templateData interface{}
 
 	switch {
+	case result.Error != nil:
+		tmpl = t.buildTemplate(Error, baseRepo.VCSHost.Type, wrappedErrTmpl, unwrappedErrTmpl, result.Error.Error(), templateOverrides)
+		templateData = struct {
+			Command string
+			Error   string
+		}{
+			Command: common.Command,
+			Error:   result.Error.Error(),
+		}
 	case result.Failure != "":
 		// use template override if specified
 		if val, ok := templateOverrides["project_failure"]; ok {
@@ -127,15 +136,6 @@ func (t *TemplateResolver) ResolveProject(result command.ProjectResult, baseRepo
 		}{
 			Command: common.Command,
 			Failure: result.Failure,
-		}
-	case result.Error != nil:
-		tmpl = t.buildTemplate(Error, baseRepo.VCSHost.Type, wrappedErrTmpl, unwrappedErrTmpl, result.Error.Error(), templateOverrides)
-		templateData = struct {
-			Command string
-			Error   string
-		}{
-			Command: common.Command,
-			Error:   result.Error.Error(),
 		}
 	case result.PlanSuccess != nil:
 		tmpl = t.buildTemplate(PlanSuccess, baseRepo.VCSHost.Type, planSuccessWrappedTmpl, planSuccessUnwrappedTmpl, result.PlanSuccess.TerraformOutput, templateOverrides)


### PR DESCRIPTION
This PR adds a `RenderProject()` method to markdown_renderer which renders the output for one project at a time. This allows us to populate project level check run for Github Checks. 