### PR TITLE
Add jobs URL to description 

### DIFF
--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -77,7 +77,7 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 		})
 
 		// Description is a required field
-		description := fmt.Sprintf("**Project**: `%s` **Dir**: `%s` **Workspace**: `%s`", projectResult.ProjectName, projectResult.RepoRelDir, projectResult.Workspace)
+		description := fmt.Sprintf("**Project**: `%s`\n**Dir**: `%s`\n**Workspace**: `%s`", projectResult.ProjectName, projectResult.RepoRelDir, projectResult.Workspace)
 
 		var state models.CommitStatus
 		if projectResult.Error != nil || projectResult.Failure != "" {


### PR DESCRIPTION
In this PR, we add the `jobsURL` to the description field in addition to the `detailsURL` section of the check run to make it more visible for users. 