### PR TITLE
Setup local dev with temporalite.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !docker-entrypoint.sh
 !atlantis
+!repo-config-dev-template.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,25 +33,64 @@ open your browser to http://localhost:8080.
     If you get an error like `command not found: atlantis`, ensure that `$GOPATH/bin` is in your `$PATH`.
 
 ## Running Atlantis With Local Changes
-Docker compose is set up to start an atlantis container and ngrok container in the same network in order to expose the atlantis instance to the internet.  In order to do this, create a file in the repository called `atlantis.env` and add the required env vars for the atlantis server configuration.
 
-e.g.
-```
-ATLANTIS_GH_APP_ID=123
-ATLANTIS_GH_APP_KEY_FILE="/.ssh/somekey.pem"
-ATLANTIS_GH_WEBHOOK_SECRET=12345
-ATLANTIS_REPO_ALLOWLIST=<repo-url> [Eg: github.com/Altlantis-Dev/Atlantis]
-ATLANTIS_WRITE_GIT_CREDS=true 
-USE_STATSD=false [To avoid statsd error messages during development]
-```
-- You can generate you GH_APP_KEY_FILE [here](https://github.com/settings/keys). Download the key file and save it to ~/.ssh directory. Note: `~/.ssh` is mounted to allow for referencing any local ssh keys.
+The atlantis worker can't technically be run yet locally given it's dependency on sqs.  However, Docker compose is set up 
+to run a gateway, a temporal worker, temporalite and ngrok all in the same network.  ngrok allows us to expose localhost to the public internet in order to test github app integrations.
 
-Following this just run:
+There is some setup that is required in order to have your containers running and receiving webhooks.
+
+1. Setup your own personal github organization and test github app.
+2. Install this app to a test repo within your organization with all the correct atlantis permissions as our real app.
+3. Download the key file and save it to ~/.ssh directory. Note: `~/.ssh` is mounted to allow for referencing any local ssh keys.
+4. Create the following files:
+
+`~/atlantis-gateway.env`
+ATLANTIS_GH_APP_ID=<FILL THIS IN>
+ATLANTIS_GH_APP_KEY_FILE=/.ssh/your-key-file.pem
+ATLANTIS_GH_WEBHOOK_SECRET=<FILL THIS IN>
+ATLANTIS_GH_APP_SLUG=<FILL THIS IN>
+ATLANTIS_FF_OWNER=<FILL THIS IN>
+ATLANTIS_FF_REPO=<FILL THIS IN>
+ATLANTIS_FF_PATH=<FILL THIS IN>
+ATLANTIS_DATA_DIR=/tmp/
+ATLANTIS_LYFT_MODE=gateway
+ATLANTIS_REPO_CONFIG=/generated/repo-config.yaml
+ATLANTIS_WRITE_GIT_CREDS=true
+ATLANTIS_REPO_ALLOWLIST=<FILL THIS IN>
+ATLANTIS_ENABLE_POLICY_CHECKS=true
+ATLANTIS_ENABLE_DIFF_MARKDOWN_FORMAT=true
+ATLANTIS_PORT=4143
+ALLOWED_REPOS=<FILL THIS IN>
+
+`~/atlantis-temporalworker.env`
+ATLANTIS_GH_APP_ID=<FILL THIS IN>
+ATLANTIS_GH_APP_KEY_FILE=/.ssh/your-key-file.pem
+ATLANTIS_GH_WEBHOOK_SECRET=<FILL THIS IN>
+ATLANTIS_GH_APP_SLUG=<FILL THIS IN>
+ATLANTIS_FF_OWNER=<FILL THIS IN>
+ATLANTIS_FF_REPO=<FILL THIS IN>
+ATLANTIS_FF_PATH=<FILL THIS IN>
+ATLANTIS_DATA_DIR=/tmp/
+ATLANTIS_LYFT_MODE=temporalworker
+ATLANTIS_REPO_CONFIG=/generated/repo-config.yaml
+ATLANTIS_WRITE_GIT_CREDS=true
+ATLANTIS_REPO_ALLOWLIST=<FILL THIS IN>
+ATLANTIS_ENABLE_POLICY_CHECKS=true
+ATLANTIS_ENABLE_DIFF_MARKDOWN_FORMAT=true
+ATLANTIS_PORT=4142
+ALLOWED_REPOS=<FILL THIS IN>
+
+Once these steps are complete, everything should startup as normal. You just need to run:
 
 ```
 make build-service
+docker-compose build
 docker-compose up
 ```
+
+In order to have events routed to gateway, you'll need to visit `http://localhost:4040/` and copy the https url into your gihub app.  
+
+In order to see the temporal ui visit `http://localhost:8233/`.
 
 ### Rebuilding
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,26 @@
-FROM runatlantis/atlantis:latest
+FROM ghcr.io/runatlantis/atlantis:v0.19.7
 COPY atlantis /usr/local/bin/atlantis
 # TODO: remove this once we get this in the base image
 ENV DEFAULT_CONFTEST_VERSION=0.25.0
 
+RUN apk add --no-cache openssl
+
+# Install dockerize for configuration templating at runtime.
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+COPY . /atlantis/src/
+
 WORKDIR /atlantis/src
+
+RUN : \
+    && mkdir -p /generated \
+    && :
+
+COPY repo-config-dev-template.yaml /tmp/repo-config-dev-template.yaml
+
+RUN : \
+    && dockerize -template /tmp/repo-config-dev-template.yaml:/generated/repo-config.yaml \
+    && :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,35 @@ services:
         - 4040:4040
         environment:
             NGROK_PROTOCOL: http
-            NGROK_PORT: atlantis:4141
+            NGROK_PORT: atlantis-gateway:4143
         depends_on:
-        - atlantis
-    atlantis:
+        - atlantis-gateway
+    atlantis-gateway:
         build:
             context: .
             dockerfile: Dockerfile.dev
         ports:
-        - 4141:4141
+        - 4143:4143
         volumes:
             - ~/.ssh:/.ssh
             - ./:/atlantis/src
         # Contains the flags that atlantis uses in env var form
         env_file:
-            - ~/.atlantis.env
+            - ~/.atlantis-gateway.env
+    atlantis-temporalworker:
+        build:
+            context: .
+            dockerfile: Dockerfile.dev
+        ports:
+        - 4142:4142
+        volumes:
+            - ~/.ssh:/.ssh
+            - ./:/atlantis/src
+        # Contains the flags that atlantis uses in env var form
+        env_file:
+            - ~/.atlantis-temporalworker.env
+    temporalite:
+        build: https://github.com/temporalio/temporalite.git#main
+        ports:
+        - 7233:7233
+        - 8233:8233

--- a/repo-config-dev-template.yaml
+++ b/repo-config-dev-template.yaml
@@ -1,0 +1,13 @@
+repos:
+  - id: {{ .Env.ALLOWED_REPOS }} 
+    apply_requirements: []
+    checkout_strategy: merge
+
+metrics:
+  statsd:
+    host: "127.0.0.1"
+    port: "8125"
+
+temporal:
+  host: temporalite
+  port: 7233

--- a/server/core/config/raw/temporal.go
+++ b/server/core/config/raw/temporal.go
@@ -10,6 +10,7 @@ type Temporal struct {
 	Port            string `yaml:"port" json:"port"`
 	Host            string `yaml:"host" json:"host"`
 	UseSystemCACert bool   `yaml:"us_system_ca_cert" json:"us_system_ca_cert"`
+	Namespace       string `yaml:"namespace" json:"namespace"`
 }
 
 func (t *Temporal) Validate() error {
@@ -24,5 +25,6 @@ func (t *Temporal) ToValid() valid.Temporal {
 		Host:            t.Host,
 		Port:            t.Port,
 		UseSystemCACert: t.UseSystemCACert,
+		Namespace:       t.Namespace,
 	}
 }

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -101,6 +101,7 @@ type Temporal struct {
 	Port            string
 	Host            string
 	UseSystemCACert bool
+	Namespace       string
 }
 
 type TerraformLogFilters struct {

--- a/server/neptune/temporal/client.go
+++ b/server/neptune/temporal/client.go
@@ -12,12 +12,15 @@ import (
 	"logur.dev/logur"
 )
 
-var namespace = "atlantis"
-
 func NewClient(scope tally.Scope, logger logur.Logger, cfg valid.Temporal) (client.Client, error) {
+	addr := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
+
+	logger.Info(addr)
+	logger.Info("test")
+
 	opts := client.Options{
-		HostPort:       fmt.Sprintf("%s:%s", cfg.Host, cfg.Port),
-		Namespace:      namespace,
+		HostPort:       addr,
+		Namespace:      cfg.Namespace,
 		MetricsHandler: temporaltally.NewMetricsHandler(scope),
 		Logger:         logur.LoggerToKV(logger),
 	}


### PR DESCRIPTION
Docker compose now creates 4 containers in the same network:
1. temporalite container
2. atlantis-temporalworker
3. atlantis-gateway
4. ngrok