### PR TITLE
Add default branch and branch deletion checks.

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -58,6 +58,9 @@ type Repo struct {
 	SanitizedCloneURL string
 	// VCSHost is where this repo is hosted.
 	VCSHost VCSHost
+
+	// Repo's default branch
+	DefaultBranch string
 }
 
 // ID returns the atlantis ID for this repo.

--- a/server/vcs/provider/github/converter/comment_event_test.go
+++ b/server/vcs/provider/github/converter/comment_event_test.go
@@ -56,6 +56,7 @@ func setup(t *testing.T) (github.IssueCommentEvent, models.Repo, models.PullRequ
 			Hostname: "github.com",
 			Type:     models.Github,
 		},
+		DefaultBranch: "main",
 	}
 
 	modelPull := models.PullRequest{

--- a/server/vcs/provider/github/converter/pull_event_test.go
+++ b/server/vcs/provider/github/converter/pull_event_test.go
@@ -57,6 +57,7 @@ func TestConvert_PullRequestEvent(t *testing.T) {
 			Hostname: "github.com",
 			Type:     models.Github,
 		},
+		DefaultBranch: "main",
 	}
 	Equals(t, models.PullRequest{
 		URL:        Pull.GetHTMLURL(),

--- a/server/vcs/provider/github/converter/pull_test.go
+++ b/server/vcs/provider/github/converter/pull_test.go
@@ -82,6 +82,7 @@ func TestParseGithubPull(t *testing.T) {
 			Hostname: "github.com",
 			Type:     models.Github,
 		},
+		DefaultBranch: "main",
 	}
 	assert.Equal(t, models.PullRequest{
 		URL:        Pull.GetHTMLURL(),

--- a/server/vcs/provider/github/converter/push_event.go
+++ b/server/vcs/provider/github/converter/push_event.go
@@ -42,9 +42,20 @@ func (p PushEvent) Convert(e *github.PushEvent) (event.Push, error) {
 
 	installationToken := githubapp.GetInstallationIDFromEvent(e)
 
+	action := event.UpdatedAction
+
+	if e.GetCreated() {
+		action = event.CreatedAction
+	}
+
+	if e.GetDeleted() {
+		action = event.DeletedAction
+	}
+
 	return event.Push{
-		Repo: repo,
-		Sha:  e.GetHeadCommit().GetSHA(),
+		Repo:   repo,
+		Sha:    e.GetHeadCommit().GetID(),
+		Action: action,
 		Sender: vcs.User{
 			Login: e.GetSender().GetLogin(),
 		},

--- a/server/vcs/provider/github/converter/push_event_test.go
+++ b/server/vcs/provider/github/converter/push_event_test.go
@@ -29,49 +29,100 @@ func TestConvert_PushEvent(t *testing.T) {
 	installationToken := 1234
 
 	pushEventRepo := &github.PushEventRepository{
-		FullName: github.String(repoFullName),
-		Owner:    &github.User{Login: github.String(repoOwner)},
-		Name:     github.String(repoName),
-		CloneURL: github.String(cloneURL),
+		FullName:      github.String(repoFullName),
+		Owner:         &github.User{Login: github.String(repoOwner)},
+		Name:          github.String(repoName),
+		CloneURL:      github.String(cloneURL),
+		DefaultBranch: github.String("main"),
 	}
 
-	expectedResult := event.Push{
-		Repo: models.Repo{
-			FullName:          repoFullName,
-			Owner:             repoOwner,
-			Name:              repoName,
-			CloneURL:          "https://user:token@github.com/owner/repo.git",
-			SanitizedCloneURL: "https://user:<redacted>@github.com/owner/repo.git",
-			VCSHost: models.VCSHost{
-				Type:     models.Github,
-				Hostname: "github.com",
+	t.Run("created branch ref", func(t *testing.T) {
+		expectedResult := event.Push{
+			Repo: models.Repo{
+				FullName:          repoFullName,
+				Owner:             repoOwner,
+				Name:              repoName,
+				CloneURL:          "https://user:token@github.com/owner/repo.git",
+				SanitizedCloneURL: "https://user:<redacted>@github.com/owner/repo.git",
+				VCSHost: models.VCSHost{
+					Type:     models.Github,
+					Hostname: "github.com",
+				},
+				DefaultBranch: "main",
 			},
-		},
-		Ref: vcs.Ref{
-			Type: vcs.BranchRef,
-			Name: "main",
-		},
-		Sha: sha,
-		Sender: vcs.User{
-			Login: "nish",
-		},
-		InstallationToken: int64(installationToken),
-	}
+			Ref: vcs.Ref{
+				Type: vcs.BranchRef,
+				Name: "main",
+			},
+			Sha: sha,
+			Sender: vcs.User{
+				Login: "nish",
+			},
+			InstallationToken: int64(installationToken),
+			Action:            event.CreatedAction,
+		}
 
-	result, err := subject.Convert(&github.PushEvent{
-		Repo: pushEventRepo,
-		Ref:  github.String(ref),
-		HeadCommit: &github.HeadCommit{
-			SHA: github.String(sha),
-		},
-		Sender: &github.User{
-			Login: github.String(user),
-		},
-		Installation: &github.Installation{
-			ID: github.Int64(int64(installationToken)),
-		},
+		result, err := subject.Convert(&github.PushEvent{
+			Repo: pushEventRepo,
+			Ref:  github.String(ref),
+			HeadCommit: &github.HeadCommit{
+				ID: github.String(sha),
+			},
+			Sender: &github.User{
+				Login: github.String(user),
+			},
+			Installation: &github.Installation{
+				ID: github.Int64(int64(installationToken)),
+			},
+			Created: github.Bool(true),
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
 	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, expectedResult, result)
+	t.Run("deleted branch ref", func(t *testing.T) {
+		expectedResult := event.Push{
+			Repo: models.Repo{
+				FullName:          repoFullName,
+				Owner:             repoOwner,
+				Name:              repoName,
+				CloneURL:          "https://user:token@github.com/owner/repo.git",
+				SanitizedCloneURL: "https://user:<redacted>@github.com/owner/repo.git",
+				VCSHost: models.VCSHost{
+					Type:     models.Github,
+					Hostname: "github.com",
+				},
+				DefaultBranch: "main",
+			},
+			Ref: vcs.Ref{
+				Type: vcs.BranchRef,
+				Name: "main",
+			},
+			Sha: sha,
+			Sender: vcs.User{
+				Login: "nish",
+			},
+			InstallationToken: int64(installationToken),
+			Action:            event.DeletedAction,
+		}
+
+		result, err := subject.Convert(&github.PushEvent{
+			Repo: pushEventRepo,
+			Ref:  github.String(ref),
+			HeadCommit: &github.HeadCommit{
+				ID: github.String(sha),
+			},
+			Sender: &github.User{
+				Login: github.String(user),
+			},
+			Installation: &github.Installation{
+				ID: github.Int64(int64(installationToken)),
+			},
+			Deleted: github.Bool(true),
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+	})
 }

--- a/server/vcs/provider/github/converter/repo.go
+++ b/server/vcs/provider/github/converter/repo.go
@@ -13,10 +13,20 @@ type RepoConverter struct {
 type externalRepo interface {
 	GetFullName() string
 	GetCloneURL() string
+	GetDefaultBranch() string
 }
 
 // ParseGithubRepo parses the response from the GitHub API endpoint that
 // returns a repo into the Atlantis model.
 func (c *RepoConverter) Convert(ghRepo externalRepo) (models.Repo, error) {
-	return models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), c.GithubUser, c.GithubToken)
+	repo, err := models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), c.GithubUser, c.GithubToken)
+
+	if err != nil {
+		return repo, err
+	}
+
+	// set the default branch here since it's annoying to do so within models since a lot of other code depends on it.
+	// We should be moving all that code here in the future anyways
+	repo.DefaultBranch = ghRepo.GetDefaultBranch()
+	return repo, nil
 }

--- a/server/vcs/provider/github/converter/repo_test.go
+++ b/server/vcs/provider/github/converter/repo_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 var Repo = github.Repository{
-	FullName: github.String("owner/repo"),
-	Owner:    &github.User{Login: github.String("owner")},
-	Name:     github.String("repo"),
-	CloneURL: github.String("https://github.com/owner/repo.git"),
+	FullName:      github.String("owner/repo"),
+	Owner:         &github.User{Login: github.String("owner")},
+	Name:          github.String("repo"),
+	CloneURL:      github.String("https://github.com/owner/repo.git"),
+	DefaultBranch: github.String("main"),
 }
 
 func TestParseGithubRepo(t *testing.T) {
@@ -33,5 +34,6 @@ func TestParseGithubRepo(t *testing.T) {
 			Hostname: "github.com",
 			Type:     models.Github,
 		},
+		DefaultBranch: "main",
 	}, r)
 }


### PR DESCRIPTION
Few things happening here:
1. HeadCommit.Sha is not the right field to use, id is the one populated with the sha
2. Default branch needs to be taken into consideration, we don't want to deploy on non-default branch pushes (yet..?)
3. When a branch is deleted a push event is sent, we should just filter those out as the sha is some bogus value.