### PR TITLE
Part II - Update Commit Status Updater Interface to propagate Client interface changes

### DIFF
--- a/server/core/runtime/apply_step_runner_test.go
+++ b/server/core/runtime/apply_step_runner_test.go
@@ -293,8 +293,8 @@ Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
 
 	// Check that the status was updated with the run url.
 	runURL := "https://app.terraform.io/app/lkysow-enterprises/atlantis-tfe-test-dir2/runs/run-PiDsRYKGcerTttV2"
-	updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Apply, models.PendingCommitStatus, runURL)
-	updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Apply, models.SuccessCommitStatus, runURL)
+	updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Apply, models.PendingCommitStatus, runURL, "")
+	updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Apply, models.SuccessCommitStatus, runURL, "")
 }
 
 // Test that if the plan is different, we error out.

--- a/server/core/runtime/plan_step_runner.go
+++ b/server/core/runtime/plan_step_runner.go
@@ -247,8 +247,8 @@ func (p *PlanStepRunner) runRemotePlan(
 	envs map[string]string) (string, error) {
 
 	// updateStatusF will update the commit status and log any error.
-	updateStatusF := func(status models.CommitStatus, url string) {
-		if err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url); err != nil {
+	updateStatusF := func(status models.CommitStatus, url string, statusId string) {
+		if _, err := p.CommitStatusUpdater.UpdateProject(ctx, prjCtx, command.Plan, status, url, statusId); err != nil {
 			prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("unable to update status: %s", err))
 		}
 	}
@@ -273,16 +273,16 @@ func (p *PlanStepRunner) runRemotePlan(
 			nextLineIsRunURL = true
 		} else if nextLineIsRunURL {
 			runURL = strings.TrimSpace(line.Line)
-			updateStatusF(models.PendingCommitStatus, runURL)
+			updateStatusF(models.PendingCommitStatus, runURL, prjCtx.StatusId)
 			nextLineIsRunURL = false
 		}
 	}
 
 	output := strings.Join(lines, "\n")
 	if err != nil {
-		updateStatusF(models.FailedCommitStatus, runURL)
+		updateStatusF(models.FailedCommitStatus, runURL, prjCtx.StatusId)
 	} else {
-		updateStatusF(models.SuccessCommitStatus, runURL)
+		updateStatusF(models.SuccessCommitStatus, runURL, prjCtx.StatusId)
 	}
 	return output, err
 }

--- a/server/core/runtime/plan_step_runner_test.go
+++ b/server/core/runtime/plan_step_runner_test.go
@@ -870,8 +870,8 @@ Plan: 0 to add, 0 to change, 1 to destroy.`, string(bytes))
 
 			// Ensure that the status was updated with the runURL.
 			runURL := "https://app.terraform.io/app/lkysow-enterprises/atlantis-tfe-test/runs/run-is4oVvJfrkud1KvE"
-			updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Plan, models.PendingCommitStatus, runURL)
-			updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Plan, models.SuccessCommitStatus, runURL)
+			updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Plan, models.PendingCommitStatus, runURL, "")
+			updater.VerifyWasCalledOnce().UpdateProject(ctx, prjCtx, command.Plan, models.SuccessCommitStatus, runURL, "")
 		})
 	}
 }

--- a/server/core/runtime/runtime.go
+++ b/server/core/runtime/runtime.go
@@ -49,7 +49,7 @@ type AsyncTFExec interface {
 // StatusUpdater brings the interface from CommitStatusUpdater into this package
 // without causing circular imports.
 type StatusUpdater interface {
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, statusId string) (string, error)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_runner.go Runner

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -36,13 +36,14 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull
 
-	if err := a.commitStatusUpdater.UpdateCombined(context.TODO(), baseRepo, pull, models.PendingCommitStatus, command.PolicyCheck); err != nil {
+	statusId, err := a.commitStatusUpdater.UpdateCombined(context.TODO(), baseRepo, pull, models.PendingCommitStatus, command.PolicyCheck, "")
+	if err != nil {
 		ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 
 	projectCmds, err := a.prjCmdBuilder.BuildApprovePoliciesCommands(ctx, cmd)
 	if err != nil {
-		if statusErr := a.commitStatusUpdater.UpdateCombined(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.PolicyCheck); statusErr != nil {
+		if _, statusErr := a.commitStatusUpdater.UpdateCombined(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.FailedCommitStatus, command.PolicyCheck, statusId); statusErr != nil {
 			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", statusErr))
 		}
 		a.outputUpdater.UpdateOutput(ctx, cmd, command.Result{Error: err})
@@ -54,7 +55,7 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		// If there were no projects modified, we set successful commit statuses
 		// with 0/0 projects approve_policies successfully because some users require
 		// the Atlantis status to be passing for all pull requests.
-		if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+		if _, err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0, statusId); err != nil {
 			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 		}
 		return
@@ -74,7 +75,7 @@ func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Co
 		return
 	}
 
-	a.updateCommitStatus(ctx, pullStatus)
+	a.updateCommitStatus(ctx, pullStatus, statusId)
 }
 
 func (a *ApprovePoliciesCommandRunner) buildApprovePolicyCommandResults(ctx *command.Context, prjCmds []command.ProjectContext) (result command.Result) {
@@ -96,7 +97,7 @@ func (a *ApprovePoliciesCommandRunner) buildApprovePolicyCommandResults(ctx *com
 	return
 }
 
-func (a *ApprovePoliciesCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus) {
+func (a *ApprovePoliciesCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus, statusId string) {
 	var numSuccess int
 	var numErrored int
 	status := models.SuccessCommitStatus
@@ -108,7 +109,7 @@ func (a *ApprovePoliciesCommandRunner) updateCommitStatus(ctx *command.Context, 
 		status = models.FailedCommitStatus
 	}
 
-	if err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects)); err != nil {
+	if _, err := a.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects), statusId); err != nil {
 		ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 }

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -153,6 +153,8 @@ type ProjectContext struct {
 	JobID string
 	// RequestCtx is the context generated when request is first received from VCS
 	RequestCtx context.Context
+	// StatusId is used for consecutive status updates in the step runners
+	StatusId string
 }
 
 // ProjectCloneDir creates relative path to clone the repo to. If we are running

--- a/server/events/command/project_result.go
+++ b/server/events/command/project_result.go
@@ -16,7 +16,7 @@ type ProjectResult struct {
 	ApplySuccess       string
 	VersionSuccess     string
 	ProjectName        string
-	CheckRunId         string
+	StatusId           string
 }
 
 // CommitStatus returns the vcs commit status of this project result.

--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -17,7 +17,7 @@ type VCSStatusUpdater struct {
 	TitleBuilder vcs.StatusTitleBuilder
 }
 
-func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
+func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, checkRunId string) (string, error) {
 	src := d.TitleBuilder.Build(cmdName.String())
 	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
 
@@ -30,12 +30,12 @@ func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo,
 		Description:      descrip,
 		DetailsURL:       "",
 		PullCreationTime: pull.CreatedAt,
+		StatusId:         checkRunId,
 	}
-	_, err := d.Client.UpdateStatus(ctx, request)
-	return err
+	return d.Client.UpdateStatus(ctx, request)
 }
 
-func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
+func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, checkRunId string) (string, error) {
 	src := d.TitleBuilder.Build(cmdName.String())
 	cmdVerb := "unknown"
 
@@ -57,13 +57,13 @@ func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.
 		Description:      fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
 		DetailsURL:       "",
 		PullCreationTime: pull.CreatedAt,
+		StatusId:         checkRunId,
 	}
 
-	_, err := d.Client.UpdateStatus(ctx, request)
-	return err
+	return d.Client.UpdateStatus(ctx, request)
 }
 
-func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error {
+func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, checkRunId string) (string, error) {
 	projectID := projectCtx.ProjectName
 	if projectID == "" {
 		projectID = fmt.Sprintf("%s/%s", projectCtx.RepoRelDir, projectCtx.Workspace)
@@ -82,9 +82,10 @@ func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx Project
 		Description:      description,
 		DetailsURL:       url,
 		PullCreationTime: projectCtx.Pull.CreatedAt,
+		StatusId:         checkRunId,
 	}
-	_, err := d.Client.UpdateStatus(ctx, request)
-	return err
+
+	return d.Client.UpdateStatus(ctx, request)
 }
 
 func (d *VCSStatusUpdater) statusDescription(status models.CommitStatus) string {

--- a/server/events/command/vcs_test.go
+++ b/server/events/command/vcs_test.go
@@ -74,7 +74,7 @@ func TestUpdateCombined(t *testing.T) {
 			s := command.VCSStatusUpdater{Client: client, TitleBuilder: titleBuilder}
 			ctx := context.Background()
 
-			err := s.UpdateCombined(ctx, models.Repo{}, models.PullRequest{}, c.status, c.command)
+			_, err := s.UpdateCombined(ctx, models.Repo{}, models.PullRequest{}, c.status, c.command, "")
 			Ok(t, err)
 
 			expSrc := fmt.Sprintf("atlantis/%s", c.command)
@@ -148,7 +148,7 @@ func TestUpdateCombinedCount(t *testing.T) {
 			titleBuilder := vcs.StatusTitleBuilder{TitlePrefix: "atlantis-test"}
 			s := command.VCSStatusUpdater{Client: client, TitleBuilder: titleBuilder}
 			ctx := context.Background()
-			err := s.UpdateCombinedCount(ctx, models.Repo{}, models.PullRequest{}, c.status, c.command, c.numSuccess, c.numTotal)
+			_, err := s.UpdateCombinedCount(ctx, models.Repo{}, models.PullRequest{}, c.status, c.command, c.numSuccess, c.numTotal, "")
 			Ok(t, err)
 
 			expSrc := fmt.Sprintf("%s/%s", titleBuilder.TitlePrefix, c.command)
@@ -193,14 +193,14 @@ func TestDefaultCommitStatusUpdater_UpdateProjectSrc(t *testing.T) {
 			titleBuilder := vcs.StatusTitleBuilder{TitlePrefix: "atlantis"}
 			s := command.VCSStatusUpdater{Client: client, TitleBuilder: titleBuilder}
 			ctx := context.Background()
-			err := s.UpdateProject(ctx, command.ProjectContext{
+			_, err := s.UpdateProject(ctx, command.ProjectContext{
 				ProjectName: c.projectName,
 				RepoRelDir:  c.repoRelDir,
 				Workspace:   c.workspace,
 			},
 				command.Plan,
 				models.PendingCommitStatus,
-				"url")
+				"url", "")
 			Ok(t, err)
 			client.VerifyWasCalledOnce().UpdateStatus(ctx, types.UpdateStatusRequest{
 				Repo:        models.Repo{},
@@ -260,13 +260,13 @@ func TestDefaultCommitStatusUpdater_UpdateProject(t *testing.T) {
 			titleBuilder := vcs.StatusTitleBuilder{TitlePrefix: "atlantis"}
 			s := command.VCSStatusUpdater{Client: client, TitleBuilder: titleBuilder}
 			ctx := context.Background()
-			err := s.UpdateProject(ctx, command.ProjectContext{
+			_, err := s.UpdateProject(ctx, command.ProjectContext{
 				RepoRelDir: ".",
 				Workspace:  "default",
 			},
 				c.cmd,
 				c.status,
-				"url")
+				"url", "")
 			Ok(t, err)
 			client.VerifyWasCalledOnce().UpdateStatus(ctx, types.UpdateStatusRequest{
 				Repo:        models.Repo{},
@@ -287,13 +287,13 @@ func TestDefaultCommitStatusUpdater_UpdateProjectCustomStatusName(t *testing.T) 
 	titleBuilder := vcs.StatusTitleBuilder{TitlePrefix: "custom"}
 	s := command.VCSStatusUpdater{Client: client, TitleBuilder: titleBuilder}
 	ctx := context.Background()
-	err := s.UpdateProject(ctx, command.ProjectContext{
+	_, err := s.UpdateProject(ctx, command.ProjectContext{
 		RepoRelDir: ".",
 		Workspace:  "default",
 	},
 		command.Apply,
 		models.SuccessCommitStatus,
-		"url")
+		"url", "")
 	Ok(t, err)
 	client.VerifyWasCalledOnce().UpdateStatus(ctx, types.UpdateStatusRequest{
 		Repo:        models.Repo{},

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -140,7 +140,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(ctx context.Context, baseRepo 
 
 	if err := c.PreWorkflowHooksCommandRunner.RunPreHooks(ctx, cmdCtx); err != nil {
 		c.Logger.ErrorContext(ctx, "Error running pre-workflow hooks", fields.PullRequestWithErr(pull, err))
-		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, command.Plan)
+		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, command.Plan, "")
 		return
 	}
 
@@ -203,7 +203,7 @@ func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo m
 
 	if err := c.PreWorkflowHooksCommandRunner.RunPreHooks(ctx, cmdCtx); err != nil {
 		c.Logger.ErrorContext(ctx, "Error running pre-workflow hooks", fields.PullRequestWithErr(pull, err))
-		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, cmd.Name)
+		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, cmd.Name, "")
 		return
 	}
 

--- a/server/events/command_runner_internal_test.go
+++ b/server/events/command_runner_internal_test.go
@@ -77,7 +77,7 @@ func TestApplyUpdateCommitStatus(t *testing.T) {
 			cr := &ApplyCommandRunner{
 				commitStatusUpdater: csu,
 			}
-			cr.updateCommitStatus(&command.Context{}, c.pullStatus)
+			cr.updateCommitStatus(&command.Context{}, c.pullStatus, "")
 			Equals(t, models.Repo{}, csu.CalledRepo)
 			Equals(t, models.PullRequest{}, csu.CalledPull)
 			Equals(t, c.expStatus, csu.CalledStatus)
@@ -139,7 +139,7 @@ func TestPlanUpdateCommitStatus(t *testing.T) {
 			cr := &PlanCommandRunner{
 				commitStatusUpdater: csu,
 			}
-			cr.updateCommitStatus(&command.Context{}, c.pullStatus)
+			cr.updateCommitStatus(&command.Context{}, c.pullStatus, "")
 			Equals(t, models.Repo{}, csu.CalledRepo)
 			Equals(t, models.PullRequest{}, csu.CalledPull)
 			Equals(t, c.expStatus, csu.CalledStatus)
@@ -157,20 +157,22 @@ type MockCSU struct {
 	CalledCommand    string
 	CalledNumSuccess int
 	CalledNumTotal   int
+	CalledStatusId   string
 }
 
-func (m *MockCSU) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command fmt.Stringer, numSuccess int, numTotal int) error {
+func (m *MockCSU) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command fmt.Stringer, numSuccess int, numTotal int, statusId string) (string, error) {
 	m.CalledRepo = repo
 	m.CalledPull = pull
 	m.CalledStatus = status
 	m.CalledCommand = command.String()
 	m.CalledNumSuccess = numSuccess
 	m.CalledNumTotal = numTotal
-	return nil
+	m.CalledStatusId = statusId
+	return "", nil
 }
-func (m *MockCSU) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command fmt.Stringer) error {
-	return nil
+func (m *MockCSU) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, command fmt.Stringer, statusId string) (string, error) {
+	return "", nil
 }
-func (m *MockCSU) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error {
-	return nil
+func (m *MockCSU) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, statusId string) (string, error) {
+	return "", nil
 }

--- a/server/events/commit_status_updater.go
+++ b/server/events/commit_status_updater.go
@@ -25,11 +25,11 @@ import (
 type CommitStatusUpdater interface {
 	// UpdateCombined updates the combined status of the head commit of pull.
 	// A combined status represents all the projects modified in the pull.
-	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error
+	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, statusId string) (string, error)
 	// UpdateCombinedCount updates the combined status to reflect the
 	// numSuccess out of numTotal.
-	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error
+	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusId string) (string, error)
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, statusId string) (string, error)
 }

--- a/server/events/mocks/mock_commit_status_updater.go
+++ b/server/events/mocks/mock_commit_status_updater.go
@@ -28,49 +28,61 @@ func NewMockCommitStatusUpdater(options ...pegomock.Option) *MockCommitStatusUpd
 func (mock *MockCommitStatusUpdater) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockCommitStatusUpdater) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockCommitStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) error {
+func (mock *MockCommitStatusUpdater) UpdateCombined(_param0 context.Context, _param1 models.Repo, _param2 models.PullRequest, _param3 models.CommitStatus, _param4 fmt.Stringer, _param5 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, repo, pull, status, cmdName}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombined", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 error
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombined", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(error)
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
 		}
 	}
-	return ret0
+	return ret0, ret1
 }
 
-func (mock *MockCommitStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) error {
+func (mock *MockCommitStatusUpdater) UpdateCombinedCount(_param0 context.Context, _param1 models.Repo, _param2 models.PullRequest, _param3 models.CommitStatus, _param4 fmt.Stringer, _param5 int, _param6 int, _param7 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, repo, pull, status, cmdName, numSuccess, numTotal}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombinedCount", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 error
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateCombinedCount", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(error)
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
 		}
 	}
-	return ret0
+	return ret0, ret1
 }
 
-func (mock *MockCommitStatusUpdater) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error {
+func (mock *MockCommitStatusUpdater) UpdateProject(_param0 context.Context, _param1 command.ProjectContext, _param2 fmt.Stringer, _param3 models.CommitStatus, _param4 string, _param5 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCommitStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, projectCtx, cmdName, status, url}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 error
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(error)
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
 		}
 	}
-	return ret0
+	return ret0, ret1
 }
 
 func (mock *MockCommitStatusUpdater) VerifyWasCalledOnce() *VerifierMockCommitStatusUpdater {
@@ -110,8 +122,8 @@ type VerifierMockCommitStatusUpdater struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockCommitStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer) *MockCommitStatusUpdater_UpdateCombined_OngoingVerification {
-	params := []pegomock.Param{ctx, repo, pull, status, cmdName}
+func (verifier *VerifierMockCommitStatusUpdater) UpdateCombined(_param0 context.Context, _param1 models.Repo, _param2 models.PullRequest, _param3 models.CommitStatus, _param4 fmt.Stringer, _param5 string) *MockCommitStatusUpdater_UpdateCombined_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateCombined", params, verifier.timeout)
 	return &MockCommitStatusUpdater_UpdateCombined_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -121,12 +133,12 @@ type MockCommitStatusUpdater_UpdateCombined_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetCapturedArguments() (context.Context, models.Repo, models.PullRequest, models.CommitStatus, fmt.Stringer) {
-	ctx, repo, pull, status, cmdName := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], cmdName[len(cmdName)-1]
+func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetCapturedArguments() (context.Context, models.Repo, models.PullRequest, models.CommitStatus, fmt.Stringer, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1]
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []fmt.Stringer) {
+func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []fmt.Stringer, _param5 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]context.Context, len(c.methodInvocations))
@@ -149,12 +161,16 @@ func (c *MockCommitStatusUpdater_UpdateCombined_OngoingVerification) GetAllCaptu
 		for u, param := range params[4] {
 			_param4[u] = param.(fmt.Stringer)
 		}
+		_param5 = make([]string, len(c.methodInvocations))
+		for u, param := range params[5] {
+			_param5[u] = param.(string)
+		}
 	}
 	return
 }
 
-func (verifier *VerifierMockCommitStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, numSuccess int, numTotal int) *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification {
-	params := []pegomock.Param{ctx, repo, pull, status, cmdName, numSuccess, numTotal}
+func (verifier *VerifierMockCommitStatusUpdater) UpdateCombinedCount(_param0 context.Context, _param1 models.Repo, _param2 models.PullRequest, _param3 models.CommitStatus, _param4 fmt.Stringer, _param5 int, _param6 int, _param7 string) *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateCombinedCount", params, verifier.timeout)
 	return &MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -164,12 +180,12 @@ type MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetCapturedArguments() (context.Context, models.Repo, models.PullRequest, models.CommitStatus, fmt.Stringer, int, int) {
-	ctx, repo, pull, status, cmdName, numSuccess, numTotal := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], repo[len(repo)-1], pull[len(pull)-1], status[len(status)-1], cmdName[len(cmdName)-1], numSuccess[len(numSuccess)-1], numTotal[len(numTotal)-1]
+func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetCapturedArguments() (context.Context, models.Repo, models.PullRequest, models.CommitStatus, fmt.Stringer, int, int, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1], _param6[len(_param6)-1], _param7[len(_param7)-1]
 }
 
-func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []fmt.Stringer, _param5 []int, _param6 []int) {
+func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []models.Repo, _param2 []models.PullRequest, _param3 []models.CommitStatus, _param4 []fmt.Stringer, _param5 []int, _param6 []int, _param7 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]context.Context, len(c.methodInvocations))
@@ -200,12 +216,16 @@ func (c *MockCommitStatusUpdater_UpdateCombinedCount_OngoingVerification) GetAll
 		for u, param := range params[6] {
 			_param6[u] = param.(int)
 		}
+		_param7 = make([]string, len(c.methodInvocations))
+		for u, param := range params[7] {
+			_param7[u] = param.(string)
+		}
 	}
 	return
 }
 
-func (verifier *VerifierMockCommitStatusUpdater) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) *MockCommitStatusUpdater_UpdateProject_OngoingVerification {
-	params := []pegomock.Param{ctx, projectCtx, cmdName, status, url}
+func (verifier *VerifierMockCommitStatusUpdater) UpdateProject(_param0 context.Context, _param1 command.ProjectContext, _param2 fmt.Stringer, _param3 models.CommitStatus, _param4 string, _param5 string) *MockCommitStatusUpdater_UpdateProject_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", params, verifier.timeout)
 	return &MockCommitStatusUpdater_UpdateProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -215,12 +235,12 @@ type MockCommitStatusUpdater_UpdateProject_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCommitStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (context.Context, command.ProjectContext, fmt.Stringer, models.CommitStatus, string) {
-	ctx, projectCtx, cmdName, status, url := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], projectCtx[len(projectCtx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1]
+func (c *MockCommitStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (context.Context, command.ProjectContext, fmt.Stringer, models.CommitStatus, string, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1]
 }
 
-func (c *MockCommitStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []command.ProjectContext, _param2 []fmt.Stringer, _param3 []models.CommitStatus, _param4 []string) {
+func (c *MockCommitStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []command.ProjectContext, _param2 []fmt.Stringer, _param3 []models.CommitStatus, _param4 []string, _param5 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]context.Context, len(c.methodInvocations))
@@ -242,6 +262,10 @@ func (c *MockCommitStatusUpdater_UpdateProject_OngoingVerification) GetAllCaptur
 		_param4 = make([]string, len(c.methodInvocations))
 		for u, param := range params[4] {
 			_param4[u] = param.(string)
+		}
+		_param5 = make([]string, len(c.methodInvocations))
+		for u, param := range params[5] {
+			_param5[u] = param.(string)
 		}
 	}
 	return

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -92,7 +92,7 @@ func (c *ChecksOutputUpdater) UpdateOutput(ctx *command.Context, cmd PullCommand
 			Description:      description,
 			Output:           output,
 			State:            state,
-			CheckRunId:       projectResult.CheckRunId,
+			StatusId:         projectResult.StatusId,
 			PullCreationTime: ctx.Pull.CreatedAt,
 		}
 
@@ -119,7 +119,7 @@ func (c *ChecksOutputUpdater) handleApprovePolicies(ctx *command.Context, cmd Pu
 			StatusName:       statusName,
 			PullNum:          ctx.Pull.Num,
 			State:            models.SuccessCommitStatus,
-			CheckRunId:       projectResult.CheckRunId,
+			StatusId:         projectResult.StatusId,
 			Output:           output,
 			PullCreationTime: ctx.Pull.CreatedAt,
 		}

--- a/server/events/policy_check_command_runner.go
+++ b/server/events/policy_check_command_runner.go
@@ -38,14 +38,15 @@ func (p *PolicyCheckCommandRunner) Run(ctx *command.Context, cmds []command.Proj
 		// If there were no projects modified, we set successful commit statuses
 		// with 0/0 projects policy_checked successfully because some users require
 		// the Atlantis status to be passing for all pull requests.
-		if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0); err != nil {
+		if _, err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.SuccessCommitStatus, command.PolicyCheck, 0, 0, ""); err != nil {
 			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 		}
 		return
 	}
 
 	// So set policy_check commit status to pending
-	if err := p.commitStatusUpdater.UpdateCombined(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.PendingCommitStatus, command.PolicyCheck); err != nil {
+	statusId, err := p.commitStatusUpdater.UpdateCombined(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, models.PendingCommitStatus, command.PolicyCheck, "")
+	if err != nil {
 		ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 
@@ -64,10 +65,10 @@ func (p *PolicyCheckCommandRunner) Run(ctx *command.Context, cmds []command.Proj
 		ctx.Log.ErrorContext(ctx.RequestCtx, fmt.Sprintf("writing results: %s", err))
 	}
 
-	p.updateCommitStatus(ctx, pullStatus)
+	p.updateCommitStatus(ctx, pullStatus, statusId)
 }
 
-func (p *PolicyCheckCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus) {
+func (p *PolicyCheckCommandRunner) updateCommitStatus(ctx *command.Context, pullStatus models.PullStatus, statusId string) {
 	var numSuccess int
 	var numErrored int
 	status := models.SuccessCommitStatus
@@ -79,7 +80,7 @@ func (p *PolicyCheckCommandRunner) updateCommitStatus(ctx *command.Context, pull
 		status = models.FailedCommitStatus
 	}
 
-	if err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects)); err != nil {
+	if _, err := p.commitStatusUpdater.UpdateCombinedCount(context.TODO(), ctx.Pull.BaseRepo, ctx.Pull, status, command.PolicyCheck, numSuccess, len(pullStatus.Projects), statusId); err != nil {
 		ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 }

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -143,6 +143,7 @@ func (p *DefaultProjectCommandRunner) Plan(ctx command.ProjectContext) command.P
 		RepoRelDir:  ctx.RepoRelDir,
 		Workspace:   ctx.Workspace,
 		ProjectName: ctx.ProjectName,
+		StatusId:    ctx.StatusId,
 	}
 }
 
@@ -157,6 +158,7 @@ func (p *DefaultProjectCommandRunner) PolicyCheck(ctx command.ProjectContext) co
 		RepoRelDir:         ctx.RepoRelDir,
 		Workspace:          ctx.Workspace,
 		ProjectName:        ctx.ProjectName,
+		StatusId:           ctx.StatusId,
 	}
 }
 
@@ -171,6 +173,7 @@ func (p *DefaultProjectCommandRunner) Apply(ctx command.ProjectContext) command.
 		RepoRelDir:   ctx.RepoRelDir,
 		Workspace:    ctx.Workspace,
 		ProjectName:  ctx.ProjectName,
+		StatusId:     ctx.StatusId,
 	}
 }
 
@@ -184,6 +187,7 @@ func (p *DefaultProjectCommandRunner) ApprovePolicies(ctx command.ProjectContext
 		RepoRelDir:         ctx.RepoRelDir,
 		Workspace:          ctx.Workspace,
 		ProjectName:        ctx.ProjectName,
+		StatusId:           ctx.StatusId,
 	}
 }
 

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -487,11 +487,11 @@ func (g *GithubClient) UpdateStatus(ctx context.Context, request types.UpdateSta
 // [WENGINES-4643] TODO: Move the checks implementation to UpdateStatus once github checks is stable
 func (g *GithubClient) UpdateChecksStatus(ctx context.Context, request types.UpdateStatusRequest) (string, error) {
 
-	if request.CheckRunId == "" {
+	if request.StatusId == "" {
 		return g.createChecksStatus(ctx, request)
 	}
 
-	return request.CheckRunId, g.updateChecksStatus(ctx, request, request.CheckRunId)
+	return request.StatusId, g.updateChecksStatus(ctx, request, request.StatusId)
 }
 
 // Update existing checkrun

--- a/server/events/vcs/types/status.go
+++ b/server/events/vcs/types/status.go
@@ -17,5 +17,5 @@ type UpdateStatusRequest struct {
 	// if not present, should be -1
 	PullNum          int
 	PullCreationTime time.Time
-	CheckRunId       string
+	StatusId         string
 }

--- a/server/jobs/job_url_setter.go
+++ b/server/jobs/job_url_setter.go
@@ -20,7 +20,7 @@ type ProjectJobURLGenerator interface {
 type ProjectStatusUpdater interface {
 	// UpdateProject sets the commit status for the project represented by
 	// ctx.
-	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error
+	UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string, statusId string) (string, error)
 }
 
 type JobURLSetter struct {
@@ -41,5 +41,7 @@ func (j *JobURLSetter) SetJobURLWithStatus(ctx command.ProjectContext, cmdName c
 	if err != nil {
 		return err
 	}
-	return j.projectStatusUpdater.UpdateProject(context.TODO(), ctx, cmdName, status, url)
+
+	_, err = j.projectStatusUpdater.UpdateProject(context.TODO(), ctx, cmdName, status, url, ctx.StatusId)
+	return err
 }

--- a/server/jobs/job_url_setter_test.go
+++ b/server/jobs/job_url_setter_test.go
@@ -26,11 +26,11 @@ func TestJobURLSetter(t *testing.T) {
 		jobURLSetter := jobs.NewJobURLSetter(projectJobURLGenerator, projectStatusUpdater)
 
 		When(projectJobURLGenerator.GenerateProjectJobURL(matchers.EqModelsProjectCommandContext(ctx))).ThenReturn(url, nil)
-		When(projectStatusUpdater.UpdateProject(context.TODO(), ctx, command.Plan, models.PendingCommitStatus, url)).ThenReturn(nil)
+		When(projectStatusUpdater.UpdateProject(context.TODO(), ctx, command.Plan, models.PendingCommitStatus, url, "")).ThenReturn("", nil)
 		err := jobURLSetter.SetJobURLWithStatus(ctx, command.Plan, models.PendingCommitStatus)
 		Ok(t, err)
 
-		projectStatusUpdater.VerifyWasCalledOnce().UpdateProject(context.TODO(), ctx, command.Plan, models.PendingCommitStatus, "url-to-project-jobs")
+		projectStatusUpdater.VerifyWasCalledOnce().UpdateProject(context.TODO(), ctx, command.Plan, models.PendingCommitStatus, "url-to-project-jobs", "")
 	})
 
 	t.Run("update project status with project jobs url error", func(t *testing.T) {

--- a/server/jobs/mocks/mock_project_status_updater.go
+++ b/server/jobs/mocks/mock_project_status_updater.go
@@ -28,19 +28,23 @@ func NewMockProjectStatusUpdater(options ...pegomock.Option) *MockProjectStatusU
 func (mock *MockProjectStatusUpdater) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockProjectStatusUpdater) FailHandler() pegomock.FailHandler      { return mock.fail }
 
-func (mock *MockProjectStatusUpdater) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) error {
+func (mock *MockProjectStatusUpdater) UpdateProject(_param0 context.Context, _param1 command.ProjectContext, _param2 fmt.Stringer, _param3 models.CommitStatus, _param4 string, _param5 string) (string, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockProjectStatusUpdater().")
 	}
-	params := []pegomock.Param{ctx, projectCtx, cmdName, status, url}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})
-	var ret0 error
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateProject", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 string
+	var ret1 error
 	if len(result) != 0 {
 		if result[0] != nil {
-			ret0 = result[0].(error)
+			ret0 = result[0].(string)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
 		}
 	}
-	return ret0
+	return ret0, ret1
 }
 
 func (mock *MockProjectStatusUpdater) VerifyWasCalledOnce() *VerifierMockProjectStatusUpdater {
@@ -80,8 +84,8 @@ type VerifierMockProjectStatusUpdater struct {
 	timeout                time.Duration
 }
 
-func (verifier *VerifierMockProjectStatusUpdater) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.CommitStatus, url string) *MockProjectStatusUpdater_UpdateProject_OngoingVerification {
-	params := []pegomock.Param{ctx, projectCtx, cmdName, status, url}
+func (verifier *VerifierMockProjectStatusUpdater) UpdateProject(_param0 context.Context, _param1 command.ProjectContext, _param2 fmt.Stringer, _param3 models.CommitStatus, _param4 string, _param5 string) *MockProjectStatusUpdater_UpdateProject_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1, _param2, _param3, _param4, _param5}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "UpdateProject", params, verifier.timeout)
 	return &MockProjectStatusUpdater_UpdateProject_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -91,12 +95,12 @@ type MockProjectStatusUpdater_UpdateProject_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (context.Context, command.ProjectContext, fmt.Stringer, models.CommitStatus, string) {
-	ctx, projectCtx, cmdName, status, url := c.GetAllCapturedArguments()
-	return ctx[len(ctx)-1], projectCtx[len(projectCtx)-1], cmdName[len(cmdName)-1], status[len(status)-1], url[len(url)-1]
+func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetCapturedArguments() (context.Context, command.ProjectContext, fmt.Stringer, models.CommitStatus, string, string) {
+	_param0, _param1, _param2, _param3, _param4, _param5 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1], _param2[len(_param2)-1], _param3[len(_param3)-1], _param4[len(_param4)-1], _param5[len(_param5)-1]
 }
 
-func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []command.ProjectContext, _param2 []fmt.Stringer, _param3 []models.CommitStatus, _param4 []string) {
+func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetAllCapturedArguments() (_param0 []context.Context, _param1 []command.ProjectContext, _param2 []fmt.Stringer, _param3 []models.CommitStatus, _param4 []string, _param5 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]context.Context, len(c.methodInvocations))
@@ -118,6 +122,10 @@ func (c *MockProjectStatusUpdater_UpdateProject_OngoingVerification) GetAllCaptu
 		_param4 = make([]string, len(c.methodInvocations))
 		for u, param := range params[4] {
 			_param4[u] = param.(string)
+		}
+		_param5 = make([]string, len(c.methodInvocations))
+		for u, param := range params[5] {
+			_param5[u] = param.(string)
 		}
 	}
 	return

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -58,7 +58,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 
 	projectCmds, err := r.PrjCmdBuilder.BuildAutoplanCommands(cmdCtx)
 	if err != nil {
-		if statusErr := r.CommitStatusUpdater.UpdateCombined(context.TODO(), baseRepo, pull, models.FailedCommitStatus, command.Plan); statusErr != nil {
+		if _, statusErr := r.CommitStatusUpdater.UpdateCombined(context.TODO(), baseRepo, pull, models.FailedCommitStatus, command.Plan, ""); statusErr != nil {
 			cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %v", statusErr))
 		}
 		// If error happened after clone was made, we should clean it up here too
@@ -87,7 +87,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 	if len(projectCmds) == 0 {
 		cmdCtx.Log.InfoContext(cmdCtx.RequestCtx, "no modified projects have been found")
 		for _, cmd := range []command.Name{command.Plan, command.Apply, command.PolicyCheck} {
-			if err := r.CommitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, cmd, 0, 0); err != nil {
+			if _, err := r.CommitStatusUpdater.UpdateCombinedCount(context.TODO(), baseRepo, pull, models.SuccessCommitStatus, cmd, 0, 0, ""); err != nil {
 				cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 			}
 		}

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -149,7 +149,8 @@ func TestIsValid_TerraformChanges(t *testing.T) {
 		matchers.AnyModelsCommitStatus(),
 		matchers.AnyModelsCommandName(),
 		AnyInt(),
-		AnyInt())
+		AnyInt(),
+		AnyString())
 	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 	workingDirLocker.VerifyWasCalledOnce().TryLock(AnyString(), AnyInt(), AnyString())
 }
@@ -170,7 +171,8 @@ func TestPullRequestHasTerraformChanges_NoTerraformChanges(t *testing.T) {
 		matchers.AnyModelsCommitStatus(),
 		matchers.AnyModelsCommandName(),
 		AnyInt(),
-		AnyInt())
+		AnyInt(),
+		AnyString())
 	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 	workingDirLocker.VerifyWasCalledOnce().TryLock(AnyString(), AnyInt(), AnyString())
 }


### PR DESCRIPTION
In this PR, we 
- Update the `CommitStatusUpdater` interface to propagate the statusId to the command runners
- Update command runners to store StatusId in memory for consecutive updates 