### PR TITLE
Add support for vcs statuses to temporal workflow.

### DIFF
--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -14,10 +14,11 @@ import (
 )
 
 type Push struct {
-	Repo   models.Repo
-	Ref    vcs.Ref
-	Sha    string
-	Sender vcs.User
+	Repo              models.Repo
+	Ref               vcs.Ref
+	Sha               string
+	Sender            vcs.User
+	InstallationToken int64
 }
 
 type signaler interface {
@@ -79,6 +80,9 @@ func (p *PushHandler) handle(ctx context.Context, event Push) error {
 				FullName: event.Repo.FullName,
 				Name:     event.Repo.Name,
 				Owner:    event.Repo.Owner,
+				Credentials: workflows.AppCredentials{
+					InstallationToken: event.InstallationToken,
+				},
 			},
 		},
 	)

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -9,6 +9,7 @@ import (
 // Export anything that callers need such as requests, signals, etc.
 type DeployRequest = deploy.Request
 type Repo = deploy.Repo
+type AppCredentials = deploy.AppCredentials
 
 type DeployNewRevisionSignalRequest = revision.NewRevisionRequest
 

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -1,8 +1,12 @@
 package workflows
 
 import (
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
+	"github.com/uber-go/tally/v4"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -16,6 +20,22 @@ type DeployNewRevisionSignalRequest = revision.NewRevisionRequest
 var DeployTaskQueue = deploy.TaskQueue
 
 var DeployNewRevisionSignalID = deploy.NewRevisionSignalID
+
+type Activities struct {
+	activities.Deploy
+}
+
+func NewActivities(appConfig githubapp.Config, scope tally.Scope) (*Activities, error) {
+	deployActivities, err := activities.NewDeploy(appConfig, scope)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing deploy activities")
+	}
+
+	return &Activities{
+		Deploy: *deployActivities,
+	}, nil
+}
 
 func Deploy(ctx workflow.Context, request DeployRequest) error {
 	return deploy.Workflow(ctx, request)

--- a/server/neptune/workflows/internal/activities/github.go
+++ b/server/neptune/workflows/internal/activities/github.go
@@ -1,0 +1,115 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	internal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+)
+
+type githubActivities struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+type CreateCheckRunRequest struct {
+	Title      string
+	Sha        string
+	Repo       internal.Repo
+	State      internal.CheckRunState
+	Conclusion internal.CheckRunConclusion
+}
+
+type UpdateCheckRunRequest struct {
+	Title      string
+	State      internal.CheckRunState
+	Conclusion internal.CheckRunConclusion
+	Repo       internal.Repo
+	ID         int64
+}
+
+type CreateCheckRunResponse struct {
+	ID int64
+}
+type UpdateCheckRunResponse struct {
+	ID int64
+}
+
+func (a *githubActivities) UpdateCheckRun(ctx context.Context, request UpdateCheckRunRequest) (UpdateCheckRunResponse, error) {
+	output := github.CheckRunOutput{
+		Title: &request.Title,
+		Text:  github.String("this is test"),
+	}
+
+	opts := github.UpdateCheckRunOptions{
+		Name:   request.Title,
+		Status: github.String(string(request.State)),
+		Output: &output,
+	}
+
+	// Conclusion is required if status is Completed
+	if request.State == internal.CheckRunComplete {
+		opts.Conclusion = github.String(string(request.Conclusion))
+	}
+
+	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
+
+	if err != nil {
+		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating installation client")
+	}
+
+	run, _, err := client.Checks.UpdateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, request.ID, opts)
+
+	if err != nil {
+		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating check run")
+	}
+
+	return UpdateCheckRunResponse{
+		ID: run.GetID(),
+	}, nil
+}
+
+func (a *githubActivities) CreateCheckRun(ctx context.Context, request CreateCheckRunRequest) (CreateCheckRunResponse, error) {
+	output := github.CheckRunOutput{
+		Title: &request.Title,
+		Text:  github.String("this is test"),
+	}
+
+	opts := github.CreateCheckRunOptions{
+		Name:    request.Title,
+		HeadSHA: request.Sha,
+		Status:  github.String("queued"),
+		Output:  &output,
+	}
+
+	var state internal.CheckRunState
+	if request.State == internal.CheckRunState("") {
+		state = internal.CheckRunQueued
+	} else {
+		state = request.State
+	}
+
+	opts.Status = github.String(string(state))
+
+	// Conclusion is required if status is Completed
+	if state == internal.CheckRunComplete {
+		opts.Conclusion = github.String(string(request.Conclusion))
+	}
+
+	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
+
+	if err != nil {
+		return CreateCheckRunResponse{}, errors.Wrap(err, "creating installation client")
+	}
+
+	run, _, err := client.Checks.CreateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, opts)
+
+	if err != nil {
+		return CreateCheckRunResponse{}, errors.Wrap(err, "creating check run")
+	}
+
+	return CreateCheckRunResponse{
+		ID: run.GetID(),
+	}, nil
+}

--- a/server/neptune/workflows/internal/activities/github/middleware.go
+++ b/server/neptune/workflows/internal/activities/github/middleware.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gregjones/httpcache"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/uber-go/tally/v4"
+)
+
+const (
+	MetricsKeyRequests    = "github.requests"
+	MetricsKeyRequests2xx = "github.requests.2xx"
+	MetricsKeyRequests3xx = "github.requests.3xx"
+	MetricsKeyRequests4xx = "github.requests.4xx"
+	MetricsKeyRequests5xx = "github.requests.5xx"
+
+	MetricsKeyRequestsCached = "github.requests.cached"
+
+	MetricsKeyRateLimit          = "github.rate.limit"
+	MetricsKeyRateLimitRemaining = "github.rate.remaining"
+)
+
+// ClientMetrics creates client middleware that records metrics about all
+// requests.
+//
+// Pretty much copied from:
+// https://github.com/palantir/go-githubapp/blob/develop/githubapp/middleware.go#L41
+func ClientMetrics(scope tally.Scope) githubapp.ClientMiddleware {
+
+	return func(next http.RoundTripper) http.RoundTripper {
+		return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			res, err := next.RoundTrip(r)
+
+			if res != nil {
+				scope.Counter(MetricsKeyRequests).Inc(1)
+				if key := bucketStatus(res.StatusCode); key != "" {
+					scope.Counter(key).Inc(1)
+				}
+
+				if res.Header.Get(httpcache.XFromCache) != "" {
+					scope.Counter(MetricsKeyRequestsCached).Inc(1)
+				}
+
+				// Headers from https://developer.github.com/v3/#rate-limiting
+				updateRegistryForHeader(res.Header, "X-RateLimit-Limit", scope.Gauge(MetricsKeyRateLimit))
+				updateRegistryForHeader(res.Header, "X-RateLimit-Remaining", scope.Gauge(MetricsKeyRateLimitRemaining))
+			}
+
+			return res, err
+		})
+	}
+}
+
+func updateRegistryForHeader(headers http.Header, header string, metric tally.Gauge) {
+	headerString := headers.Get(header)
+	if headerString != "" {
+		headerVal, err := strconv.ParseFloat(headerString, 64)
+		if err == nil {
+			metric.Update(headerVal)
+		}
+	}
+}
+
+func bucketStatus(status int) string {
+	switch {
+	case status >= 200 && status < 300:
+		return MetricsKeyRequests2xx
+	case status >= 300 && status < 400:
+		return MetricsKeyRequests3xx
+	case status >= 400 && status < 500:
+		return MetricsKeyRequests4xx
+	case status >= 500 && status < 600:
+		return MetricsKeyRequests5xx
+	}
+	return ""
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -1,5 +1,12 @@
 package activities
 
+import (
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities/github"
+	"github.com/uber-go/tally/v4"
+)
+
 // Exported Activites should be here.
 // The convention should be one exported struct per workflow
 // This guarantees function naming uniqueness within a given workflow
@@ -12,9 +19,21 @@ type Deploy struct {
 	*githubActivities
 }
 
-func NewDeploy() *Deploy {
-	return &Deploy{
-		dbActivities:     &dbActivities{},
-		githubActivities: &githubActivities{},
+func NewDeploy(config githubapp.Config, scope tally.Scope) (*Deploy, error) {
+	clientCreator, err := githubapp.NewDefaultCachingClientCreator(
+		config,
+		githubapp.WithClientMiddleware(
+			github.ClientMetrics(scope),
+		))
+
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing client creator")
 	}
+
+	return &Deploy{
+		dbActivities: &dbActivities{},
+		githubActivities: &githubActivities{
+			ClientCreator: clientCreator,
+		},
+	}, nil
 }

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -9,10 +9,12 @@ package activities
 // registering multiple workflows to the same worker
 type Deploy struct {
 	*dbActivities
+	*githubActivities
 }
 
 func NewDeploy() *Deploy {
 	return &Deploy{
-		dbActivities: &dbActivities{},
+		dbActivities:     &dbActivities{},
+		githubActivities: &githubActivities{},
 	}
 }

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -18,6 +18,12 @@ type Repo struct {
 	Name string
 	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
 	URL string
+
+	Credentials AppCredentials
+}
+
+type AppCredentials struct {
+	InstallationToken int64
 }
 
 type Root struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -5,7 +5,8 @@ import (
 )
 
 type Message struct {
-	Revision string
+	Revision   string
+	CheckRunID int64
 }
 
 // Queue is a standard queue implementation

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -1,7 +1,12 @@
 package revision
 
 import (
+	"context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -13,16 +18,24 @@ type Queue interface {
 	Push(queue.Message)
 }
 
-func NewReceiver(ctx workflow.Context, queue Queue) *Receiver {
+type Activities interface {
+	CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
+}
+
+func NewReceiver(ctx workflow.Context, queue Queue, repo github.Repo, activities Activities) *Receiver {
 	return &Receiver{
-		queue: queue,
-		ctx:   ctx,
+		queue:      queue,
+		ctx:        ctx,
+		repo:       repo,
+		activities: activities,
 	}
 }
 
 type Receiver struct {
-	queue Queue
-	ctx   workflow.Context
+	queue      Queue
+	ctx        workflow.Context
+	activities Activities
+	repo       github.Repo
 }
 
 func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
@@ -34,8 +47,26 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 	var request NewRevisionRequest
 	c.Receive(n.ctx, &request)
 
+	ctx := workflow.WithRetryPolicy(n.ctx, temporal.RetryPolicy{
+		MaximumAttempts: 5,
+	})
+
+	var resp activities.CreateCheckRunResponse
+
+	err := workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
+		Title: "atlantis/deploy",
+		Sha:   request.Revision,
+		Repo:  n.repo,
+	}).Get(ctx, &resp)
+
+	// don't block on error here, we'll just try again later when we have our result.
+	if err != nil {
+		logger.Error(ctx, err.Error())
+	}
+
 	n.queue.Push(queue.Message{
-		Revision: request.Revision,
+		Revision:   request.Revision,
+		CheckRunID: resp.ID,
 	})
 
 }

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -1,33 +1,50 @@
 package revision_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
 
 type testQueue struct {
-	Queue []string
+	Queue []queue.Message
 }
 
 func (q *testQueue) Push(msg queue.Message) {
-	q.Queue = append(q.Queue, msg.Revision)
+	q.Queue = append(q.Queue, msg)
 }
 
 type response struct {
-	Queue   []string
+	Queue   []queue.Message
 	Timeout bool
 }
 
+type testActivities struct{}
+
+func (a *testActivities) CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+	return activities.CreateCheckRunResponse{}, nil
+}
+
 func testWorkflow(ctx workflow.Context) (response, error) {
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
 	var timeout bool
 	queue := &testQueue{}
 
-	receiver := revision.NewReceiver(ctx, queue)
+	var a *testActivities
+
+	receiver := revision.NewReceiver(ctx, queue, github.Repo{Name: "nish"}, a)
 	selector := workflow.NewSelector(ctx)
 
 	selector.AddReceive(workflow.GetSignalChannel(ctx, "test-signal"), receiver.Receive)
@@ -57,13 +74,30 @@ func TestEnqueue(t *testing.T) {
 			Revision: rev,
 		})
 	}, 0)
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title: "atlantis/deploy",
+		Sha:   rev,
+		Repo:  github.Repo{Name: "nish"},
+	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
+
 	env.ExecuteWorkflow(testWorkflow)
+	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
 
 	var resp response
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{rev}, resp.Queue)
+	assert.Equal(t, []queue.Message{
+		{
+			Revision:   rev,
+			CheckRunID: 1,
+		},
+	}, resp.Queue)
 	assert.False(t, resp.Timeout)
 }

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -67,9 +67,12 @@ type Runner struct {
 func newRunner(ctx workflow.Context, request Request) *Runner {
 	// convert to internal types, we should probably move these into another struct
 	repo := github.Repo{
-		Name:     request.Repository.Name,
-		Owner:    request.Repository.Owner,
-		URL:      request.Repository.URL,
+		Name:  request.Repository.Name,
+		Owner: request.Repository.Owner,
+		URL:   request.Repository.URL,
+		Credentials: github.AppCredentials{
+			InstallationToken: request.Repository.Credentials.InstallationToken,
+		},
 	}
 
 	// inject dependencies
@@ -79,7 +82,7 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 	var a *activities.Deploy
 
 	revisionQueue := queue.NewQueue()
-	revisionReceiver := revision.NewReceiver(ctx, revisionQueue)
+	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, repo, a)
 
 	worker := &queue.Worker{
 		Queue:      revisionQueue,

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -1,0 +1,12 @@
+package github
+
+type CheckRunState string
+type CheckRunConclusion string
+
+const (
+	Success          CheckRunConclusion = "success"
+	Failure          CheckRunConclusion = "failure"
+	CheckRunComplete CheckRunState      = "completed"
+	CheckRunPending  CheckRunState      = "in_progress"
+	CheckRunQueued   CheckRunState      = "queued"
+)

--- a/server/neptune/workflows/internal/github/repo.go
+++ b/server/neptune/workflows/internal/github/repo.go
@@ -8,8 +8,14 @@ type Repo struct {
 	Name string
 	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
 	URL string
+
+	Credentials AppCredentials
 }
 
 func (r Repo) GetFullName() string {
 	return r.Owner + "/" + r.Name
+}
+
+type AppCredentials struct {
+	InstallationToken int64
 }

--- a/server/vcs/provider/github/converter/push_event.go
+++ b/server/vcs/provider/github/converter/push_event.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
 	"github.com/runatlantis/atlantis/server/vcs"
@@ -39,6 +40,8 @@ func (p PushEvent) Convert(e *github.PushEvent) (event.Push, error) {
 		return event.Push{}, errors.Wrap(err, "getting ref type")
 	}
 
+	installationToken := githubapp.GetInstallationIDFromEvent(e)
+
 	return event.Push{
 		Repo: repo,
 		Sha:  e.GetHeadCommit().GetSHA(),
@@ -49,5 +52,6 @@ func (p PushEvent) Convert(e *github.PushEvent) (event.Push, error) {
 			Type: refType,
 			Name: name,
 		},
+		InstallationToken: installationToken,
 	}, nil
 }

--- a/server/vcs/provider/github/converter/push_event_test.go
+++ b/server/vcs/provider/github/converter/push_event_test.go
@@ -26,6 +26,7 @@ func TestConvert_PushEvent(t *testing.T) {
 	ref := "refs/heads/main"
 	sha := "1234"
 	user := "nish"
+	installationToken := 1234
 
 	pushEventRepo := &github.PushEventRepository{
 		FullName: github.String(repoFullName),
@@ -54,6 +55,7 @@ func TestConvert_PushEvent(t *testing.T) {
 		Sender: vcs.User{
 			Login: "nish",
 		},
+		InstallationToken: int64(installationToken),
 	}
 
 	result, err := subject.Convert(&github.PushEvent{
@@ -64,6 +66,9 @@ func TestConvert_PushEvent(t *testing.T) {
 		},
 		Sender: &github.User{
 			Login: github.String(user),
+		},
+		Installation: &github.Installation{
+			ID: github.Int64(int64(installationToken)),
 		},
 	})
 


### PR DESCRIPTION
This basically adds vcs statuses for when something is queued, when it's in progress and when it completes.  This is how we'll basically validate that our temporal workflow runs e2e once we turn on the flag for a specific repo.