### PR TITLE
Add urls to gh app config.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -520,6 +520,11 @@ func (t *TemporalWorker) NewServer(userConfig server.UserConfig, config server.C
 			WebhookSecret: userConfig.GithubWebhookSecret,
 			PrivateKey:    string(privateKey),
 		},
+
+		//TODO: parameterize this
+		WebURL:   "https://github.com",
+		V3APIURL: "https://api.github.com",
+		V4APIURL: "https://api.github.com/graphql",
 	}
 	cfg := &temporalworker.Config{
 		AtlantisURL:     parsedURL,


### PR DESCRIPTION
seeing this failure:
```
"creating check run: Patch \"/repos/lyft/orchestration-sandbox/check-runs/0\": could not refresh installation id <REDACTED>'s token: could not get access_tokens from GitHub API for installation ID <REDACTED>: unsupported protocol scheme \"\"",
```

and i believe it's because im not explicitly defining the host URLs.