### PR TITLE
Cloning activity [draft]

### DIFF
--- a/server/neptune/workflows/internal/github/repo.go
+++ b/server/neptune/workflows/internal/github/repo.go
@@ -8,6 +8,7 @@ type Repo struct {
 	Name string
 	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
 	URL string
+	Ref string
 
 	Credentials AppCredentials
 }

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -68,7 +68,11 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 func (r *Runner) Run(ctx workflow.Context) error {
 	// Clone repository into disk
 	var cloneResp activities.CloneRepoResponse
-	err := workflow.ExecuteActivity(ctx, r.Activities.CloneRepo, activities.CloneRepoRequest{}).Get(ctx, cloneResp)
+	err := workflow.ExecuteActivity(ctx, r.Activities.CloneRepo, activities.CloneRepoRequest{
+		Repo:            r.Request.Repo,
+		RootPath:        "", // TODO: use root path from root instance
+		DestinationPath: "", // TODO: generate destination path within workflow and pass along to tf activities
+	}).Get(ctx, cloneResp)
 	if err != nil {
 		return errors.Wrap(err, "executing GH repo clone")
 	}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -43,7 +43,7 @@ func Workflow(ctx workflow.Context, request Request) error {
 }
 
 type workerActivities interface {
-	GithubRepoClone(context.Context, activities.GithubRepoCloneRequest) error
+	CloneRepo(context.Context, activities.CloneRepoRequest) (activities.CloneRepoResponse, error)
 	TerraformInit(context.Context, activities.TerraformInitRequest) error
 	TerraformPlan(context.Context, activities.TerraformPlanRequest) error
 	TerraformApply(context.Context, activities.TerraformApplyRequest) error
@@ -67,7 +67,8 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 
 func (r *Runner) Run(ctx workflow.Context) error {
 	// Clone repository into disk
-	err := workflow.ExecuteActivity(ctx, r.Activities.GithubRepoClone, activities.GithubRepoCloneRequest{}).Get(ctx, nil)
+	var cloneResp activities.CloneRepoResponse
+	err := workflow.ExecuteActivity(ctx, r.Activities.CloneRepo, activities.CloneRepoRequest{}).Get(ctx, cloneResp)
 	if err != nil {
 		return errors.Wrap(err, "executing GH repo clone")
 	}


### PR DESCRIPTION
Before I add testing (and pull in changes from Execute Cmd Activity), wanted to get thoughts on cloning this way:

- use GH client's GetArchiveLink() fxn to fetch URL of repo
- use go-getter's GetAny() fxn to handle downloading, extracting, and filtering for necessary files

Things to note: 
* GH client's archive link lasts 5 minutes
* using go-getter just reduces our code complexity by letting us avoid dealing with generating temporary directories and migrating files from it to another spot
* will use Repo Instance construct when Execute activity PR merges in