### PR TITLE
Add async scheduler.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,5 +178,6 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	go.temporal.io/api v1.8.0 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/logging/fields"
+	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 	"github.com/runatlantis/atlantis/server/recovery"
 	"github.com/uber-go/tally/v4"
 )
@@ -212,8 +213,8 @@ func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo m
 }
 
 func newCtx(ctx context.Context, repoFullName string, pullNum int) context.Context {
-	ctx = context.WithValue(ctx, logging.RepositoryKey, repoFullName)
-	return context.WithValue(ctx, logging.PullNumKey, strconv.Itoa(pullNum))
+	ctx = context.WithValue(ctx, contextInternal.RepositoryKey, repoFullName)
+	return context.WithValue(ctx, contextInternal.PullNumKey, strconv.Itoa(pullNum))
 }
 
 func (c *DefaultCommandRunner) validateCtxAndComment(cmdCtx *command.Context) bool {

--- a/server/events/vcs/instrumented_client.go
+++ b/server/events/vcs/instrumented_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/logging/fields"
+	keys "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 	"github.com/uber-go/tally/v4"
 )
 
@@ -81,7 +82,7 @@ func (c *InstrumentedGithubClient) GetContents(owner, repo, branch, path string)
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Info("fetched contents", map[string]interface{}{
-		logging.RepositoryKey.String(): repo,
+		keys.RepositoryKey.String(): repo,
 	})
 
 	return contents, err
@@ -111,8 +112,8 @@ func (c *InstrumentedGithubClient) GetPullRequestFromName(repoName string, repoO
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Info("fetched pull request", map[string]interface{}{
-		logging.RepositoryKey.String(): fmt.Sprintf("%s/%s", repoOwner, repoName),
-		logging.PullNumKey.String():    strconv.Itoa(pullNum),
+		keys.RepositoryKey.String(): fmt.Sprintf("%s/%s", repoOwner, repoName),
+		keys.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 
 	return pull, err
@@ -214,8 +215,8 @@ func (c *InstrumentedClient) CreateComment(repo models.Repo, pullNum int, commen
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Info("created pull request comment", map[string]interface{}{
-		logging.RepositoryKey.String(): repo.FullName,
-		logging.PullNumKey.String():    strconv.Itoa(pullNum),
+		keys.RepositoryKey.String(): repo.FullName,
+		keys.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 	return nil
 }
@@ -237,8 +238,8 @@ func (c *InstrumentedClient) HidePrevCommandComments(repo models.Repo, pullNum i
 
 	//TODO: thread context and use related logging methods.
 	c.Logger.Info("hid previous comments", map[string]interface{}{
-		logging.RepositoryKey.String(): repo.FullName,
-		logging.PullNumKey.String():    strconv.Itoa(pullNum),
+		keys.RepositoryKey.String(): repo.FullName,
+		keys.PullNumKey.String():    strconv.Itoa(pullNum),
 	})
 	return nil
 
@@ -308,11 +309,11 @@ func (c *InstrumentedClient) UpdateStatus(ctx context.Context, request types.Upd
 	// for now keeping this at info to debug weirdness we've been
 	// seeing with status api calls.
 	c.Logger.Info("updated vcs status", map[string]interface{}{
-		logging.RepositoryKey.String(): request.Repo.FullName,
-		logging.PullNumKey.String():    strconv.Itoa(request.PullNum),
-		logging.SHAKey.String():        request.Ref,
-		"status-name":                  request.StatusName,
-		"state":                        request.State.String(),
+		keys.RepositoryKey.String(): request.Repo.FullName,
+		keys.PullNumKey.String():    strconv.Itoa(request.PullNum),
+		keys.SHAKey.String():        request.Ref,
+		"status-name":               request.StatusName,
+		"state":                     request.State.String(),
 	})
 
 	executionSuccess.Inc(1)

--- a/server/logging/fields/repo.go
+++ b/server/logging/fields/repo.go
@@ -8,25 +8,25 @@ import (
 	"strconv"
 
 	"github.com/runatlantis/atlantis/server/events/models"
-	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/context"
 )
 
 func Repo(repo models.Repo) map[string]interface{} {
 	return map[string]interface{}{
-		logging.RepositoryKey.String(): repo.FullName,
+		context.RepositoryKey.String(): repo.FullName,
 	}
 }
 
 func PullRequest(pull models.PullRequest) map[string]interface{} {
 	return map[string]interface{}{
-		logging.RepositoryKey.String(): pull.BaseRepo.FullName,
-		logging.PullNumKey.String():    strconv.Itoa(pull.Num),
-		logging.SHAKey.String():        pull.HeadCommit,
+		context.RepositoryKey.String(): pull.BaseRepo.FullName,
+		context.PullNumKey.String():    strconv.Itoa(pull.Num),
+		context.SHAKey.String():        pull.HeadCommit,
 	}
 }
 
 func PullRequestWithErr(pull models.PullRequest, err error) map[string]interface{} {
 	kv := PullRequest(pull)
-	kv[logging.Err.String()] = err
+	kv[context.Err.String()] = err
 	return kv
 }

--- a/server/logging/logger.go
+++ b/server/logging/logger.go
@@ -15,7 +15,6 @@
 package logging
 
 import (
-	"context"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -24,22 +23,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	logurzap "logur.dev/adapter/zap"
 	"logur.dev/logur"
-)
-
-type ContextKey string
-
-func (c ContextKey) String() string {
-	return string(c)
-}
-
-const (
-	InstallationIDKey = ContextKey("gh-installation-id")
-	RequestIDKey   = ContextKey("gh-request-id")
-	RepositoryKey  = ContextKey("repository")
-	SHAKey         = ContextKey("sha")
-	PullNumKey     = ContextKey("pull-num")
-	ProjectKey     = ContextKey("project")
-	Err            = ContextKey("err")
+	context "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 )
 
 // Logger is the logging interface used throughout the code.
@@ -70,26 +54,13 @@ func NewLoggerFromLevel(lvl LogLevel) (*logger, error) {
 
 	ctxLogger := logur.WithContextExtractor(
 		structuredLogger,
-		extractFields,
+		context.ExtractFields,
 	)
 
 	return &logger{
 		LoggerFacade: ctxLogger,
 	}, nil
 
-}
-
-// Extracts relevant fields from context for structured logging.
-func extractFields(ctx context.Context) map[string]interface{} {
-	args := make(map[string]interface{})
-
-	for _, k := range []ContextKey{RequestIDKey, RepositoryKey, PullNumKey, ProjectKey, SHAKey, InstallationIDKey} {
-		if v, ok := ctx.Value(k).(string); ok {
-			args[k.String()] = v
-		}
-	}
-
-	return args
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_simple_logging.go SimpleLogging
@@ -222,7 +193,7 @@ func NewNoopCtxLogger(t *testing.T) Logger {
 	return &logger{
 		LoggerFacade: logur.WithContextExtractor(
 			sLogger,
-			extractFields,
+			context.ExtractFields,
 		),
 	}
 }

--- a/server/neptune/gateway/context/key.go
+++ b/server/neptune/gateway/context/key.go
@@ -1,0 +1,42 @@
+package context
+
+import "context"
+
+type Key string
+
+func (c Key) String() string {
+	return string(c)
+}
+
+const (
+	InstallationIDKey = Key("gh-installation-id")
+	RequestIDKey      = Key("gh-request-id")
+	RepositoryKey     = Key("repository")
+	SHAKey            = Key("sha")
+	PullNumKey        = Key("pull-num")
+	ProjectKey        = Key("project")
+	Err               = Key("err")
+)
+
+var Keys = []Key{RequestIDKey, RepositoryKey, PullNumKey, ProjectKey, SHAKey, InstallationIDKey}
+
+// Extracts relevant fields from context for structured logging.
+func ExtractFields(ctx context.Context) map[string]interface{} {
+	args := make(map[string]interface{})
+
+	for _, k := range Keys {
+		if v, ok := ctx.Value(k).(string); ok {
+			args[k.String()] = v
+		}
+	}
+
+	return args
+}
+
+// Copies fields from a context to a new context created from a given base.
+func CopyFields(base context.Context, from context.Context) context.Context {
+	for _, k := range Keys {
+		base = context.WithValue(base, k, from.Value(k))
+	}
+	return base
+}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/runatlantis/atlantis/server/vcs"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/sync"
 )
 
 type Push struct {
@@ -16,12 +17,16 @@ type Push struct {
 	Sender vcs.User
 }
 
+type scheduler interface {
+	Schedule(ctx context.Context, f sync.Executor)
+}
+
 type PushHandler struct {
 	Allocator feature.Allocator
+	Scheduler scheduler
 }
 
 func (p *PushHandler) Handle(ctx context.Context, event Push) error {
-
 	shouldAllocate, err := p.Allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{
 		RepoName: event.Repo.FullName,
 	})
@@ -31,9 +36,17 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 	}
 
 	if !shouldAllocate {
-		// drop the event for now
 		return nil
 	}
 
+	p.Scheduler.Schedule(ctx, func(ctx context.Context) error {
+		return p.handle(ctx, event)
+	})
+
+	return nil
+}
+
+// TODO
+func (p *PushHandler) handle(ctx context.Context, event Push) error {
 	return nil
 }

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -31,11 +32,14 @@ import (
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	lyft_gateway "github.com/runatlantis/atlantis/server/lyft/gateway"
 	"github.com/runatlantis/atlantis/server/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/sync"
+	httpInternal "github.com/runatlantis/atlantis/server/neptune/http"
 	"github.com/runatlantis/atlantis/server/vcs/markdown"
 	github_converter "github.com/runatlantis/atlantis/server/vcs/provider/github/converter"
 	"github.com/runatlantis/atlantis/server/wrappers"
 	"github.com/urfave/cli"
 	"github.com/urfave/negroni"
+	"golang.org/x/sync/errgroup"
 )
 
 // TODO: let's make this struct nicer using actual OOP instead of just a god type struct
@@ -65,15 +69,13 @@ type Config struct {
 }
 
 type Server struct {
-	StatsCloser      io.Closer
-	Router           *mux.Router
-	EventController  *lyft_gateway.VCSEventsController
-	StatusController *controllers.StatusController
-	Logger           logging.Logger
-	Port             int
-	Drainer          *events.Drainer
-	SSLKeyFile       string
-	SSLCertFile      string
+	StatsCloser io.Closer
+	Handler     http.Handler
+	Logger      logging.Logger
+	Port        int
+	Drainer     *events.Drainer
+	Scheduler   *sync.AsyncScheduler
+	Server      httpInternal.ServerProxy
 }
 
 // NewServer injects all dependencies nothing should "start" here
@@ -231,6 +233,8 @@ func NewServer(config Config) (*Server, error) {
 		config.MaxProjectsPerPR,
 	)
 
+	asyncScheduler := sync.NewAsyncScheduler(ctxLogger)
+
 	gatewaySnsWriter := sns.NewWriterWithStats(session, config.SNSTopicArn, statsScope.SubScope("aws.sns.gateway"))
 	autoplanValidator := &lyft_gateway.AutoplanValidator{
 		Scope:                         statsScope.SubScope("validator"),
@@ -266,34 +270,13 @@ func NewServer(config Config) (*Server, error) {
 		pullConverter,
 		vcsClient,
 		featureAllocator,
+		asyncScheduler,
 	)
 
 	router := mux.NewRouter()
-
-	return &Server{
-		StatsCloser:      closer,
-		Router:           router,
-		EventController:  gatewayEventsController,
-		StatusController: statusController,
-		Logger:           ctxLogger,
-		Port:             config.Port,
-		Drainer:          drainer,
-	}, nil
-
-}
-
-// Start is blocking and listens for incoming requests until a configured shutdown
-// signal is received.
-func (s *Server) Start() error {
-
-	// TODO: remove router initialization from here
-	// I assume this is currently happening to ensure that healthz is returning ready
-	// only when we are actually ready to receive requests, however, a better to do this is
-	// by using some atomic value to determine when our server is ready to start taking traffic.
-	// This way we'd have clean separation between setup and execution
-	s.Router.HandleFunc("/healthz", s.Healthz).Methods("GET")
-	s.Router.HandleFunc("/status", s.StatusController.Get).Methods("GET")
-	s.Router.HandleFunc("/events", s.EventController.Post).Methods("POST")
+	router.HandleFunc("/healthz", Healthz).Methods("GET")
+	router.HandleFunc("/status", statusController.Get).Methods("GET")
+	router.HandleFunc("/events", gatewayEventsController.Post).Methods("POST")
 
 	n := negroni.New(&negroni.Recovery{
 		Logger:     log.New(os.Stdout, "", log.LstdFlags),
@@ -301,47 +284,91 @@ func (s *Server) Start() error {
 		StackAll:   false,
 		StackSize:  1024 * 8,
 	})
-	n.UseHandler(s.Router)
+	n.UseHandler(router)
 
+	s := httpInternal.ServerProxy{
+		Server: &http.Server{
+			Addr:    fmt.Sprintf(":%d", config.Port),
+			Handler: n,
+		},
+		SSLCertFile: config.SSLCertFile,
+		SSLKeyFile:  config.SSLKeyFile,
+	}
+
+	return &Server{
+		StatsCloser: closer,
+		Handler:     n,
+		Scheduler:   asyncScheduler,
+		Logger:      ctxLogger,
+		Port:        config.Port,
+		Drainer:     drainer,
+		Server:      s,
+	}, nil
+
+}
+
+// Start is blocking and listens for incoming requests until a configured shutdown
+// signal is received.
+func (s *Server) Start() error {
 	defer s.Logger.Close()
 
-	// Ensure server gracefully drains connections when stopped.
-	stop := make(chan os.Signal, 1)
-	// Stop on SIGINTs and SIGTERMs.
-	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	// we create a base context that is marked done when we get a sigterm.
+	// this basecontext is used as the parent for each http request.
+	// in addition we should use this context for other async work to ensure we
+	// are gracefully handling shutdown and not dropping data.
+	mainCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	server := &http.Server{Addr: fmt.Sprintf(":%d", s.Port), Handler: n}
-	go func() {
+	s.Server.BaseContext = func(l net.Listener) context.Context {
+		return mainCtx
+	}
+	group, gCtx := errgroup.WithContext(mainCtx)
+
+	group.Go(func() error {
 		s.Logger.Info(fmt.Sprintf("Atlantis started - listening on port %v", s.Port))
-
-		var err error
-		if s.SSLCertFile != "" && s.SSLKeyFile != "" {
-			err = server.ListenAndServeTLS(s.SSLCertFile, s.SSLKeyFile)
-		} else {
-			err = server.ListenAndServe()
-		}
-
+		err := s.Server.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			s.Logger.Error(err.Error())
 		}
-	}()
-	<-stop
 
-	s.Logger.Warn("Received interrupt. Waiting for in-progress operations to complete")
+		return err
+	})
+
+	group.Go(func() error {
+		<-gCtx.Done()
+		s.Logger.Warn("Received interrupt. Waiting for in-progress operations to complete")
+
+		return s.Shutdown()
+	})
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Server) Shutdown() error {
+
+	// legacy way of draining ops, we should remove
+	// in favor of context based approach.
 	s.waitForDrain()
+
+	// block on async work for 30 seconds max
+	s.Scheduler.Shutdown(30 * time.Second)
 
 	// flush stats before shutdown
 	if err := s.StatsCloser.Close(); err != nil {
 		s.Logger.Error(err.Error())
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second) // nolint: vet
-	if err := server.Shutdown(ctx); err != nil {
+	// wait for 5 seconds to shutdown http server and drain existing requests if any.
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := s.Server.Shutdown(ctx); err != nil {
 		return cli.NewExitError(fmt.Sprintf("while shutting down: %s", err), 1)
 	}
 
 	return nil
-
 }
 
 // waitForDrain blocks until draining is complete.
@@ -364,7 +391,7 @@ func (s *Server) waitForDrain() {
 }
 
 // Healthz returns the health check response. It always returns a 200 currently.
-func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
+func Healthz(w http.ResponseWriter, _ *http.Request) {
 	data, err := json.MarshalIndent(&struct {
 		Status string `json:"status"`
 	}{

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -358,7 +358,9 @@ func (s *Server) Shutdown() error {
 	}
 
 	// wait for 5 seconds to shutdown http server and drain existing requests if any.
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	if err := s.Server.Shutdown(ctx); err != nil {
 		return cli.NewExitError(fmt.Sprintf("while shutting down: %s", err), 1)
 	}

--- a/server/neptune/gateway/server_test.go
+++ b/server/neptune/gateway/server_test.go
@@ -12,10 +12,9 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-	s := gateway.Server{}
 	req, _ := http.NewRequest("GET", "/healthz", bytes.NewBuffer(nil))
 	w := httptest.NewRecorder()
-	s.Healthz(w, req)
+	gateway.Healthz(w, req)
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 	body, _ := ioutil.ReadAll(w.Result().Body)
 	assert.Equal(t, "application/json", w.Result().Header["Content-Type"][0])

--- a/server/neptune/gateway/sync/scheduler.go
+++ b/server/neptune/gateway/sync/scheduler.go
@@ -1,0 +1,83 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/logging"
+	contextUtils "github.com/runatlantis/atlantis/server/neptune/gateway/context"
+	"github.com/runatlantis/atlantis/server/recovery"
+)
+
+type Executor func(ctx context.Context) error
+
+// AsyncScheduler handles scheduling background work with the correct
+// context values while ensuring work can gracefully exit when
+// necessary.
+type AsyncScheduler struct {
+	delegate  *SynchronousScheduler
+	poolCtx   context.Context
+	cancelCtx context.CancelFunc
+	wg        sync.WaitGroup
+}
+
+func NewAsyncScheduler(logger logging.Logger) *AsyncScheduler {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &AsyncScheduler{
+		delegate: &SynchronousScheduler{
+			logger: logger,
+		},
+		poolCtx:   ctx,
+		cancelCtx: cancel,
+	}
+}
+
+func (s *AsyncScheduler) Schedule(ctx context.Context, f Executor) {
+
+	// copy relevant context fields to a new ctx based off a single parent
+	// for easy cancellation when shutting down.
+	ctx = contextUtils.CopyFields(s.poolCtx, ctx)
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.delegate.Schedule(ctx, f)
+	}()
+}
+
+func (s *AsyncScheduler) Shutdown(t time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(t):
+		s.cancelCtx()
+	}
+}
+
+// SynchronousScheduler schedules work and handles panics/logging in a consistent manner.
+type SynchronousScheduler struct {
+	logger logging.Logger
+}
+
+func (s *SynchronousScheduler) Schedule(ctx context.Context, f Executor) {
+	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			stack := recovery.Stack(3)
+			s.logger.ErrorContext(ctx, fmt.Sprintf("PANIC: %s\n%s", r, stack))
+		}
+		if err != nil {
+			s.logger.ErrorContext(context.WithValue(ctx, contextUtils.Err, err), "error running handle")
+		}
+	}()
+	err = f(ctx)
+}

--- a/server/neptune/http/server_proxy.go
+++ b/server/neptune/http/server_proxy.go
@@ -12,14 +12,10 @@ type ServerProxy struct {
 	Logger      logging.Logger
 }
 
-func (p *ServerProxy) ListenAndServe() {
-	var err error
+func (p *ServerProxy) ListenAndServe() error {
 	if p.SSLCertFile != "" && p.SSLKeyFile != "" {
-		err = p.Server.ListenAndServeTLS(p.SSLCertFile, p.SSLKeyFile)
+		return p.Server.ListenAndServeTLS(p.SSLCertFile, p.SSLKeyFile)
 	} else {
-		err = p.Server.ListenAndServe()
-	}
-	if err != nil && err != http.ErrServerClosed {
-		p.Logger.Error(err.Error())
+		return p.Server.ListenAndServe()
 	}
 }

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -124,7 +124,14 @@ func (s Server) Start() error {
 
 	s.Logger.Info(fmt.Sprintf("Atlantis started - listening on port %v", s.Port))
 
-	go s.HttpServerProxy.ListenAndServe()
+	go func() {
+		err = s.HttpServerProxy.ListenAndServe()
+
+		if err != nil && err != http.ErrServerClosed {
+			s.Logger.Error(err.Error())
+		}
+	}()
+
 	<-stop
 
 	// flush stats before shutdown

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/controllers/events/handlers"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/runatlantis/atlantis/server/controllers/events/errors"
@@ -123,7 +124,7 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 
 	ctx := context.WithValue(
 		r.GetRequest().Context(),
-		logging.RequestIDKey,
+		contextInternal.RequestIDKey,
 		r.GetHeader(requestIDHeader),
 	)
 
@@ -144,7 +145,7 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 	installationID := githubapp.GetInstallationIDFromEvent(installationSource)
 
 	// this will be used to create the relevant installation client
-	ctx = context.WithValue(ctx, logging.InstallationIDKey, installationID)
+	ctx = context.WithValue(ctx, contextInternal.InstallationIDKey, installationID)
 
 	switch event := event.(type) {
 	case *github.IssueCommentEvent:
@@ -179,9 +180,9 @@ func (h *Handler) handleCommentEvent(ctx context.Context, e *github.IssueComment
 	if err != nil {
 		return &errors.EventParsingError{Err: err}
 	}
-	ctx = context.WithValue(ctx, logging.RepositoryKey, commentEvent.BaseRepo.FullName)
-	ctx = context.WithValue(ctx, logging.PullNumKey, commentEvent.PullNum)
-	ctx = context.WithValue(ctx, logging.SHAKey, commentEvent.Pull.HeadCommit)
+	ctx = context.WithValue(ctx, contextInternal.RepositoryKey, commentEvent.BaseRepo.FullName)
+	ctx = context.WithValue(ctx, contextInternal.PullNumKey, commentEvent.PullNum)
+	ctx = context.WithValue(ctx, contextInternal.SHAKey, commentEvent.Pull.HeadCommit)
 
 	return h.commentHandler.Handle(ctx, request, commentEvent)
 }
@@ -192,9 +193,9 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, e *github.PullRequ
 	if err != nil {
 		return &errors.EventParsingError{Err: err}
 	}
-	ctx = context.WithValue(ctx, logging.RepositoryKey, pullEvent.Pull.BaseRepo.FullName)
-	ctx = context.WithValue(ctx, logging.PullNumKey, pullEvent.Pull.Num)
-	ctx = context.WithValue(ctx, logging.SHAKey, pullEvent.Pull.HeadCommit)
+	ctx = context.WithValue(ctx, contextInternal.RepositoryKey, pullEvent.Pull.BaseRepo.FullName)
+	ctx = context.WithValue(ctx, contextInternal.PullNumKey, pullEvent.Pull.Num)
+	ctx = context.WithValue(ctx, contextInternal.SHAKey, pullEvent.Pull.HeadCommit)
 
 	return h.prHandler.Handle(ctx, request, pullEvent)
 }
@@ -205,8 +206,8 @@ func (h *Handler) handlePushEvent(ctx context.Context, e *github.PushEvent) erro
 	if err != nil {
 		return &errors.EventParsingError{Err: err}
 	}
-	ctx = context.WithValue(ctx, logging.RepositoryKey, pushEvent.Repo.FullName)
-	ctx = context.WithValue(ctx, logging.SHAKey, pushEvent.Sha)
+	ctx = context.WithValue(ctx, contextInternal.RepositoryKey, pushEvent.Repo.FullName)
+	ctx = context.WithValue(ctx, contextInternal.SHAKey, pushEvent.Sha)
 
 	return h.pushHandler.Handle(ctx, pushEvent)
 }


### PR DESCRIPTION
Changed the way we manage our server runtime by using `errgroup` which should make it easy to add other go routines that need graceful shutdown.