### PR TITLE
Fix policy approval for github checks

### DIFF
--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -68,6 +68,14 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		result,
 	)
 
+	// Update project level atlantis/policy_check checkrun
+	// This is a noop for PullOutputUpdater
+	a.outputUpdater.UpdateOutput(
+		ctx,
+		PolicyCheckCommand{},
+		result,
+	)
+
 	pullStatus, err := a.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
 	if err != nil {
 		ctx.Log.ErrorContext(ctx.RequestCtx, fmt.Sprintf("writing results: %s", err))

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -68,14 +68,6 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		result,
 	)
 
-	// Update project level atlantis/policy_check checkrun
-	// This is a noop for PullOutputUpdater
-	a.outputUpdater.UpdateOutput(
-		ctx,
-		PolicyCheckCommand{},
-		result,
-	)
-
 	pullStatus, err := a.dbUpdater.updateDB(ctx, pull, result.ProjectResults)
 	if err != nil {
 		ctx.Log.ErrorContext(ctx.RequestCtx, fmt.Sprintf("writing results: %s", err))

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -75,7 +75,7 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 
 		// iterate through all project results and the update the github check
 		for _, projectResult := range res.ProjectResults {
-			statusName := c.TitleBuilder.Build(command.ApprovePolicies.String(), vcs.StatusTitleOptions{
+			statusName := c.TitleBuilder.Build(command.PolicyCheck.String(), vcs.StatusTitleOptions{
 				ProjectName: projectResult.ProjectName,
 			})
 

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -70,6 +70,59 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 		return
 	}
 
+	// Temporary fix for updating project level atlantis/policy_check status when running atlantis approve_policies
+	if cmd.CommandName() == command.PolicyCheck && res.ProjectResults[0].Command == command.ApprovePolicies {
+
+		// iterate through all project results and the update the github check
+		for _, projectResult := range res.ProjectResults {
+			statusName := c.TitleBuilder.Build(command.ApprovePolicies.String(), vcs.StatusTitleOptions{
+				ProjectName: projectResult.ProjectName,
+			})
+
+			var state models.CommitStatus
+			if projectResult.Error != nil || projectResult.Failure != "" {
+				state = models.FailedCommitStatus
+			} else {
+				state = models.SuccessCommitStatus
+			}
+
+			updateStatusReq := types.UpdateStatusRequest{
+				Repo:       ctx.HeadRepo,
+				Ref:        ctx.Pull.HeadCommit,
+				StatusName: statusName,
+				PullNum:    ctx.Pull.Num,
+				State:      state,
+			}
+
+			if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
+				ctx.Log.Error("updable to update check run", map[string]interface{}{
+					"error": err.Error(),
+				})
+			}
+		}
+	}
+
+	// No need to make project level checkruns for Approve Policies
+	if cmd.CommandName() == command.ApprovePolicies {
+		output := c.MarkdownRenderer.Render(res, cmd.CommandName(), ctx.Pull.BaseRepo)
+		updateStatusReq := types.UpdateStatusRequest{
+			Repo:        ctx.HeadRepo,
+			Ref:         ctx.Pull.HeadCommit,
+			StatusName:  c.TitleBuilder.Build(cmd.CommandName().String()),
+			PullNum:     ctx.Pull.Num,
+			Description: fmt.Sprintf("%s succeded", strings.Title(cmd.CommandName().String())),
+			Output:      output,
+			State:       models.SuccessCommitStatus,
+		}
+
+		if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
+			ctx.Log.Error("updable to update check run", map[string]interface{}{
+				"error": err.Error(),
+			})
+		}
+		return
+	}
+
 	// iterate through all project results and the update the github check
 	for _, projectResult := range res.ProjectResults {
 		statusName := c.TitleBuilder.Build(cmd.CommandName().String(), vcs.StatusTitleOptions{
@@ -114,6 +167,12 @@ type PullOutputUpdater struct {
 }
 
 func (c *PullOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, res command.Result) {
+
+	// Temporary fix to handle approve_policies
+	if cmd.CommandName() == command.PolicyCheck && res.ProjectResults[0].Command == command.ApprovePolicies {
+		return
+	}
+
 	// Log if we got any errors or failures.
 	if res.Error != nil {
 		ctx.Log.Error("", map[string]interface{}{

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -30,7 +30,7 @@ type FeatureAwareChecksOutputUpdater struct {
 func (c *FeatureAwareChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, res command.Result) {
 	shouldAllocate, err := c.FeatureAllocator.ShouldAllocate(feature.GithubChecks, ctx.HeadRepo.FullName)
 	if err != nil {
-		c.Logger.Error(fmt.Sprintf("unable to allocate for feature: %s, error: %s", feature.GithubChecks, err))
+		c.Logger.ErrorContext(ctx.RequestCtx, fmt.Sprintf("unable to allocate for feature: %s, error: %s", feature.GithubChecks, err))
 	}
 
 	// Github Checks turned on and github provider
@@ -63,7 +63,7 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 		}
 
 		if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
-			ctx.Log.Error("updable to update check run", map[string]interface{}{
+			ctx.Log.ErrorContext(ctx.RequestCtx, "updable to update check run", map[string]interface{}{
 				"error": err.Error(),
 			})
 		}
@@ -104,7 +104,7 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 		}
 
 		if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
-			ctx.Log.Error("unable to update check run", map[string]interface{}{
+			ctx.Log.ErrorContext(ctx.RequestCtx, "unable to update check run", map[string]interface{}{
 				"error": err.Error(),
 			})
 		}
@@ -125,7 +125,7 @@ func (c *ChecksOutputUpdater) handleApprovePolicies(ctx *command.Context, cmd Pu
 	}
 
 	if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
-		ctx.Log.Error("updable to update check run", map[string]interface{}{
+		ctx.Log.ErrorContext(ctx.RequestCtx, "updable to update check run", map[string]interface{}{
 			"error": err.Error(),
 		})
 	}
@@ -152,7 +152,7 @@ func (c *ChecksOutputUpdater) handleApprovePolicies(ctx *command.Context, cmd Pu
 		}
 
 		if err := c.VCSClient.UpdateStatus(ctx.RequestCtx, updateStatusReq); err != nil {
-			ctx.Log.Error("updable to update check run", map[string]interface{}{
+			ctx.Log.ErrorContext(ctx.RequestCtx, "updable to update check run", map[string]interface{}{
 				"error": err.Error(),
 			})
 		}
@@ -171,11 +171,11 @@ type PullOutputUpdater struct {
 func (c *PullOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, res command.Result) {
 	// Log if we got any errors or failures.
 	if res.Error != nil {
-		ctx.Log.Error("", map[string]interface{}{
+		ctx.Log.ErrorContext(ctx.RequestCtx, "", map[string]interface{}{
 			"error": res.Error.Error(),
 		})
 	} else if res.Failure != "" {
-		ctx.Log.Warn("", map[string]interface{}{
+		ctx.Log.WarnContext(ctx.RequestCtx, "", map[string]interface{}{
 			"failiure": res.Failure,
 		})
 	}
@@ -185,7 +185,7 @@ func (c *PullOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, 
 	// comment trail may be useful in auditing or backtracing problems.
 	if c.HidePrevPlanComments {
 		if err := c.VCSClient.HidePrevCommandComments(ctx.Pull.BaseRepo, ctx.Pull.Num, cmd.CommandName().TitleString()); err != nil {
-			ctx.Log.Error("unable to hide old comments", map[string]interface{}{
+			ctx.Log.ErrorContext(ctx.RequestCtx, "unable to hide old comments", map[string]interface{}{
 				"error": err.Error(),
 			})
 		}
@@ -193,7 +193,7 @@ func (c *PullOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, 
 
 	comment := c.MarkdownRenderer.Render(res, cmd.CommandName(), ctx.Pull.BaseRepo)
 	if err := c.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, comment, cmd.CommandName().String()); err != nil {
-		ctx.Log.Error("unable to comment", map[string]interface{}{
+		ctx.Log.ErrorContext(ctx.RequestCtx, "unable to comment", map[string]interface{}{
 			"error": err.Error(),
 		})
 	}

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -164,12 +164,6 @@ type PullOutputUpdater struct {
 }
 
 func (c *PullOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand, res command.Result) {
-
-	// Temporary fix to handle approve_policies
-	if cmd.CommandName() == command.PolicyCheck && res.ProjectResults[0].Command == command.ApprovePolicies {
-		return
-	}
-
 	// Log if we got any errors or failures.
 	if res.Error != nil {
 		ctx.Log.Error("", map[string]interface{}{

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -483,113 +483,113 @@ func (g *GithubClient) UpdateStatus(ctx context.Context, request types.UpdateSta
 	return err
 }
 
-func (g *GithubClient) findCheckRun(statusName string, checkRuns []*github.CheckRun) *github.CheckRun {
-	for _, checkRun := range checkRuns {
-		if *checkRun.Name == statusName {
-			return checkRun
-		}
-	}
-	return nil
-}
-
 // [WENGINES-4643] TODO: Move the checks implementation to UpdateStatus once github checks is stable
 func (g *GithubClient) UpdateChecksStatus(ctx context.Context, request types.UpdateStatusRequest) error {
-
-	// Cap the output string if it exceeds the max checks output length
-	var output string
-	if len(request.Output) > maxChecksOutputLength {
-		output = request.Output[:maxChecksOutputLength]
-	} else {
-		output = request.Output
-	}
-
 	checkRuns, err := g.GetRepoChecks(request.Repo, request.Ref)
 	if err != nil {
 		return err
 	}
 
-	status, conclusion := g.resolveChecksStatus(request.State)
-
 	// Update checkrun if it exists and if it's not a rerun
 	// request.state is pending only when an operation starts. So, if the checkrun exists and the state is pending, it is a rerun.
 	if checkRun := g.findCheckRun(request.StatusName, checkRuns); checkRun != nil && request.State != models.PendingCommitStatus {
-
-		// Copy the checkrun output if not passed in.
-		var checkRunOutput github.CheckRunOutput
-		if output != "" {
-			checkRunOutput = github.CheckRunOutput{
-				Title: &request.StatusName,
-				Text:  &output,
-			}
-		} else {
-			checkRunOutput = *checkRun.Output
-		}
-
-		summary := request.Description
-
-		// Append job URL if it is a project plan/apply command
-		if strings.Contains(request.StatusName, ":") &&
-			(strings.Contains(request.StatusName, "plan") || strings.Contains(request.StatusName, "apply")) {
-
-			// URL in update request takes precedence over the URL in the check run
-			// checkrun URL could be stale from previous operation
-			if request.DetailsURL != "" {
-				summary = fmt.Sprintf("%s\n[Logs](%s)", request.Description, request.DetailsURL)
-			} else if checkRun.DetailsURL != nil {
-				summary = fmt.Sprintf("%s\n[Logs](%s)", request.Description, *checkRun.DetailsURL)
-			}
-		}
-		checkRunOutput.Summary = &summary
-
-		updateCheckRunOpts := github.UpdateCheckRunOptions{
-			Name:    request.StatusName,
-			HeadSHA: &request.Ref,
-			Status:  &status,
-			Output:  &checkRunOutput,
-		}
-
-		if request.DetailsURL != "" {
-			updateCheckRunOpts.DetailsURL = &request.DetailsURL
-		}
-
-		// Conclusion is required if status is Completed
-		if status == Completed.String() {
-			updateCheckRunOpts.Conclusion = &conclusion
-		}
-		_, _, err := g.client.Checks.UpdateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, *checkRun.ID, updateCheckRunOpts)
-		return err
+		return g.updateChecksStatus(ctx, request, checkRun)
 	}
+
+	return g.createChecksStatus(ctx, request)
+}
+
+// Update existing checkrun
+func (g *GithubClient) updateChecksStatus(ctx context.Context, request types.UpdateStatusRequest, checkRun *github.CheckRun) error {
+
+	var fallBackURL string
+	if checkRun.DetailsURL != nil {
+		fallBackURL = *checkRun.DetailsURL
+	}
+
+	ouptut := g.capCheckRunOutput(request.Output)
+	status, conclusion := g.resolveChecksStatus(request.State)
+	summary := g.summaryWithJobURL(request, fallBackURL)
 
 	checkRunOutput := github.CheckRunOutput{
-		Title: &request.StatusName,
+		Title:   &request.StatusName,
+		Text:    &ouptut,
+		Summary: &summary,
 	}
 
-	if output != "" {
-		checkRunOutput.Text = &output
+	updateCheckRunOpts := github.UpdateCheckRunOptions{
+		Name:    request.StatusName,
+		HeadSHA: &request.Ref,
+		Status:  &status,
+		Output:  &checkRunOutput,
+	}
+
+	// URL in update request takes precedence.
+	// fall back to checkRun details URL
+	if request.DetailsURL != "" {
+		updateCheckRunOpts.DetailsURL = &request.DetailsURL
+	} else if checkRun.DetailsURL != nil {
+		updateCheckRunOpts.DetailsURL = checkRun.DetailsURL
+	}
+
+	// Conclusion is required if status is Completed
+	if status == Completed.String() {
+		updateCheckRunOpts.Conclusion = &conclusion
+	}
+	_, _, err := g.client.Checks.UpdateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, *checkRun.ID, updateCheckRunOpts)
+	return err
+}
+
+// create a new checkrun
+func (g *GithubClient) createChecksStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+	ouptut := g.capCheckRunOutput(request.Output)
+	status, conclusion := g.resolveChecksStatus(request.State)
+	summary := g.summaryWithJobURL(request, "")
+
+	checkRunOutput := github.CheckRunOutput{
+		Title:   &request.StatusName,
+		Text:    &ouptut,
+		Summary: &summary,
 	}
 
 	createCheckRunOpts := github.CreateCheckRunOptions{
 		Name:    request.StatusName,
 		HeadSHA: request.Ref,
 		Status:  &status,
+		Output:  &checkRunOutput,
 	}
-
-	summary := request.Description
-	// Append job URL if project command
-	if strings.Contains(request.StatusName, ":") && request.DetailsURL != "" {
-		createCheckRunOpts.DetailsURL = &request.DetailsURL
-		summary = fmt.Sprintf("%s\n[Logs](%s)", summary, request.DetailsURL)
-	}
-	checkRunOutput.Summary = &summary
-	createCheckRunOpts.Output = &checkRunOutput
 
 	// Conclusion is required if status is Completed
 	if status == Completed.String() {
 		createCheckRunOpts.Conclusion = &conclusion
 	}
 
-	_, _, err = g.client.Checks.CreateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, createCheckRunOpts)
+	_, _, err := g.client.Checks.CreateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, createCheckRunOpts)
 	return err
+}
+
+// Cap the output string if it exceeds the max checks output length
+func (g *GithubClient) capCheckRunOutput(output string) string {
+	if len(output) > maxChecksOutputLength {
+		return output[:maxChecksOutputLength]
+	}
+	return output
+}
+
+// Append job URL to summary if it's a project plan or apply operation bc we currently only stream logs for these two operations
+func (g *GithubClient) summaryWithJobURL(request types.UpdateStatusRequest, fallBackURL string) string {
+	if strings.Contains(request.StatusName, ":") &&
+		(strings.Contains(request.StatusName, "plan") || strings.Contains(request.StatusName, "apply")) {
+
+		// URL in update request takes precedence
+		// fallbackURL i.e checkrun URL could be stale from previous operation
+		if request.DetailsURL != "" {
+			return fmt.Sprintf("%s\n[Logs](%s)", request.Description, request.DetailsURL)
+		} else if fallBackURL != "" {
+			return fmt.Sprintf("%s\n[Logs](%s)", request.Description, fallBackURL)
+		}
+	}
+	return request.Description
 }
 
 // Github Checks uses Status and Conclusion to report status of the check run. Need to map models.CommitStatus to Status and Conclusion
@@ -613,6 +613,15 @@ func (g *GithubClient) resolveChecksStatus(state models.CommitStatus) (string, s
 	}
 
 	return status.String(), conclusion.String()
+}
+
+func (g *GithubClient) findCheckRun(statusName string, checkRuns []*github.CheckRun) *github.CheckRun {
+	for _, checkRun := range checkRuns {
+		if *checkRun.Name == statusName {
+			return checkRun
+		}
+	}
+	return nil
 }
 
 // MarkdownPullLink specifies the string used in a pull request comment to reference another pull request.

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -529,8 +529,7 @@ func (g *GithubClient) UpdateChecksStatus(ctx context.Context, request types.Upd
 
 		// Append job URL if it is a project plan/apply command
 		if strings.Contains(request.StatusName, ":") &&
-			strings.Contains(request.StatusName, "plan") &&
-			strings.Contains(request.StatusName, "apply") {
+			(strings.Contains(request.StatusName, "plan") || strings.Contains(request.StatusName, "apply")) {
 
 			// URL in update request takes precedence over the URL in the check run
 			// checkrun URL could be stale from previous operation


### PR DESCRIPTION
Policy approval for github checks is broken because the policy_check command runner creates project level `policy_check` checkruns and the approve_policies command runner only sets the status for aggregate `atlantis/apply` check_run which leaves the project level `policy_check` check runs failing. 

So, in this PR we add the logic to update the project level `policy_check` checkruns when running `atlantis approve_policies`. 

TODO: 

- [ ] Add e2e test to ensure policy approval works 