### PR TITLE
Fix Atlantis Policy Check when using GIthub Checks

### DIFF
--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -45,7 +45,7 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		if statusErr := a.commitStatusUpdater.UpdateCombined(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.PolicyCheck); statusErr != nil {
 			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", statusErr))
 		}
-		a.outputUpdater.UpdateOutput(ctx, cmd, command.Result{Error: err})
+		a.outputUpdater.UpdateOutput(ctx, PolicyCheckCommand{}, command.Result{Error: err})
 		return
 	}
 
@@ -64,7 +64,7 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 
 	a.outputUpdater.UpdateOutput(
 		ctx,
-		cmd,
+		PolicyCheckCommand{},
 		result,
 	)
 

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -62,6 +62,9 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 
 	result := a.buildApprovePolicyCommandResults(ctx, projectCmds)
 
+	// Replace the ApprovePolicies command with PolicyCheck since the ChecksOutputUpdater creates a policy check checkrun for every project
+	// So, need to set the PolicyCheck per project to green when using github checks
+	// When using pull output updater, this will modify the comment output which should not affect the operation.
 	a.outputUpdater.UpdateOutput(
 		ctx,
 		PolicyCheckCommand{},


### PR DESCRIPTION
When using commit status API, during an approve_policies operation, we only need to set the `atlantis/policy_check` status to green. However, when using github checks, we create a check run for policy check per project level. So, we need to set the status to green for each of the checkrun when a user runs `atlantis approve_policies`, or else the apply operation is blocked as mentioned in the thread. 

So, instead of creating a check run for `atlantis/approve_policies` per project level, we update the `atlantis/policy_check` per project level to green, which shall unblock the PR for failing policies. 

[Slack Thread](https://lyft.slack.com/archives/C7HKA53FF/p1654814809020909)

TODO:

- [ ] Add e2e test for policy approval. 

