### PR TITLE
Add pending apply checks filter to PullMergeabilityChecker

### DIFF
--- a/server/events/vcs/inject.go
+++ b/server/events/vcs/inject.go
@@ -4,7 +4,7 @@ package vcs
 
 func NewPullMergeabilityChecker(commitStatusPrefix string) MergeabilityChecker {
 	statusFilters := newValidStatusFilters(commitStatusPrefix)
-	checksFilters := newValidChecksFilters()
+	checksFilters := newValidChecksFilters(commitStatusPrefix)
 
 	return &PullMergeabilityChecker{
 		supplementalChecker: newSupplementalMergeabilityChecker(statusFilters, checksFilters),
@@ -13,6 +13,8 @@ func NewPullMergeabilityChecker(commitStatusPrefix string) MergeabilityChecker {
 
 func newValidStatusFilters(commitStatusPrefix string) []ValidStatusFilter {
 	titleMatcher := StatusTitleMatcher{TitlePrefix: commitStatusPrefix}
+
+	// TODO: Remove apply status filter after github checks is fully rolled out.
 	applyStatusFilter := &ApplyStatusFilter{
 		statusTitleMatcher: titleMatcher,
 	}
@@ -22,9 +24,13 @@ func newValidStatusFilters(commitStatusPrefix string) []ValidStatusFilter {
 	}
 }
 
-func newValidChecksFilters() []ValidChecksFilter {
+func newValidChecksFilters(commitStatusPrefix string) []ValidChecksFilter {
+	titleMatcher := StatusTitleMatcher{TitlePrefix: commitStatusPrefix}
+	applyChecksFilter := &ApplyChecksFilter{
+		statusTitleMatcher: titleMatcher,
+	}
 	return []ValidChecksFilter{
-		SuccessConclusionFilter,
+		SuccessConclusionFilter, applyChecksFilter,
 	}
 }
 

--- a/server/events/vcs/inject_lyft.go
+++ b/server/events/vcs/inject_lyft.go
@@ -8,7 +8,7 @@ func NewLyftPullMergeabilityChecker(commitStatusPrefix string) MergeabilityCheck
 	statusFilters := newValidStatusFilters(commitStatusPrefix)
 
 	statusFilters = append(statusFilters, lyft.NewSQFilter())
-	checksFilters := newValidChecksFilters()
+	checksFilters := newValidChecksFilters(commitStatusPrefix)
 
 	supplementalChecker := newSupplementalMergeabilityChecker(statusFilters, checksFilters)
 	supplementalChecker = lyft.NewOwnersStatusChecker(supplementalChecker)

--- a/server/events/vcs/mergeability.go
+++ b/server/events/vcs/mergeability.go
@@ -50,6 +50,24 @@ type ValidChecksFilter interface {
 	Filter(status []*github.CheckRun) []*github.CheckRun
 }
 
+// ApplyChecksFilter filters statuses that correspond to atlantis apply
+type ApplyChecksFilter struct {
+	statusTitleMatcher StatusTitleMatcher
+}
+
+func (d ApplyChecksFilter) Filter(checks []*github.CheckRun) []*github.CheckRun {
+	var filtered []*github.CheckRun
+	for _, check := range checks {
+		if d.statusTitleMatcher.MatchesCommand(*check.Name, "apply") {
+			continue
+		}
+
+		filtered = append(filtered, check)
+	}
+
+	return filtered
+}
+
 // ConclusionFilter filters checks that match a given conclusion
 type ConclusionFilter string
 


### PR DESCRIPTION
Since we'll be migrating to github checks, we'll need to filter out pending apply checks similar to how we do it for commit statuses. Here, we add support for filtering out pending apply checkruns when calculating mergeability of a PR. 

The status filter is required for now to support PRs in-flight during the rollout. This will be removed once github checks is fully rolled out. 


[Reference](https://docs.google.com/document/d/1vNGXKRDSb9ZNWBuRbQl3Rc6Gw6j8u_TSPGigw-bco5E/edit?usp=sharing)