### PR TITLE
Add support for handling in-flight PRs during rollout

### DIFF
--- a/server/lyft/checks/github_client.go
+++ b/server/lyft/checks/github_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -29,5 +31,32 @@ func (c *ChecksClientWrapper) UpdateStatus(ctx context.Context, request types.Up
 		return c.GithubClient.UpdateStatus(ctx, request)
 	}
 
+	// Get all commit statuses and check if the commit status for this operation is pending
+	// and mirror the checks status. This is possible when PRs are in-flight during rollout.
+	// [WENGINES-4643] - Clean up after github checks is stable.
+	statuses, err := c.GithubClient.GetRepoStatuses(request.Repo, models.PullRequest{
+		HeadCommit: request.Ref,
+	})
+	if err != nil {
+		return errors.Wrap(err, "retrieving repo statuses")
+	}
+
+	for _, status := range statuses {
+		// Skip if name does not match or the state is same
+		if *status.Context != request.StatusName || isSameState(*status.State, request.State) {
+			continue
+		}
+		c.GithubClient.UpdateStatus(ctx, request)
+	}
+
 	return c.GithubClient.UpdateChecksStatus(ctx, request)
+}
+
+func isSameState(statusState string, requestState models.CommitStatus) bool {
+	if requestState == models.PendingCommitStatus && statusState == "pending" ||
+		requestState == models.FailedCommitStatus && statusState == "failure" ||
+		requestState == models.SuccessCommitStatus && statusState == "success" {
+		return true
+	}
+	return false
 }

--- a/server/lyft/checks/github_client_test.go
+++ b/server/lyft/checks/github_client_test.go
@@ -1,0 +1,215 @@
+package checks
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/events/vcs/types"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubClient_PendingCommitStatusWhenUsingChecksAPI(t *testing.T) {
+	listCheckRunResp := `
+	{
+		"total_count": 0,
+		"check_runs": []
+	  }
+	`
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	statusName := "atlantis/apply"
+	pendingStatusResolved := false
+
+	testServer := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.RequestURI {
+			// Update Status
+			case "/api/v3/repos/owner/repo/statuses/sha":
+				body, err := ioutil.ReadAll(r.Body)
+				assert.NoError(t, err)
+
+				m := make(map[string]interface{})
+				err = json.Unmarshal(body, &m)
+				assert.NoError(t, err)
+
+				if m["context"] == statusName {
+					pendingStatusResolved = true
+				}
+
+			// Get statuses
+			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
+				assert.NoError(t, err)
+
+			// List checkruns
+			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
+				_, err := w.Write([]byte(listCheckRunResp))
+				assert.NoError(t, err)
+
+			// Create checkrun
+			case "/api/v3/repos/owner/repo/check-runs":
+
+			default:
+				t.Errorf("got unexpected request at %q", r.RequestURI)
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+		}))
+
+	testServerURL, err := url.Parse(testServer.URL)
+	assert.NoError(t, err)
+	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+	assert.NoError(t, err)
+
+	defer disableSSLVerification()()
+
+	checksClientWrapper := ChecksClientWrapper{
+		GithubClient:     client,
+		FeatureAllocator: &mockFeatureAllocator{},
+		Logger:           logging.NewNoopCtxLogger(t),
+	}
+
+	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
+		StatusName: statusName,
+		Ref:        "sha",
+		Repo: models.Repo{
+			Owner: "owner",
+			Name:  "repo",
+		},
+		State: models.SuccessCommitStatus,
+	})
+
+	assert.True(t, pendingStatusResolved)
+}
+
+func TestGithubClient_NoStatusUpdateIfSameState(t *testing.T) {
+	listCheckRunResp := `
+	{
+		"total_count": 0,
+		"check_runs": []
+	  }
+	`
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	statusName := "atlantis/apply"
+	updateStatusReqReceived := false
+
+	testServer := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.RequestURI {
+			// Update Status
+			case "/api/v3/repos/owner/repo/statuses/sha":
+				updateStatusReqReceived = true
+				body, err := ioutil.ReadAll(r.Body)
+				assert.NoError(t, err)
+
+				m := make(map[string]interface{})
+				err = json.Unmarshal(body, &m)
+				assert.NoError(t, err)
+			// Get statuses
+			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
+				assert.NoError(t, err)
+
+			// List checkruns
+			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
+				_, err := w.Write([]byte(listCheckRunResp))
+				assert.NoError(t, err)
+
+			// Create checkrun
+			case "/api/v3/repos/owner/repo/check-runs":
+
+			default:
+				t.Errorf("got unexpected request at %q", r.RequestURI)
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+		}))
+
+	testServerURL, err := url.Parse(testServer.URL)
+	assert.NoError(t, err)
+	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+	assert.NoError(t, err)
+
+	defer disableSSLVerification()()
+
+	checksClientWrapper := ChecksClientWrapper{
+		GithubClient:     client,
+		FeatureAllocator: &mockFeatureAllocator{},
+		Logger:           logging.NewNoopCtxLogger(t),
+	}
+
+	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
+		StatusName: statusName,
+		Ref:        "sha",
+		Repo: models.Repo{
+			Owner: "owner",
+			Name:  "repo",
+		},
+		State: models.PendingCommitStatus,
+	})
+
+	assert.False(t, updateStatusReqReceived)
+}
+
+// disableSSLVerification disables ssl verification for the global http client
+// and returns a function to be called in a defer that will re-enable it.
+func disableSSLVerification() func() {
+	orig := http.DefaultTransport.(*http.Transport).TLSClientConfig
+	// nolint: gosec
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return func() {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = orig
+	}
+}
+
+type mockFeatureAllocator struct{}
+
+func (c *mockFeatureAllocator) ShouldAllocate(featureID feature.Name, fullRepoName string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
Open PRs during github checks rollout will have pending atlantis apply statuses which needs to be set to complete in order to unblock the PR from merging. So, in addition to updating the status of the checkrun, we also look for matching statuses and update the state of the commit status as well, unblocking the PRs for merge. 

[Reference](https://docs.google.com/document/d/1vNGXKRDSb9ZNWBuRbQl3Rc6Gw6j8u_TSPGigw-bco5E/edit?usp=sharing)