### PR TITLE
Add boltdb to gateway autoplan validator

### DIFF
--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -92,6 +92,11 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 	if len(projectCmds) == 0 {
 		cmdCtx.Log.InfoContext(cmdCtx.RequestCtx, "no modified projects have been found")
 		for _, cmd := range []command.Name{command.Plan, command.Apply, command.PolicyCheck} {
+			// Set to pending first to create a new  checkrun and populate the db
+			if err := r.CommitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, cmd, 0, 0); err != nil {
+				cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
+			}
+
 			if err := r.CommitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, cmd, 0, 0); err != nil {
 				cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 			}

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -163,7 +163,7 @@ func TestPullRequestHasTerraformChanges_NoTerraformChanges(t *testing.T) {
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(context.TODO(), log, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	Assert(t, containsTerraformChanges == false, "should have no terraform changes")
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
-	commitStatusUpdater.VerifyWasCalled(Times(3)).UpdateCombinedCount(
+	commitStatusUpdater.VerifyWasCalled(Times(6)).UpdateCombinedCount(
 		matchers.AnyContextContext(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/runatlantis/atlantis/server/controllers"
 	cfgParser "github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -83,6 +84,12 @@ func NewServer(config Config) (*Server, error) {
 		return nil, err
 	}
 
+	// Status updates require bolt db for consecutive status updates
+	boltdb, err := db.New(config.DataDir)
+	if err != nil {
+		return nil, err
+	}
+
 	repoAllowlist, err := events.NewRepoAllowlistChecker(config.RepoAllowList)
 	if err != nil {
 		return nil, err
@@ -137,6 +144,7 @@ func NewServer(config Config) (*Server, error) {
 		FeatureAllocator: featureAllocator,
 		Logger:           ctxLogger,
 		GithubClient:     rawGithubClient,
+		Db:               boltdb,
 	}
 
 	vcsClient := vcs.NewInstrumentedGithubClient(rawGithubClient, checksWrapperGhClient, statsScope, ctxLogger)


### PR DESCRIPTION
Since we perform status updates in the gateway, we also need to pass in boltdb to the `checksClientWrapper`.  In addition, we also set all commands to pending before we set it to success when no projects are modified in the PR. 