### PR TITLE
Remove hybrid mode

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1004,21 +1004,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		ctxLogger.Info("running Atlantis in gateway mode", map[string]interface{}{
 			"sns": userConfig.LyftGatewaySnsTopicArn,
 		})
-	case Hybrid: // gateway eventsController handles POST, and SQS worker is set up to handle messages via default eventsController
-		vcsPostHandler = gatewayEventsController
-		worker, err := sqs.NewGatewaySQSWorker(ctx, statsScope, ctxLogger, userConfig.LyftWorkerQueueURL, defaultEventsController)
-		if err != nil {
-			ctxLogger.Error("unable to set up worker", map[string]interface{}{
-				"err": err,
-			})
-			cancel()
-			return nil, errors.Wrapf(err, "setting up sqs handler for hybrid mode")
-		}
-		go worker.Work(ctx)
-		ctxLogger.Info("running Atlantis in hybrid mode", map[string]interface{}{
-			"sns":   userConfig.LyftGatewaySnsTopicArn,
-			"queue": userConfig.LyftWorkerQueueURL,
-		})
 	case Worker: // an SQS worker is set up to handle messages via default eventsController
 		worker, err := sqs.NewGatewaySQSWorker(ctx, statsScope, ctxLogger, userConfig.LyftWorkerQueueURL, defaultEventsController)
 		if err != nil {
@@ -1127,7 +1112,7 @@ func (s *Server) Start() error {
 	<-stop
 
 	// Shutdown sqs polling. Any received messages being processed will either succeed/fail depending on if drainer started.
-	if s.LyftMode == Hybrid || s.LyftMode == Worker {
+	if s.LyftMode == Worker {
 		s.CtxLogger.Warn("Received interrupt. Shutting down the sqs handler")
 		s.CancelWorker()
 	}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -9,7 +9,6 @@ type Mode int
 const (
 	Default Mode = iota
 	Gateway
-	Hybrid
 	Worker
 )
 
@@ -110,8 +109,6 @@ func (u UserConfig) ToLyftMode() Mode {
 		return Default
 	case "gateway":
 		return Gateway
-	case "hybrid":
-		return Hybrid
 	case "worker":
 		return Worker
 	}

--- a/server/user_config_test.go
+++ b/server/user_config_test.go
@@ -59,10 +59,6 @@ func TestUserConfig_ToLyftMode(t *testing.T) {
 			server.Gateway,
 		},
 		{
-			"hybrid",
-			server.Hybrid,
-		},
-		{
 			"worker",
 			server.Worker,
 		},


### PR DESCRIPTION
Hybrid mode was only needed for testing the new gateway/worker paradigm. Now that those modes are validated, we can remove this. Default mode is maintained in case a user would prefer Atlantis runs in the original style.