### PR TITLE
Handle In Flight PRs during github checks rollout

### DIFF
--- a/server/events/output_updater_test.go
+++ b/server/events/output_updater_test.go
@@ -1,0 +1,188 @@
+package events
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/runatlantis/atlantis/server/vcs/markdown"
+	"github.com/stretchr/testify/assert"
+)
+
+// disableSSLVerification disables ssl verification for the global http client
+// and returns a function to be called in a defer that will re-enable it.
+func disableSSLVerification() func() {
+	orig := http.DefaultTransport.(*http.Transport).TLSClientConfig
+	// nolint: gosec
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return func() {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = orig
+	}
+}
+
+type StatusType int
+
+const (
+	CommitStatus StatusType = iota
+	ChecksStatus
+)
+
+func TestUpdateOutput(t *testing.T) {
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  },
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	cases := []struct {
+		statusNames   []string
+		desription    string
+		checksEnabled bool
+		expType       StatusType
+	}{
+		{
+			statusNames:   []string{"atlantis/plan", "atlantis/apply"},
+			desription:    "all atlantis statuses when checks is enabled",
+			checksEnabled: true,
+			expType:       CommitStatus,
+		},
+		{
+			statusNames:   []string{"terraform-fmt", "terraform-checks"},
+			desription:    "no atlantis status when checks is enabled",
+			checksEnabled: true,
+			expType:       ChecksStatus,
+		},
+		{
+			statusNames:   []string{"atlantis/plan", "terraform-fmt"},
+			desription:    "at least one atlantis status when checks is enabled",
+			checksEnabled: true,
+			expType:       CommitStatus,
+		},
+		{
+			statusNames:   []string{"terraform-checks", "terraform-fmt"},
+			desription:    "no atlantis status when checks is disabled",
+			checksEnabled: true,
+			expType:       CommitStatus,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desription, func(t *testing.T) {
+
+			var callType StatusType
+			testServer := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.RequestURI {
+
+					// Create status
+					case "/api/v3/repos/owner/repo/issues/0/comments":
+						callType = CommitStatus
+						w.WriteHeader(http.StatusOK)
+
+					case "/api/v3/repos/owner/repo/check-runs":
+						callType = ChecksStatus
+						w.WriteHeader(http.StatusOK)
+
+					// Get statuses
+					case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+						_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, c.statusNames[0], c.statusNames[1])))
+						assert.NoError(t, err)
+
+					default:
+						t.Errorf("got unexpected request at %q", r.RequestURI)
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+				}))
+
+			testServerURL, err := url.Parse(testServer.URL)
+			assert.NoError(t, err)
+
+			mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+			assert.NoError(t, err)
+
+			defer disableSSLVerification()()
+
+			outputUpdater := FeatureAwareChecksOutputUpdater{
+				PullOutputUpdater: PullOutputUpdater{
+					VCSClient:        client,
+					MarkdownRenderer: &markdown.Renderer{},
+				},
+				ChecksOutputUpdater: ChecksOutputUpdater{
+					VCSClient:        client,
+					MarkdownRenderer: &markdown.Renderer{},
+					TitleBuilder:     vcs.StatusTitleBuilder{TitlePrefix: "atlantis"},
+				},
+				FeatureAllocator: &mockFeatureAllocator{c.checksEnabled},
+				Logger:           logging.NewNoopCtxLogger(t),
+				GithubClient:     *client,
+			}
+
+			outputUpdater.UpdateOutput(&command.Context{
+				HeadRepo: models.Repo{
+					Owner: "owner",
+					Name:  "repo",
+					VCSHost: models.VCSHost{
+						Type: models.Github,
+					},
+				},
+				Pull: models.PullRequest{
+					HeadCommit: "sha",
+					BaseRepo: models.Repo{
+						Owner: "owner",
+						Name:  "repo",
+						VCSHost: models.VCSHost{
+							Type: models.Github,
+						},
+					},
+				},
+			}, PolicyCheckCommand{}, command.Result{
+				ProjectResults: []command.ProjectResult{
+					{
+						Command:      command.PolicyCheck,
+						ApplySuccess: "Apply Success",
+					},
+				},
+			})
+
+			assert.Equal(t, c.expType, callType)
+		})
+
+	}
+
+}
+
+type mockFeatureAllocator struct {
+	shouldAllocate bool
+}
+
+func (m *mockFeatureAllocator) ShouldAllocate(featureID feature.Name, fullRepoName string) (bool, error) {
+	return m.shouldAllocate, nil
+}

--- a/server/events/vcs/types/status.go
+++ b/server/events/vcs/types/status.go
@@ -12,4 +12,9 @@ type UpdateStatusRequest struct {
 	Description string
 	DetailsURL  string
 	Output      string
+
+	// [WENGINES-4643] TODO: Remove UseGithubChecks flag when github checks is stable.
+	// UseGithubChecks is false by default. It is set to true if the output updater determines that there's no existing atlantis status
+	// Used to avoid duplicate API call to determine if github checks needs to be used in checks client wrapper
+	UseGithubChecks bool
 }

--- a/server/lyft/checks/github_client.go
+++ b/server/lyft/checks/github_client.go
@@ -22,6 +22,13 @@ type ChecksClientWrapper struct {
 
 // [WENGINES-4643] - Clean up after github checks is stable.
 func (c *ChecksClientWrapper) UpdateStatus(ctx context.Context, request types.UpdateStatusRequest) error {
+
+	// UseGithubChecks is set by outputUpdater if feature flag and repo status has already been evaluated.
+	// false by default, check the feature flag and existing statuses if this flag is not set.
+	if request.UseGithubChecks {
+		return c.GithubClient.UpdateChecksStatus(ctx, request)
+	}
+
 	shouldAllocate, err := c.FeatureAllocator.ShouldAllocate(feature.GithubChecks, request.Repo.FullName)
 	if err != nil {
 		c.Logger.ErrorContext(ctx, fmt.Sprintf("unable to allocate for feature: %s", feature.GithubChecks), map[string]interface{}{

--- a/server/lyft/checks/github_client.go
+++ b/server/lyft/checks/github_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
@@ -29,5 +31,32 @@ func (c *ChecksClientWrapper) UpdateStatus(ctx context.Context, request types.Up
 		return c.GithubClient.UpdateStatus(ctx, request)
 	}
 
+	// Get all commit statuses and check if the commit status for this operation is pending
+	// and mirror the checks status. This is possible when PRs are in-flight during rollout.
+	// [WENGINES-4643] - Clean up after github checks is stable.
+	statuses, err := c.GithubClient.GetRepoStatuses(request.Repo, models.PullRequest{
+		HeadCommit: request.Ref,
+	})
+	if err != nil {
+		return errors.Wrap(err, "retrieving repo statuses")
+	}
+
+	for _, status := range statuses {
+		// Skip if name does not match or the state is same
+		if *status.Context != request.StatusName || isSameState(*status.State, request.State) {
+			continue
+		}
+		c.GithubClient.UpdateStatus(ctx, request)
+	}
+
 	return c.GithubClient.UpdateChecksStatus(ctx, request)
+}
+
+func isSameState(statusState string, requestState models.CommitStatus) bool {
+	if requestState == models.PendingCommitStatus && statusState == "pending" ||
+		requestState == models.FailedCommitStatus && statusState == "failure" ||
+		requestState == models.SuccessCommitStatus && statusState == "success" {
+		return true
+	}
+	return false
 }

--- a/server/lyft/checks/github_client_test.go
+++ b/server/lyft/checks/github_client_test.go
@@ -90,6 +90,7 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 		},
 	}
 
+	var statusType StatusType
 	for _, c := range cases {
 		t.Run(c.desription, func(t *testing.T) {
 			testServer := httptest.NewTLSServer(
@@ -98,11 +99,11 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 
 					// Create status
 					case "/api/v3/repos/owner/repo/statuses/sha":
-						assert.Equal(t, c.expType, CommitStatus)
+						statusType = CommitStatus
 						w.WriteHeader(http.StatusOK)
 
 					case "/api/v3/repos/owner/repo/check-runs":
-						assert.Equal(t, c.expType, ChecksStatus)
+						statusType = ChecksStatus
 						w.WriteHeader(http.StatusOK)
 
 					case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
@@ -145,6 +146,8 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 				},
 				State: models.SuccessCommitStatus,
 			})
+
+			assert.Equal(t, c.expType, statusType)
 
 		})
 	}
@@ -240,93 +243,6 @@ func TestGithubClient_PendingCommitStatusWhenUsingChecksAPI(t *testing.T) {
 	})
 
 	assert.True(t, pendingStatusResolved)
-}
-
-func TestGithubClient_NoStatusUpdateIfSameState(t *testing.T) {
-	listCheckRunResp := `
-	{
-		"total_count": 0,
-		"check_runs": []
-	  }
-	`
-	listStatusesResp := `
-	{
-		"state": "pending",
-		"statuses": [
-		  {
-			"context": "%s",
-			"state": "pending",
-			"created_at": "2012-07-20T01:19:13Z",
-			"updated_at": "2012-07-20T01:19:13Z"
-		  }
-		],
-		"sha": "sha",
-		"total_count": 1,
-		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
-	  }
-	`
-
-	statusName := "atlantis/apply"
-	updateStatusReqReceived := false
-
-	testServer := httptest.NewTLSServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.RequestURI {
-			// Update Status
-			case "/api/v3/repos/owner/repo/statuses/sha":
-				updateStatusReqReceived = true
-				body, err := ioutil.ReadAll(r.Body)
-				assert.NoError(t, err)
-
-				m := make(map[string]interface{})
-				err = json.Unmarshal(body, &m)
-				assert.NoError(t, err)
-			// Get statuses
-			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
-				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
-				assert.NoError(t, err)
-
-			// List checkruns
-			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
-				_, err := w.Write([]byte(listCheckRunResp))
-				assert.NoError(t, err)
-
-			// Create checkrun
-			case "/api/v3/repos/owner/repo/check-runs":
-
-			default:
-				t.Errorf("got unexpected request at %q", r.RequestURI)
-				http.Error(w, "not found", http.StatusNotFound)
-				return
-			}
-		}))
-
-	testServerURL, err := url.Parse(testServer.URL)
-	assert.NoError(t, err)
-	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
-	assert.NoError(t, err)
-
-	defer disableSSLVerification()()
-
-	checksClientWrapper := ChecksClientWrapper{
-		GithubClient:     client,
-		FeatureAllocator: &mockFeatureAllocator{},
-		Logger:           logging.NewNoopCtxLogger(t),
-	}
-
-	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
-		StatusName: statusName,
-		Ref:        "sha",
-		Repo: models.Repo{
-			Owner: "owner",
-			Name:  "repo",
-		},
-		State: models.PendingCommitStatus,
-	})
-
-	assert.False(t, updateStatusReqReceived)
 }
 
 // disableSSLVerification disables ssl verification for the global http client

--- a/server/lyft/checks/github_client_test.go
+++ b/server/lyft/checks/github_client_test.go
@@ -1,0 +1,215 @@
+package checks
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events/vcs"
+	"github.com/runatlantis/atlantis/server/events/vcs/types"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubClient_PendingCommitStatusWhenUsingChecksAPI(t *testing.T) {
+	listCheckRunResp := `
+	{
+		"total_count": 0,
+		"check_runs": []
+	  }
+	`
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	statusName := "atlantis/apply"
+	pendingStatusResolved := false
+
+	testServer := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.RequestURI {
+			// Update Status
+			case "/api/v3/repos/owner/repo/statuses/sha":
+				body, err := ioutil.ReadAll(r.Body)
+				assert.NoError(t, err)
+
+				m := make(map[string]interface{})
+				err = json.Unmarshal(body, &m)
+				assert.NoError(t, err)
+
+				if m["context"] == statusName {
+					pendingStatusResolved = true
+				}
+
+			// Get statuses
+			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
+				assert.NoError(t, err)
+
+			// List checkruns
+			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
+				_, err := w.Write([]byte(listCheckRunResp))
+				assert.NoError(t, err)
+
+			// Create checkrun
+			case "/api/v3/repos/owner/repo/check-runs":
+
+			default:
+				t.Errorf("got unexpected request at %q", r.RequestURI)
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+		}))
+
+	testServerURL, err := url.Parse(testServer.URL)
+	assert.NoError(t, err)
+	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+	assert.NoError(t, err)
+
+	defer disableSSLVerification()()
+
+	checksClientWrapper := ChecksClientWrapper{
+		GithubClient:     client,
+		FeatureAllocator: &mockFeatureAllocator{},
+		Logger:           logging.NewNoopCtxLogger(t),
+	}
+
+	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
+		StatusName: statusName,
+		Ref:        "sha",
+		Repo: models.Repo{
+			Owner: "owner",
+			Name:  "repo",
+		},
+		State: models.SuccessCommitStatus,
+	})
+
+	assert.True(t, pendingStatusResolved)
+}
+
+func TestGithubClient_NoStatusUpdateIfSameState(t *testing.T) {
+	listCheckRunResp := `
+	{
+		"total_count": 0,
+		"check_runs": []
+	  }
+	`
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	statusName := "atlantis/apply"
+	updateStatusReqReceived := false
+
+	testServer := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.RequestURI {
+			// Update Status
+			case "/api/v3/repos/owner/repo/statuses/sha":
+				updateStatusReqReceived = true
+				body, err := ioutil.ReadAll(r.Body)
+				assert.NoError(t, err)
+
+				m := make(map[string]interface{})
+				err = json.Unmarshal(body, &m)
+				assert.NoError(t, err)
+			// Get statuses
+			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
+				assert.NoError(t, err)
+
+			// List checkruns
+			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
+				_, err := w.Write([]byte(listCheckRunResp))
+				assert.NoError(t, err)
+
+			// Create checkrun
+			case "/api/v3/repos/owner/repo/check-runs":
+
+			default:
+				t.Errorf("got unexpected request at %q", r.RequestURI)
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+		}))
+
+	testServerURL, err := url.Parse(testServer.URL)
+	assert.NoError(t, err)
+	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+	assert.NoError(t, err)
+
+	defer disableSSLVerification()()
+
+	checksClientWrapper := ChecksClientWrapper{
+		GithubClient:     client,
+		FeatureAllocator: &mockFeatureAllocator{},
+		Logger:           logging.NewNoopCtxLogger(t),
+	}
+
+	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
+		StatusName: statusName,
+		Ref:        "sha",
+		Repo: models.Repo{
+			Owner: "owner",
+			Name:  "repo",
+		},
+		State: models.PendingCommitStatus,
+	})
+
+	assert.False(t, updateStatusReqReceived)
+}
+
+// disableSSLVerification disables ssl verification for the global http client
+// and returns a function to be called in a defer that will re-enable it.
+func disableSSLVerification() func() {
+	orig := http.DefaultTransport.(*http.Transport).TLSClientConfig
+	// nolint: gosec
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return func() {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = orig
+	}
+}
+
+type mockFeatureAllocator struct{}
+
+func (c *mockFeatureAllocator) ShouldAllocate(featureID feature.Name, fullRepoName string) (bool, error) {
+	return true, nil
+}

--- a/server/lyft/checks/github_client_test.go
+++ b/server/lyft/checks/github_client_test.go
@@ -3,9 +3,7 @@ package checks
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -152,97 +150,6 @@ func TestGithubClient_UpdateStatus(t *testing.T) {
 		})
 	}
 
-}
-
-func TestGithubClient_PendingCommitStatusWhenUsingChecksAPI(t *testing.T) {
-	listCheckRunResp := `
-	{
-		"total_count": 0,
-		"check_runs": []
-	  }
-	`
-	listStatusesResp := `
-	{
-		"state": "pending",
-		"statuses": [
-		  {
-			"context": "%s",
-			"state": "pending",
-			"created_at": "2012-07-20T01:19:13Z",
-			"updated_at": "2012-07-20T01:19:13Z"
-		  }
-		],
-		"sha": "sha",
-		"total_count": 1,
-		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
-	  }
-	`
-
-	statusName := "atlantis/apply"
-	pendingStatusResolved := false
-
-	testServer := httptest.NewTLSServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.RequestURI {
-			// Update Status
-			case "/api/v3/repos/owner/repo/statuses/sha":
-				body, err := ioutil.ReadAll(r.Body)
-				assert.NoError(t, err)
-
-				m := make(map[string]interface{})
-				err = json.Unmarshal(body, &m)
-				assert.NoError(t, err)
-
-				if m["context"] == statusName {
-					pendingStatusResolved = true
-				}
-
-			// Get statuses
-			case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
-				_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, statusName)))
-				assert.NoError(t, err)
-
-			// List checkruns
-			case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
-				_, err := w.Write([]byte(listCheckRunResp))
-				assert.NoError(t, err)
-
-			// Create checkrun
-			case "/api/v3/repos/owner/repo/check-runs":
-
-			default:
-				t.Errorf("got unexpected request at %q", r.RequestURI)
-				http.Error(w, "not found", http.StatusNotFound)
-				return
-			}
-		}))
-
-	testServerURL, err := url.Parse(testServer.URL)
-	assert.NoError(t, err)
-	mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
-	client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
-	assert.NoError(t, err)
-
-	defer disableSSLVerification()()
-
-	checksClientWrapper := ChecksClientWrapper{
-		GithubClient:     client,
-		FeatureAllocator: &mockFeatureAllocator{},
-		Logger:           logging.NewNoopCtxLogger(t),
-	}
-
-	checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
-		StatusName: statusName,
-		Ref:        "sha",
-		Repo: models.Repo{
-			Owner: "owner",
-			Name:  "repo",
-		},
-		State: models.SuccessCommitStatus,
-	})
-
-	assert.True(t, pendingStatusResolved)
 }
 
 // disableSSLVerification disables ssl verification for the global http client

--- a/server/lyft/checks/github_client_test.go
+++ b/server/lyft/checks/github_client_test.go
@@ -19,6 +19,138 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type StatusType int
+
+const (
+	CommitStatus StatusType = iota
+	ChecksStatus
+)
+
+func TestGithubClient_UpdateStatus(t *testing.T) {
+	listCheckRunResp := `
+	{
+		"total_count": 0,
+		"check_runs": []
+	  }
+	`
+
+	listStatusesResp := `
+	{
+		"state": "pending",
+		"statuses": [
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  },
+		  {
+			"context": "%s",
+			"state": "pending",
+			"created_at": "2012-07-20T01:19:13Z",
+			"updated_at": "2012-07-20T01:19:13Z"
+		  }
+		],
+		"sha": "sha",
+		"total_count": 1,
+		"commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+		"url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+	  }
+	`
+
+	cases := []struct {
+		statusNames   []string
+		desription    string
+		checksEnabled bool
+		expType       StatusType
+	}{
+		{
+			statusNames:   []string{"atlantis/plan", "atlantis/apply"},
+			desription:    "all atlantis statuses when checks is enabled",
+			checksEnabled: true,
+			expType:       CommitStatus,
+		},
+		{
+			statusNames:   []string{"terraform-fmt", "terraform-checks"},
+			desription:    "no atlantis status when checks is enabled",
+			checksEnabled: true,
+			expType:       ChecksStatus,
+		},
+		{
+			statusNames:   []string{"atlantis/plan", "terraform-fmt"},
+			desription:    "at least one atlantis status when checks is enabled",
+			checksEnabled: true,
+			expType:       CommitStatus,
+		},
+		{
+			statusNames:   []string{"terraform-checks", "terraform-fmt"},
+			desription:    "no atlantis status when checks is disabled",
+			checksEnabled: false,
+			expType:       CommitStatus,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desription, func(t *testing.T) {
+			testServer := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.RequestURI {
+
+					// Create status
+					case "/api/v3/repos/owner/repo/statuses/sha":
+						assert.Equal(t, c.expType, CommitStatus)
+						w.WriteHeader(http.StatusOK)
+
+					case "/api/v3/repos/owner/repo/check-runs":
+						assert.Equal(t, c.expType, ChecksStatus)
+						w.WriteHeader(http.StatusOK)
+
+					case "/api/v3/repos/owner/repo/commits/sha/check-runs?per_page=100":
+						_, err := w.Write([]byte(listCheckRunResp))
+						assert.NoError(t, err)
+
+					// Get statuses
+					case "/api/v3/repos/owner/repo/commits/sha/status?per_page=100":
+						_, err := w.Write([]byte(fmt.Sprintf(listStatusesResp, c.statusNames[0], c.statusNames[1])))
+						assert.NoError(t, err)
+
+					default:
+						t.Errorf("got unexpected request at %q", r.RequestURI)
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+				}))
+
+			testServerURL, err := url.Parse(testServer.URL)
+			assert.NoError(t, err)
+
+			mergeabilityChecker := vcs.NewPullMergeabilityChecker("atlantis")
+			client, err := vcs.NewGithubClient(testServerURL.Host, &vcs.GithubUserCredentials{"user", "pass"}, logging.NewNoopCtxLogger(t), mergeabilityChecker)
+			assert.NoError(t, err)
+
+			defer disableSSLVerification()()
+
+			checksClientWrapper := ChecksClientWrapper{
+				GithubClient:     client,
+				FeatureAllocator: &mockFeatureAllocator{c.checksEnabled},
+				Logger:           logging.NewNoopCtxLogger(t),
+			}
+
+			checksClientWrapper.UpdateStatus(context.TODO(), types.UpdateStatusRequest{
+				StatusName: "anything",
+				Ref:        "sha",
+				Repo: models.Repo{
+					Owner: "owner",
+					Name:  "repo",
+				},
+				State: models.SuccessCommitStatus,
+			})
+
+		})
+	}
+
+}
+
 func TestGithubClient_PendingCommitStatusWhenUsingChecksAPI(t *testing.T) {
 	listCheckRunResp := `
 	{
@@ -208,8 +340,10 @@ func disableSSLVerification() func() {
 	}
 }
 
-type mockFeatureAllocator struct{}
+type mockFeatureAllocator struct {
+	checksEnabled bool
+}
 
 func (c *mockFeatureAllocator) ShouldAllocate(featureID feature.Name, fullRepoName string) (bool, error) {
-	return true, nil
+	return c.checksEnabled, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -646,6 +646,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		PullOutputUpdater:   pullOutputUpdater,
 		FeatureAllocator:    featureAllocator,
 		Logger:              ctxLogger,
+		GithubClient:        *rawGithubClient,
 	}
 
 	session, err := aws.NewSession()


### PR DESCRIPTION
Here we add logic to handle PRs with already existing atlantis statuses when rolling out github checks. If there's an existing atlantis status, we use the `commitStatusAPI` to handle status updates and PR comments for printing outputs , as usual. If there's no atlantis status, we can assume that this PR was created after github checks was rolled out, and if the feature flag is enabled, we use the new github checks API. 

We check for existing atlantis statuses alongside the feature flag for github checks. One problem with this approach is since we check the feature flag in two different places: [`outputUpdater`](https://github.com/lyft/atlantis/blob/c669c6f63ed99f6da5125759ef142c52a348cb7a/server/events/output_updater.go#L43) and [`githubClientWrapper`](https://github.com/lyft/atlantis/blob/c669c6f63ed99f6da5125759ef142c52a348cb7a/server/lyft/checks/github_client.go#L33), it is possible to look for existing atlantis statuses twice for the same status update operation since outputUpdater is configured to use the `githubClientWrapper`. One way to avoid duplicate API call is to add a `useGithubChecks` field to the `UpdateStatusReq` which is false by default. We set it true in the `checksOutputUpdater` if all the requirements are met and the 2nd check in the github client wrapper can use that to avoid making duplicate call. 

Since we won't need this logic after github checks is stable, I believe an extra API call to determine which statusAPI to use is worth the tradeoff. In addition, this is also a simple approach that keeps a fine line between the two statusAPIs ensuring there's no mix of statuses. 