### PR TITLE
Update UpdateChecksStatus to create a new check run when it's a rerun

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -548,7 +548,6 @@ func (g *GithubClient) UpdateChecksStatus(ctx context.Context, request types.Upd
 		if status == Completed.String() {
 			updateCheckRunOpts.Conclusion = &conclusion
 		}
-
 		_, _, err := g.client.Checks.UpdateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, *checkRun.ID, updateCheckRunOpts)
 		return err
 	}

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -425,7 +425,7 @@ func TestGithubClient_UpdateChecksStatus(t *testing.T) {
 					},
 				},
 				PullNum:     1,
-				State:       models.PendingCommitStatus,
+				State:       models.SuccessCommitStatus,
 				Description: "description",
 				DetailsURL:  "https://google.com",
 				Ref:         "sha",
@@ -554,7 +554,7 @@ func TestGithubClient_UpdateChecksStatus_CreateNewCheckRunWhenPendingStatus(t *t
 				err = json.Unmarshal(body, &m)
 				Ok(t, err)
 
-				// assert conclusion was set to success when status is complete
+				// assert new checkrun was created
 				assert.Equal(t, checkRunName, m["name"])
 
 			default:


### PR DESCRIPTION
Our current implementation reuses the same check run updating the status and the output when an operation is rerun. The problem with this approach is that it once a check run has been marked completed, it can't be set to in_progress. So, we fix this by adding a checking if the status is pending if a checkrun already exists. 