### PR TITLE
Add support for merge strategy per repo.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,8 @@ require (
 )
 
 require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.10.0 // indirect
@@ -167,4 +169,5 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	go.temporal.io/api v1.6.1-0.20211110205628-60c98e9cbfe2 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,10 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113 h1:+Je12tQpLUUQEfMUrLkTPXe1wh8VXCPjFsdwY29co30=
 github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
@@ -878,6 +882,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -681,16 +681,18 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		Locker:    lockingClient,
 		VCSClient: vcsClient,
 	}
+
+	globalCfg := valid.NewGlobalCfg()
+
 	workingDir := &events.FileWorkspace{
 		DataDir:                     dataDir,
 		TestingOverrideHeadCloneURL: overrideCloneURL,
+		GlobalCfg:                   globalCfg,
 	}
 
 	defaultTFVersion := terraformClient.DefaultVersion()
 	locker := events.NewDefaultWorkingDirLocker()
 	parser := &config.ParserValidator{}
-
-	globalCfg := valid.NewGlobalCfg()
 
 	if userConfig.EnablePlatformMode {
 		globalCfg = globalCfg.EnablePlatformMode()

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -21,6 +21,7 @@ var globalCfg = valid.GlobalCfg{
 			IDRegex:              regexp.MustCompile(".*"),
 			AllowCustomWorkflows: Bool(true),
 			AllowedOverrides:     []string{"apply_requirements", "workflow"},
+			CheckoutStrategy:     "branch",
 		},
 	},
 }
@@ -1286,6 +1287,7 @@ repos:
   workflow: custom1
   allowed_overrides: [apply_requirements, workflow]
   allow_custom_workflows: true
+  checkout_strategy: merge
 - id: /.*/
   branch: /(master|main)/
   pre_workflow_hooks:
@@ -1325,12 +1327,14 @@ policies:
 						Workflow:             &customWorkflow1,
 						AllowedOverrides:     []string{"apply_requirements", "workflow"},
 						AllowCustomWorkflows: Bool(true),
+						CheckoutStrategy:     "merge",
 					},
 					{
 						IDRegex:           regexp.MustCompile(".*"),
 						BranchRegex:       regexp.MustCompile("(master|main)"),
 						ApplyRequirements: []string{"policies_passed"},
 						PreWorkflowHooks:  preWorkflowHooks,
+						CheckoutStrategy:  "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -1358,7 +1362,8 @@ repos:
 				Repos: []valid.Repo{
 					defaultCfg.Repos[0],
 					{
-						IDRegex: regexp.MustCompile("github.com/"),
+						IDRegex:          regexp.MustCompile("github.com/"),
+						CheckoutStrategy: "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -1376,8 +1381,9 @@ repos:
 				Repos: []valid.Repo{
 					defaultCfg.Repos[0],
 					{
-						ID:       "github.com/owner/repo",
-						Workflow: defaultCfg.Repos[0].Workflow,
+						ID:               "github.com/owner/repo",
+						Workflow:         defaultCfg.Repos[0].Workflow,
+						CheckoutStrategy: "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -1423,6 +1429,7 @@ workflows:
 						AllowedWorkflows:     []string{},
 						AllowedOverrides:     []string{},
 						AllowCustomWorkflows: Bool(false),
+						CheckoutStrategy:     "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -1632,12 +1639,14 @@ policies:
 						ApplyRequirements:    []string{"policies_passed"},
 						AllowedOverrides:     []string{"apply_requirements", "pull_request_workflow", "deployment_workflow", "workflow"},
 						AllowCustomWorkflows: Bool(true),
+						CheckoutStrategy:     "branch",
 					},
 					{
 						IDRegex:           regexp.MustCompile(".*"),
 						BranchRegex:       regexp.MustCompile("(master|main)"),
 						ApplyRequirements: []string{"policies_passed"},
 						PreWorkflowHooks:  preWorkflowHooks,
+						CheckoutStrategy:  "branch",
 					},
 				},
 				Workflows: defaultCfg.Workflows,
@@ -1723,6 +1732,7 @@ deployment_workflows:
 						AllowedWorkflows:     []string{},
 						AllowedOverrides:     []string{},
 						AllowCustomWorkflows: Bool(false),
+						CheckoutStrategy:     "branch",
 					},
 				},
 				Workflows: defaultCfg.Workflows,
@@ -1908,6 +1918,7 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 						AllowedWorkflows:     []string{"custom"},
 						AllowedOverrides:     []string{"workflow", "apply_requirements"},
 						AllowCustomWorkflows: Bool(true),
+						CheckoutStrategy:     "branch",
 					},
 					{
 						ID:                   "github.com/owner/repo",
@@ -1915,6 +1926,7 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 						ApplyRequirements:    []string{"policies_passed"},
 						AllowedOverrides:     nil,
 						AllowCustomWorkflows: nil,
+						CheckoutStrategy:     "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{
@@ -2103,6 +2115,7 @@ func TestParserValidator_ParseGlobalCfgV2JSON(t *testing.T) {
 						AllowedDeploymentWorkflows:  []string{"custom"},
 						AllowedOverrides:            []string{"pull_request_workflow", "deployment_workflow"},
 						AllowCustomWorkflows:        Bool(true),
+						CheckoutStrategy:            "branch",
 					},
 					{
 						ID:                          "github.com/owner/repo",
@@ -2112,6 +2125,7 @@ func TestParserValidator_ParseGlobalCfgV2JSON(t *testing.T) {
 						AllowedPullRequestWorkflows: nil,
 						AllowedDeploymentWorkflows:  nil,
 						AllowCustomWorkflows:        nil,
+						CheckoutStrategy:            "branch",
 					},
 				},
 				Workflows: map[string]valid.Workflow{

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -10,6 +10,8 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 
+var validCheckoutStrategies = []string{"merge", "branch"}
+
 // GlobalCfg is the raw schema for server-side repo config.
 type GlobalCfg struct {
 	Repos                []Repo               `yaml:"repos" json:"repos"`
@@ -36,6 +38,7 @@ type Repo struct {
 	AllowedOverrides            []string          `yaml:"allowed_overrides" json:"allowed_overrides"`
 	AllowCustomWorkflows        *bool             `yaml:"allow_custom_workflows,omitempty" json:"allow_custom_workflows,omitempty"`
 	TemplateOverrides           map[string]string `yaml:"template_overrides,omitempty" json:"template_overrides,omitempty"`
+	CheckoutStrategy            string            `yaml:"checkout_strategy,omitempty" json:"checkout_strategy,omitempty"`
 }
 
 func (g GlobalCfg) GetWorkflowNames() []string {
@@ -221,6 +224,7 @@ func (r Repo) Validate() error {
 	return validation.ValidateStruct(&r,
 		validation.Field(&r.ID, validation.Required, validation.By(idValid)),
 		validation.Field(&r.Branch, validation.By(branchValid)),
+		validation.Field(&r.CheckoutStrategy, validation.In(validCheckoutStrategies)),
 		validation.Field(&r.AllowedOverrides, validation.By(overridesValid)),
 		validation.Field(&r.ApplyRequirements, validation.By(validApplyReq)),
 		validation.Field(&r.Workflow, validation.By(workflowExists)),
@@ -298,6 +302,13 @@ OUTER:
 		mergedApplyReqs = append(mergedApplyReqs, globalReq)
 	}
 
+	var checkoutStrategy string
+	if r.CheckoutStrategy == "" {
+		checkoutStrategy = "branch"
+	} else {
+		checkoutStrategy = r.CheckoutStrategy
+	}
+
 	return valid.Repo{
 		ID:                          id,
 		IDRegex:                     idRegex,
@@ -313,6 +324,7 @@ OUTER:
 		AllowedOverrides:            r.AllowedOverrides,
 		AllowCustomWorkflows:        r.AllowCustomWorkflows,
 		TemplateOverrides:           r.TemplateOverrides,
+		CheckoutStrategy:            checkoutStrategy,
 	}
 }
 

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -10,7 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 
-var validCheckoutStrategies = []string{"merge", "branch"}
+var validCheckoutStrategies = []interface{}{"merge", "branch"}
 
 // GlobalCfg is the raw schema for server-side repo config.
 type GlobalCfg struct {
@@ -224,7 +224,7 @@ func (r Repo) Validate() error {
 	return validation.ValidateStruct(&r,
 		validation.Field(&r.ID, validation.Required, validation.By(idValid)),
 		validation.Field(&r.Branch, validation.By(branchValid)),
-		validation.Field(&r.CheckoutStrategy, validation.In(validCheckoutStrategies)),
+		validation.Field(&r.CheckoutStrategy, validation.In(validCheckoutStrategies...)),
 		validation.Field(&r.AllowedOverrides, validation.By(overridesValid)),
 		validation.Field(&r.ApplyRequirements, validation.By(validApplyReq)),
 		validation.Field(&r.Workflow, validation.By(workflowExists)),

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -181,6 +181,7 @@ func NewGlobalCfg() GlobalCfg {
 		ApplyRequirements:    []string{},
 		AllowCustomWorkflows: &allowCustomWorkflows,
 		AllowedOverrides:     []string{},
+		CheckoutStrategy:     "branch",
 	}
 
 	globalCfg := GlobalCfg{

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -56,6 +56,7 @@ func TestNewGlobalCfg(t *testing.T) {
 				AllowedWorkflows:     []string{},
 				AllowedOverrides:     []string{},
 				AllowCustomWorkflows: Bool(false),
+				CheckoutStrategy:     "branch",
 			},
 		},
 		Workflows: map[string]valid.Workflow{
@@ -178,6 +179,7 @@ func TestPlatformModeNewGlobalCfg(t *testing.T) {
 				AllowedWorkflows:     []string{},
 				AllowedOverrides:     []string{},
 				AllowCustomWorkflows: Bool(false),
+				CheckoutStrategy:     "branch",
 			},
 		},
 		Workflows: map[string]valid.Workflow{

--- a/server/core/config/valid/global_repo_cfg.go
+++ b/server/core/config/valid/global_repo_cfg.go
@@ -22,6 +22,7 @@ type Repo struct {
 	AllowedOverrides            []string
 	AllowCustomWorkflows        *bool
 	TemplateOverrides           map[string]string
+	CheckoutStrategy            string
 }
 
 // IDMatches returns true if the repo ID otherID matches this config.

--- a/server/events/apply_requirement_handler.go
+++ b/server/events/apply_requirement_handler.go
@@ -33,7 +33,7 @@ func (a *AggregateApplyRequirements) ValidateProject(repoDir string, ctx command
 				return "Pull request must be mergeable before running apply.", nil
 			}
 		case raw.UnDivergedApplyRequirement:
-			if a.WorkingDir.HasDiverged(ctx.Log, repoDir) {
+			if a.WorkingDir.HasDiverged(ctx.Log, repoDir, ctx.BaseRepo) {
 				return "Default branch must be rebased onto pull request before running apply.", nil
 			}
 		case raw.UnlockedApplyRequirement:

--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/petergtz/pegomock"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	eventMocks "github.com/runatlantis/atlantis/server/events/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -27,7 +28,7 @@ func TestClone_GithubAppNoneExisting(t *testing.T) {
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
-		CheckoutMerge:               false,
+		GlobalCfg:                   valid.NewGlobalCfg(),
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 
@@ -48,7 +49,7 @@ func TestClone_GithubAppNoneExisting(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
 
 	cloneDir, _, err := gwd.Clone(logger, models.Repo{}, models.PullRequest{
-		BaseRepo:   models.Repo{},
+		BaseRepo:   NewBaseRepo(),
 		HeadBranch: "branch",
 	}, "default")
 	Ok(t, err)

--- a/server/events/mock_workingdir_test.go
+++ b/server/events/mock_workingdir_test.go
@@ -68,11 +68,11 @@ func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, w
 	return ret0, ret1
 }
 
-func (mock *MockWorkingDir) HasDiverged(log logging.Logger, cloneDir string) bool {
+func (mock *MockWorkingDir) HasDiverged(log logging.Logger, cloneDir string, baseRepo models.Repo) bool {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
-	params := []pegomock.Param{log, cloneDir}
+	params := []pegomock.Param{log, cloneDir, baseRepo}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
 	var ret0 bool
 	if len(result) != 0 {
@@ -243,8 +243,8 @@ func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetAllCapturedArgumen
 	return
 }
 
-func (verifier *VerifierMockWorkingDir) HasDiverged(log logging.Logger, cloneDir string) *MockWorkingDir_HasDiverged_OngoingVerification {
-	params := []pegomock.Param{log, cloneDir}
+func (verifier *VerifierMockWorkingDir) HasDiverged(log logging.Logger, cloneDir string, baseRepo models.Repo) *MockWorkingDir_HasDiverged_OngoingVerification {
+	params := []pegomock.Param{log, cloneDir, baseRepo}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasDiverged", params, verifier.timeout)
 	return &MockWorkingDir_HasDiverged_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -254,12 +254,12 @@ type MockWorkingDir_HasDiverged_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() (logging.Logger, string) {
-	log, cloneDir := c.GetAllCapturedArguments()
-	return log[len(log)-1], cloneDir[len(cloneDir)-1]
+func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() (logging.Logger, string, models.Repo) {
+	log, cloneDir, baseRepo := c.GetAllCapturedArguments()
+	return log[len(log)-1], cloneDir[len(cloneDir)-1], baseRepo[len(baseRepo)-1]
 }
 
-func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.Logger, _param1 []string) {
+func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.Logger, _param1 []string, _param2 []models.Repo) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]logging.Logger, len(c.methodInvocations))
@@ -269,6 +269,10 @@ func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments
 		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+		_param2 = make([]models.Repo, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(models.Repo)
 		}
 	}
 	return

--- a/server/events/mocks/mock_working_dir.go
+++ b/server/events/mocks/mock_working_dir.go
@@ -68,11 +68,11 @@ func (mock *MockWorkingDir) GetWorkingDir(r models.Repo, p models.PullRequest, w
 	return ret0, ret1
 }
 
-func (mock *MockWorkingDir) HasDiverged(log logging.Logger, cloneDir string) bool {
+func (mock *MockWorkingDir) HasDiverged(log logging.Logger, cloneDir string, baseRepo models.Repo) bool {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockWorkingDir().")
 	}
-	params := []pegomock.Param{log, cloneDir}
+	params := []pegomock.Param{log, cloneDir, baseRepo}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("HasDiverged", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
 	var ret0 bool
 	if len(result) != 0 {
@@ -243,8 +243,8 @@ func (c *MockWorkingDir_GetWorkingDir_OngoingVerification) GetAllCapturedArgumen
 	return
 }
 
-func (verifier *VerifierMockWorkingDir) HasDiverged(log logging.Logger, cloneDir string) *MockWorkingDir_HasDiverged_OngoingVerification {
-	params := []pegomock.Param{log, cloneDir}
+func (verifier *VerifierMockWorkingDir) HasDiverged(log logging.Logger, cloneDir string, baseRepo models.Repo) *MockWorkingDir_HasDiverged_OngoingVerification {
+	params := []pegomock.Param{log, cloneDir, baseRepo}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasDiverged", params, verifier.timeout)
 	return &MockWorkingDir_HasDiverged_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -254,12 +254,12 @@ type MockWorkingDir_HasDiverged_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() (logging.Logger, string) {
-	log, cloneDir := c.GetAllCapturedArguments()
-	return log[len(log)-1], cloneDir[len(cloneDir)-1]
+func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetCapturedArguments() (logging.Logger, string, models.Repo) {
+	log, cloneDir, baseRepo := c.GetAllCapturedArguments()
+	return log[len(log)-1], cloneDir[len(cloneDir)-1], baseRepo[len(baseRepo)-1]
 }
 
-func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.Logger, _param1 []string) {
+func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments() (_param0 []logging.Logger, _param1 []string, _param2 []models.Repo) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]logging.Logger, len(c.methodInvocations))
@@ -269,6 +269,10 @@ func (c *MockWorkingDir_HasDiverged_OngoingVerification) GetAllCapturedArguments
 		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
+		}
+		_param2 = make([]models.Repo, len(c.methodInvocations))
+		for u, param := range params[2] {
+			_param2[u] = param.(models.Repo)
 		}
 	}
 	return

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -430,7 +430,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
 	When(mockWorkingDir.GetWorkingDir(prjCtx.BaseRepo, prjCtx.Pull, prjCtx.Workspace)).ThenReturn(tmp, nil)
-	When(mockWorkingDir.HasDiverged(matchers.AnyLoggingLogger(), AnyString())).ThenReturn(true)
+	When(mockWorkingDir.HasDiverged(matchers.AnyLoggingLogger(), AnyString(), matchers.AnyModelsRepo())).ThenReturn(true)
 
 	firstRes := runner.Apply(prjCtx)
 	Equals(t, "Default branch must be rebased onto pull request before running apply.", firstRes.Failure)

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -83,9 +83,6 @@ func (w *FileWorkspace) Clone(
 	matchingRepo := w.GlobalCfg.MatchingRepo(p.BaseRepo.ID())
 	checkoutMerge := matchingRepo.CheckoutStrategy == "merge"
 
-	// TODO: Remove once staging testing is complete
-	log.Info(fmt.Sprintf("checkout strategy set to: %s", matchingRepo.CheckoutStrategy))
-
 	// If the directory already exists, check if it's at the right commit.
 	// If so, then we do nothing.
 	if _, err := os.Stat(cloneDir); err == nil {

--- a/server/events/working_dir.go
+++ b/server/events/working_dir.go
@@ -83,6 +83,9 @@ func (w *FileWorkspace) Clone(
 	matchingRepo := w.GlobalCfg.MatchingRepo(p.BaseRepo.ID())
 	checkoutMerge := matchingRepo.CheckoutStrategy == "merge"
 
+	// TODO: Remove once staging testing is complete
+	log.Info(fmt.Sprintf("checkout strategy set to: %s", matchingRepo.CheckoutStrategy))
+
 	// If the directory already exists, check if it's at the right commit.
 	// If so, then we do nothing.
 	if _, err := os.Stat(cloneDir); err == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -437,7 +437,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{
 		DataDir:       userConfig.DataDir,
-		CheckoutMerge: userConfig.CheckoutStrategy == "merge",
+		GlobalCfg: globalCfg,
 	}
 	// provide fresh tokens before clone from the GitHub Apps integration, proxy workingDir
 	if githubAppEnabled {

--- a/server/server.go
+++ b/server/server.go
@@ -436,7 +436,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	workingDirLocker := events.NewDefaultWorkingDirLocker()
 
 	var workingDir events.WorkingDir = &events.FileWorkspace{
-		DataDir:       userConfig.DataDir,
+		DataDir:   userConfig.DataDir,
 		GlobalCfg: globalCfg,
 	}
 	// provide fresh tokens before clone from the GitHub Apps integration, proxy workingDir


### PR DESCRIPTION
This will allow us to use the normal branch strategy for super large repos (ie. shallow clones).  

```
repos:
   - id: /github.com/lyft/*/
      checkout_strategy: merge
   - id: /github.com/lyft/large_repo
      checkout_strategy: branch
```

- [x] Validate this works on staging