### PR TITLE
Add job id generation and signal sending.

### DIFF
--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -92,6 +92,7 @@ func NewServer(config *Config) (*Server, error) {
 
 	terraformActivities, err := workflows.NewTerraformActivities(
 		config.Scope.SubScope("terraform"),
+		config.ServerCfg.URL,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing terraform activities")

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github/link"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
 	"github.com/uber-go/tally/v4"
-	"net/url"
 )
 
 // Exported Activites should be here.

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -1,6 +1,8 @@
 package activities
 
 import (
+	"net/url"
+
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/github"
@@ -27,13 +29,17 @@ func NewDeploy(config githubapp.Config, scope tally.Scope) (*Deploy, error) {
 type Terraform struct {
 	*terraformActivities
 	*executeCommandActivities
+	*workerInfoActivity
 	*notifyActivities
 	*cleanupActivities
 }
 
-func NewTerraform() *Terraform {
+func NewTerraform(serverURL *url.URL) *Terraform {
 	return &Terraform{
 		executeCommandActivities: &executeCommandActivities{},
+		workerInfoActivity: &workerInfoActivity{
+			ServerURL: serverURL,
+		},
 	}
 }
 

--- a/server/neptune/workflows/internal/activities/worker_info.go
+++ b/server/neptune/workflows/internal/activities/worker_info.go
@@ -1,0 +1,23 @@
+package activities
+
+import (
+	"context"
+	"net/url"
+)
+
+type workerInfoActivity struct {
+	ServerURL *url.URL
+}
+
+type GetWorkerInfoResponse struct {
+	ServerURL *url.URL
+}
+
+// GetWorkerInfo exists because this is the only way to pass host level info from worker construction
+// to our workflows. This should be invoked as part of a session.
+func (a *workerInfoActivity) GetWorkerInfo(ctx context.Context) (*GetWorkerInfoResponse, error) {
+	return &GetWorkerInfoResponse{
+		ServerURL: a.ServerURL,
+	}, nil
+
+}

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -1,12 +1,12 @@
 package terraform
 
 import (
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/workflow"
@@ -36,7 +36,7 @@ type WorkflowRunner struct {
 }
 
 func (r *WorkflowRunner) Run(ctx workflow.Context, checkRunID int64, revision string, root root.Root) error {
-	id, err := generateID(ctx)
+	id, err := sideeffect.GenerateUUID(ctx)
 
 	ctx = workflow.WithValue(ctx, internalContext.DeploymentIDKey, id)
 
@@ -91,31 +91,4 @@ func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.Chi
 		return errors.Wrap(err, "executing terraform workflow")
 	}
 	return nil
-}
-
-func generateID(ctx workflow.Context) (uuid.UUID, error) {
-	// UUIDErr allows us to extract both the id and the err from the sideeffect
-	// not sure if there is a better way to do this
-	type UUIDErr struct {
-		id  uuid.UUID
-		err error
-	}
-
-	var result UUIDErr
-	encodedResult := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
-		uuid, err := uuid.NewUUID()
-
-		return UUIDErr{
-			id:  uuid,
-			err: err,
-		}
-	})
-
-	err := encodedResult.Get(&result)
-
-	if err != nil {
-		return uuid.UUID{}, errors.Wrap(err, "getting uuid from side effect")
-	}
-
-	return result.id, result.err
 }

--- a/server/neptune/workflows/internal/sideeffect/uuid.go
+++ b/server/neptune/workflows/internal/sideeffect/uuid.go
@@ -1,0 +1,35 @@
+package sideeffect
+
+import (
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+)
+
+
+func GenerateUUID(ctx workflow.Context) (uuid.UUID, error) {
+	// UUIDErr allows us to extract both the id and the err from the sideeffect
+	// not sure if there is a better way to do this
+	type UUIDErr struct {
+		id  uuid.UUID
+		err error
+	}
+
+	var result UUIDErr
+	encodedResult := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
+		uuid, err := uuid.NewUUID()
+
+		return UUIDErr{
+			id:  uuid,
+			err: err,
+		}
+	})
+
+	err := encodedResult.Get(&result)
+
+	if err != nil {
+		return uuid.UUID{}, errors.Wrap(err, "getting uuid from side effect")
+	}
+
+	return result.id, result.err
+}

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -1,0 +1,58 @@
+package state
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type UpdateNotifier func(state *Workflow) error
+
+type WorkflowStore struct {
+	state              *Workflow
+	Notifier           UpdateNotifier
+	OutputURLGenerator *OutputURLGenerator
+}
+
+func (s *WorkflowStore) InitPlanJob(jobID fmt.Stringer, serverURL *url.URL) error {
+	outputURL, err := s.OutputURLGenerator.Generate(jobID, serverURL)
+
+	if err != nil {
+		return errors.Wrap(err, "generating url for plan job")
+	}
+	s.state.Plan = &Job{
+		Output: &JobOutput{
+			URL: outputURL,
+		},
+		Status: InProgressJobStatus,
+	}
+
+	return s.Notifier(s.state)
+}
+
+func (s *WorkflowStore) InitApplyJob(jobID fmt.Stringer, serverURL *url.URL) error {
+	outputURL, err := s.OutputURLGenerator.Generate(jobID, serverURL)
+
+	if err != nil {
+		return errors.Wrap(err, "generating url for plan job")
+	}
+	s.state.Plan = &Job{
+		Output: &JobOutput{
+			URL: outputURL,
+		},
+		Status: InProgressJobStatus,
+	}
+
+	return s.Notifier(s.state)
+}
+
+func (s *WorkflowStore) UpdatePlanJobWithStatus(status JobStatus) error {
+	s.state.Plan.Status = status
+	return s.Notifier(s.state)
+}
+
+func (s *WorkflowStore) UpdateApplyJobWithStatus(status JobStatus) error {
+	s.state.Apply.Status = status
+	return s.Notifier(s.state)
+}

--- a/server/neptune/workflows/internal/terraform/state/store_test.go
+++ b/server/neptune/workflows/internal/terraform/state/store_test.go
@@ -1,0 +1,170 @@
+package state_test
+
+import (
+	"bytes"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+)
+
+type testNotifier struct {
+	expectedState *state.Workflow
+	t             *testing.T
+	called        bool
+}
+
+func (n *testNotifier) notify(state *state.Workflow) error {
+	n.called = true
+	assert.Equal(n.t, n.expectedState, state)
+	return nil
+}
+
+func TestInitPlanJob(t *testing.T) {
+
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+
+	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
+	assert.NoError(t, err)
+
+	notifier := &testNotifier{
+		expectedState: &state.Workflow{
+			Plan: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: exoectedURL,
+				},
+			},
+		},
+		t: t,
+	}
+
+	subject := state.NewWorkflowStore(
+		notifier.notify,
+		&state.OutputURLGenerator{
+			URLBuilder: route,
+		},
+	)
+
+	jobID := bytes.NewBufferString("1234")
+	baseURL := bytes.NewBufferString("www.test.com")
+
+	err = subject.InitPlanJob(jobID, baseURL)
+	assert.NoError(t, err)
+	assert.True(t, notifier.called)
+}
+
+func TestInitApplyJob(t *testing.T) {
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+
+	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
+	assert.NoError(t, err)
+
+	notifier := &testNotifier{
+		expectedState: &state.Workflow{
+			Apply: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: exoectedURL,
+				},
+			},
+		},
+		t: t,
+	}
+
+	subject := state.NewWorkflowStore(
+		notifier.notify,
+		&state.OutputURLGenerator{
+			URLBuilder: route,
+		},
+	)
+
+	jobID := bytes.NewBufferString("1234")
+	baseURL := bytes.NewBufferString("www.test.com")
+
+	err = subject.InitApplyJob(jobID, baseURL)
+	assert.NoError(t, err)
+	assert.True(t, notifier.called)
+}
+
+func TestUpdateApplyJob(t *testing.T) {
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+
+	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
+	assert.NoError(t, err)
+	notifier := &testNotifier{
+		expectedState: &state.Workflow{
+			Apply: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: exoectedURL,
+				},
+			},
+		},
+		t: t,
+	}
+
+	subject := state.NewWorkflowStore(
+		notifier.notify,
+		&state.OutputURLGenerator{
+			URLBuilder: route,
+		},
+	)
+
+	jobID := bytes.NewBufferString("1234")
+	baseURL := bytes.NewBufferString("www.test.com")
+
+	// init and then update
+	err = subject.InitApplyJob(jobID, baseURL)
+	assert.NoError(t, err)
+
+	notifier.expectedState.Apply.Status = state.FailedJobStatus
+
+	err = subject.UpdateApplyJobWithStatus(state.FailedJobStatus)
+	assert.NoError(t, err)
+	assert.True(t, notifier.called)
+}
+
+func TestUpdatePlanJob(t *testing.T) {
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+
+	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
+	assert.NoError(t, err)
+	notifier := &testNotifier{
+		expectedState: &state.Workflow{
+			Plan: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: exoectedURL,
+				},
+			},
+		},
+		t: t,
+	}
+
+	subject := state.NewWorkflowStore(
+		notifier.notify,
+		&state.OutputURLGenerator{
+			URLBuilder: route,
+		},
+	)
+
+	jobID := bytes.NewBufferString("1234")
+	baseURL := bytes.NewBufferString("www.test.com")
+
+	// init and then update
+	err = subject.InitPlanJob(jobID, baseURL)
+	assert.NoError(t, err)
+
+	notifier.expectedState.Plan.Status = state.FailedJobStatus
+
+	err = subject.UpdatePlanJobWithStatus(state.FailedJobStatus)
+	assert.NoError(t, err)
+	assert.True(t, notifier.called)
+}

--- a/server/neptune/workflows/internal/terraform/state/store_test.go
+++ b/server/neptune/workflows/internal/terraform/state/store_test.go
@@ -24,9 +24,6 @@ func (n *testNotifier) notify(state *state.Workflow) error {
 
 func TestInitPlanJob(t *testing.T) {
 
-	route := &mux.Route{}
-	route.Path("/jobs/{job-id}")
-
 	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
 	assert.NoError(t, err)
 
@@ -44,9 +41,6 @@ func TestInitPlanJob(t *testing.T) {
 
 	subject := state.NewWorkflowStore(
 		notifier.notify,
-		&state.OutputURLGenerator{
-			URLBuilder: route,
-		},
 	)
 
 	jobID := bytes.NewBufferString("1234")
@@ -78,9 +72,6 @@ func TestInitApplyJob(t *testing.T) {
 
 	subject := state.NewWorkflowStore(
 		notifier.notify,
-		&state.OutputURLGenerator{
-			URLBuilder: route,
-		},
 	)
 
 	jobID := bytes.NewBufferString("1234")
@@ -111,9 +102,6 @@ func TestUpdateApplyJob(t *testing.T) {
 
 	subject := state.NewWorkflowStore(
 		notifier.notify,
-		&state.OutputURLGenerator{
-			URLBuilder: route,
-		},
 	)
 
 	jobID := bytes.NewBufferString("1234")
@@ -150,9 +138,6 @@ func TestUpdatePlanJob(t *testing.T) {
 
 	subject := state.NewWorkflowStore(
 		notifier.notify,
-		&state.OutputURLGenerator{
-			URLBuilder: route,
-		},
 	)
 
 	jobID := bytes.NewBufferString("1234")

--- a/server/neptune/workflows/internal/terraform/state/url.go
+++ b/server/neptune/workflows/internal/terraform/state/url.go
@@ -22,8 +22,7 @@ type OutputURLGenerator struct {
 	URLBuilder outputURLBuilder
 }
 
-func (g *OutputURLGenerator) Generate(jobID fmt.Stringer, BaseURL *url.URL) (*url.URL, error) {
-
+func (g *OutputURLGenerator) Generate(jobID fmt.Stringer, BaseURL fmt.Stringer) (*url.URL, error) {
 	jobIDParam := jobID.String()
 
 	jobURL, err := g.URLBuilder.URL(

--- a/server/neptune/workflows/internal/terraform/state/url.go
+++ b/server/neptune/workflows/internal/terraform/state/url.go
@@ -1,0 +1,39 @@
+package state
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	JobIDParamKey = "job-id"
+)
+
+// outputURLBuilder builds a URL for the route.
+//
+// It accepts a sequence of key/value pairs for the route variables.
+type outputURLBuilder interface {
+	URL(pairs ...string) (*url.URL, error)
+}
+
+type OutputURLGenerator struct {
+	URLBuilder outputURLBuilder
+}
+
+func (g *OutputURLGenerator) Generate(jobID fmt.Stringer, BaseURL *url.URL) (*url.URL, error) {
+
+	jobIDParam := jobID.String()
+
+	jobURL, err := g.URLBuilder.URL(
+		JobIDParamKey, jobIDParam,
+	)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating job url for %s", jobIDParam)
+	}
+
+	combined := BaseURL.String() + jobURL.String()
+	return url.Parse(combined)
+}

--- a/server/neptune/workflows/internal/terraform/state/url_test.go
+++ b/server/neptune/workflows/internal/terraform/state/url_test.go
@@ -1,0 +1,32 @@
+package state_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerate(t *testing.T) {
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+	baseURL, err := url.Parse("https://baseurl.com")
+
+	assert.NoError(t, err)
+
+	subject := &state.OutputURLGenerator{
+		URLBuilder: route,
+	}
+
+	jobID := uuid.New()
+
+	url, err := subject.Generate(jobID, baseURL)
+	assert.NoError(t, err)
+
+	expectedURL := fmt.Sprintf("https://baseurl.com/jobs/%s", jobID.String())
+	assert.Equal(t, expectedURL, url.String())
+}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -1,15 +1,20 @@
 package terraform
 
 import (
+	"net/url"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	job_runner "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job/step/cmd"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job/step/env"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -60,14 +65,22 @@ type Runner struct {
 	Activities *workflowActivities
 	JobRunner  jobRunner
 	Request    Request
+	Store      *state.WorkflowStore
 }
 
 func newRunner(ctx workflow.Context, request Request) *Runner {
 	var a *workflowActivities
 
+	// Create a dummy route with the correct jobs path
+	route := &mux.Route{}
+	route.Path("/jobs/{job-id}")
+
 	cmdStepRunner := cmd.Runner{
 		Activity: a,
 	}
+
+	parent := workflow.GetInfo(ctx).ParentWorkflowExecution
+
 	return &Runner{
 		Activities: a,
 		Request:    request,
@@ -77,38 +90,104 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 				CmdRunner: cmdStepRunner,
 			},
 		),
+		Store: &state.WorkflowStore{
+			Notifier: func(s *state.Workflow) error {
+				return workflow.SignalExternalWorkflow(ctx, parent.ID, parent.RunID, state.WorkflowStateChangeSignal, s).Get(ctx, nil)
+			},
+			OutputURLGenerator: &state.OutputURLGenerator{
+				URLBuilder: route,
+			},
+		},
 	}
 }
 
-func (r *Runner) Run(ctx workflow.Context) error {
+func (r *Runner) Plan(ctx workflow.Context, root *root.LocalRoot, serverURL *url.URL) error {
+	jobID, err := sideeffect.GenerateUUID(ctx)
 
-	// Clone repository into disk
-	var cloneResponse activities.GithubRepoCloneResponse
-	err := workflow.ExecuteActivity(ctx, r.Activities.GithubRepoClone, activities.GithubRepoCloneRequest{}).Get(ctx, &cloneResponse)
 	if err != nil {
-		return errors.Wrap(err, "executing GH repo clone")
+		return errors.Wrap(err, "generating job id")
 	}
 
-	_, err = r.JobRunner.Run(ctx, r.Request.Root.Plan, cloneResponse.LocalRoot)
+	if err := r.Store.InitPlanJob(jobID, serverURL); err != nil {
+		return errors.Wrap(err, "initializing job")
+	}
+
+	_, err = r.JobRunner.Run(ctx, r.Request.Root.Plan, root)
+
 	if err != nil {
-		return errors.Wrap(err, "running plan job")
+		if e := r.Store.UpdatePlanJobWithStatus(state.FailedJobStatus); e != nil {
+			logger.Error(ctx, "unable to update job with failed status, job failed with error. ", err)
+			return errors.Wrap(e, "updating job with failed status")
+		}
+		return errors.Wrap(err, "running job")
+	}
+	if err := r.Store.UpdatePlanJobWithStatus(state.SuccessJobStatus); err != nil {
+		return errors.Wrap(err, "updating job with success status")
+	}
+
+	return nil
+}
+
+func (r *Runner) Apply(ctx workflow.Context, root *root.LocalRoot, serverURL *url.URL) error {
+	jobID, err := sideeffect.GenerateUUID(ctx)
+
+	if err != nil {
+		return errors.Wrap(err, "generating job id")
+	}
+
+	if err := r.Store.InitApplyJob(jobID, serverURL); err != nil {
+		return errors.Wrap(err, "initializing apply job")
 	}
 
 	// Wait for plan review signal
 	var planReview PlanReview
 	signalChan := workflow.GetSignalChannel(ctx, "planreview-repo-steps")
-	more := signalChan.Receive(ctx, &planReview)
-	if !more {
-		return errors.New("plan review signal channel cancelled")
-	}
+	_ = signalChan.Receive(ctx, &planReview)
+
 	if planReview.Status == Rejected {
+		if err := r.Store.UpdateApplyJobWithStatus(state.RejectedJobStatus); err != nil {
+			return errors.Wrap(err, "updating apply job with rejected status")
+		}
 		return nil
 	}
 
-	// Run apply steps
-	_, err = r.JobRunner.Run(ctx, r.Request.Root.Apply, cloneResponse.LocalRoot)
+	_, err = r.JobRunner.Run(ctx, r.Request.Root.Apply, root)
 	if err != nil {
-		return errors.Wrap(err, "running apply job")
+
+		if err := r.Store.UpdateApplyJobWithStatus(state.FailedJobStatus); err != nil {
+			return errors.Wrap(err, "updating apply job with failed status")
+		}
+		return errors.Wrap(err, "running plan job")
+	}
+
+	if err := r.Store.UpdateApplyJobWithStatus(state.SuccessJobStatus); err != nil {
+		return errors.Wrap(err, "updating apply job with success status")
+	}
+
+	return nil
+}
+
+func (r *Runner) Run(ctx workflow.Context) error {
+	var response *activities.GetWorkerInfoResponse
+	err := workflow.ExecuteActivity(ctx, r.Activities.GetWorkerInfo).Get(ctx, &response)
+
+	if err != nil {
+		return errors.Wrap(err, "getting worker info")
+	}
+
+	// Clone repository into disk
+	var cloneResponse activities.GithubRepoCloneResponse
+	err = workflow.ExecuteActivity(ctx, r.Activities.GithubRepoClone, activities.GithubRepoCloneRequest{}).Get(ctx, &cloneResponse)
+	if err != nil {
+		return errors.Wrap(err, "executing GH repo clone")
+	}
+
+	if err := r.Plan(ctx, cloneResponse.LocalRoot, response.ServerURL); err != nil {
+		return err
+	}
+
+	if err := r.Apply(ctx, cloneResponse.LocalRoot, response.ServerURL); err != nil {
+		return err
 	}
 
 	// Cleanup

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -2,19 +2,21 @@ package terraform_test
 
 import (
 	"context"
-	"errors"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"go.temporal.io/sdk/temporal"
-	"go.temporal.io/sdk/testsuite"
-	"go.temporal.io/sdk/worker"
-	"go.temporal.io/sdk/workflow"
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
 
 const (
@@ -24,172 +26,333 @@ const (
 	testPath         = "rel/path"
 )
 
-type testActivities struct{}
-
-func (a *testActivities) FetchRoot(_ context.Context, _ activities.FetchRootRequest) (activities.FetchRootResponse, error) {
-	return activities.FetchRootResponse{}, nil
+var testGithubRepo = github.Repo{
+	Name: testRepoName,
 }
 
-func (a *testActivities) Cleanup(_ context.Context, _ activities.CleanupRequest) (activities.CleanupResponse, error) {
+var testLocalRoot = &root.LocalRoot{
+	Root: root.Root{
+		Name: testRootName,
+		Plan: job.Job{
+			Steps: []job.Step{
+				{
+					StepName: "step1",
+				},
+			},
+		},
+		Apply: job.Job{
+			Steps: []job.Step{
+				{
+					StepName: "step2",
+				},
+			},
+		},
+	},
+	Path: testPath,
+	Repo: testGithubRepo,
+}
+
+type testURLGenerator struct{}
+
+func (g *testURLGenerator) Generate(jobID fmt.Stringer, BaseURL fmt.Stringer) (*url.URL, error) {
+	return url.Parse("www.test.com/jobs/1235")
+}
+
+type githubActivities struct{}
+
+func (a *githubActivities) FetchRoot(_ context.Context, _ activities.FetchRootRequest) (activities.FetchRootResponse, error) {
+	return activities.FetchRootResponse{
+		LocalRoot: testLocalRoot,
+	}, nil
+}
+
+type terraformActivities struct{}
+
+func (a *terraformActivities) Cleanup(ctx context.Context, request activities.CleanupRequest) (activities.CleanupResponse, error) {
 	return activities.CleanupResponse{}, nil
 }
-
-func testTerraformWorkflow(ctx workflow.Context) error {
-	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ScheduleToCloseTimeout: 5 * time.Second,
-	})
-	ch := workflow.NewChannel(ctx)
-	act := &testActivities{}
-	testRepo := github.Repo{
-		Name: testRepoName,
-	}
-	testRoot := root.Root{
-		Name: testRootName,
-	}
-
-	// Run download step
-	var downloadResponse activities.FetchRootResponse
-	err := workflow.ExecuteActivity(ctx, act.FetchRoot, activities.FetchRootRequest{
-		Repo:         testRepo,
-		Root:         testRoot,
-		DeploymentId: testDeploymentID,
-	}).Get(ctx, &downloadResponse)
-	if err != nil {
-		return err
-	}
-
-	// TODO: run plan steps
-
-	// Send plan approval signal
-	approval := terraform.PlanReview{
-		Status: terraform.Approved,
-	}
-	workflow.Go(ctx, func(ctx workflow.Context) {
-		ch.Send(ctx, approval)
-	})
-
-	// Receive signal
-	var planReview terraform.PlanReview
-	ch.Receive(ctx, &planReview)
-	if planReview.Status != terraform.Approved {
-		return errors.New("failed to receive approval")
-	}
-
-	// TODO: run apply steps
-
-	// Cleanup
-	var cleanupResponse activities.CleanupResponse
-	err = workflow.ExecuteActivity(ctx, act.Cleanup, activities.CleanupRequest{
-		LocalRoot: downloadResponse.LocalRoot,
-	}).Get(ctx, &cleanupResponse)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (a *terraformActivities) GetWorkerInfo(ctx context.Context) (*activities.GetWorkerInfoResponse, error) {
+	u, err := url.Parse("www.test.com")
+	return &activities.GetWorkerInfoResponse{
+		ServerURL: u,
+	}, err
 }
 
-func Test_TerraformWorkflowSuccess(t *testing.T) {
+type jobRunner struct {
+	expectedError error
+}
+
+func (r *jobRunner) Run(ctx workflow.Context, j job.Job, localRoot *root.LocalRoot) (string, error) {
+	return "", r.expectedError
+}
+
+type request struct{}
+
+type response struct {
+	States []state.Workflow
+}
+
+func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 30 * time.Second,
+	})
+
+	var gAct *githubActivities
+	var tAct *terraformActivities
+	runner := &jobRunner{}
+
+	var s []state.Workflow
+
+	subject := &terraform.Runner{
+		GithubActivities:    gAct,
+		TerraformActivities: tAct,
+		Request: terraform.Request{
+			Root:         testLocalRoot.Root,
+			Repo:         testGithubRepo,
+			DeploymentId: testDeploymentID,
+		},
+		JobRunner: runner,
+		Store: state.NewWorkflowStoreWithGenerator(
+			// add a notifier which just appends to a list which allows us to
+			// test every state change
+			func(st *state.Workflow) error {
+				// need to copy since its a pointer and will get mutated
+				s = append(s, copy(st))
+				return nil
+			},
+			&testURLGenerator{},
+		),
+	}
+
+	if err := subject.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	return &response{
+		States: s,
+	}, nil
+}
+
+func copy(s *state.Workflow) state.Workflow {
+	var copy state.Workflow
+	if s.Plan != nil {
+		copy.Plan = &state.Job{
+			Status: s.Plan.Status,
+			Output: &state.JobOutput{
+				URL: s.Plan.Output.URL,
+			},
+		}
+	}
+
+	if s.Apply != nil {
+		copy.Apply = &state.Job{
+			Status: s.Apply.Status,
+			Output: &state.JobOutput{
+				URL: s.Apply.Output.URL,
+			},
+		}
+	}
+	return copy
+}
+
+func TestSuccess(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
-	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: context.Background(),
-	})
-	a := &testActivities{}
-	env.RegisterActivity(a)
+	ga := &githubActivities{}
+	ta := &terraformActivities{}
+	env.RegisterActivity(ga)
+	env.RegisterActivity(ta)
 
-	testRepo := github.Repo{
-		Name: testRepoName,
-	}
-	testRoot := root.Root{
-		Name: testRootName,
-	}
-	testLocalRoot := &root.LocalRoot{
-		Root: testRoot,
-		Path: testPath,
-		Repo: testRepo,
-	}
-	env.OnActivity(a.FetchRoot, mock.Anything, activities.FetchRootRequest{
-		Repo:         testRepo,
-		Root:         testRoot,
+	outputURL, err := url.Parse("www.test.com/jobs/1235")
+	assert.NoError(t, err)
+
+	// set activity expectations
+	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+		Repo:         testGithubRepo,
+		Root:         testLocalRoot.Root,
 		DeploymentId: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot: testLocalRoot,
 	}, nil)
-	env.OnActivity(a.Cleanup, mock.Anything, activities.CleanupRequest{
+	env.OnActivity(ta.Cleanup, mock.Anything, activities.CleanupRequest{
 		LocalRoot: testLocalRoot,
 	}).Return(activities.CleanupResponse{}, nil)
 
-	env.ExecuteWorkflow(testTerraformWorkflow)
+	// send approval of plan
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReview{
+			Status: terraform.Approved,
+		})
+	}, 5*time.Second)
+
+	// execute workflow
+	env.ExecuteWorkflow(testTerraformWorkflow, request{})
+	assert.True(t, env.IsWorkflowCompleted())
+
+	var resp response
+	err = env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	// assert results are expected
 	env.AssertExpectations(t)
-	assert.True(t, env.IsWorkflowCompleted())
-	assert.NoError(t, env.GetWorkflowError())
+	assert.Equal(t, []state.Workflow{
+		{
+			Plan: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+	}, resp.States)
 }
 
-func Test_TerraformWorkflow_CloneFailure(t *testing.T) {
+func TestPlanRejection(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
-	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: context.Background(),
-	})
-	a := &testActivities{}
-	env.RegisterActivity(a)
+	ga := &githubActivities{}
+	ta := &terraformActivities{}
+	env.RegisterActivity(ga)
+	env.RegisterActivity(ta)
 
-	testRepo := github.Repo{
-		Name: testRepoName,
-	}
-	testRoot := root.Root{
-		Name: testRootName,
-	}
-	env.OnActivity(a.FetchRoot, mock.Anything, activities.FetchRootRequest{
-		Repo:         testRepo,
-		Root:         testRoot,
-		DeploymentId: testDeploymentID,
-	}).Return(activities.FetchRootResponse{}, errors.New("CloneActivityError"))
+	outputURL, err := url.Parse("www.test.com/jobs/1235")
+	assert.NoError(t, err)
 
-	env.ExecuteWorkflow(testTerraformWorkflow)
-	assert.True(t, env.IsWorkflowCompleted())
-	err := env.GetWorkflowError()
-	var applicationErr *temporal.ApplicationError
-	assert.True(t, errors.As(err, &applicationErr))
-	assert.Equal(t, "CloneActivityError", applicationErr.Error())
-}
-
-func Test_TerraformWorkflow_CleanupFailure(t *testing.T) {
-	var suite testsuite.WorkflowTestSuite
-	env := suite.NewTestWorkflowEnvironment()
-	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: context.Background(),
-	})
-	a := &testActivities{}
-	env.RegisterActivity(a)
-
-	testRepo := github.Repo{
-		Name: testRepoName,
-	}
-	testRoot := root.Root{
-		Name: testRootName,
-	}
-	testLocalRoot := &root.LocalRoot{
-		Root: testRoot,
-		Path: testPath,
-		Repo: testRepo,
-	}
-	env.OnActivity(a.FetchRoot, mock.Anything, activities.FetchRootRequest{
-		Repo:         testRepo,
-		Root:         testRoot,
+	// set activity expectations
+	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+		Repo:         testGithubRepo,
+		Root:         testLocalRoot.Root,
 		DeploymentId: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot: testLocalRoot,
 	}, nil)
-	env.OnActivity(a.Cleanup, mock.Anything, activities.CleanupRequest{
-		LocalRoot: testLocalRoot,
-	}).Return(activities.CleanupResponse{}, errors.New("CleanupActivityError"))
 
-	env.ExecuteWorkflow(testTerraformWorkflow)
+	// send approval of plan
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReview{
+			Status: terraform.Rejected,
+		})
+	}, 5*time.Second)
+
+	// execute workflow
+	env.ExecuteWorkflow(testTerraformWorkflow, request{})
 	assert.True(t, env.IsWorkflowCompleted())
-	err := env.GetWorkflowError()
-	var applicationErr *temporal.ApplicationError
-	assert.True(t, errors.As(err, &applicationErr))
-	assert.Equal(t, "CleanupActivityError", applicationErr.Error())
+
+	var resp response
+	err = env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	// assert results are expected
+	env.AssertExpectations(t)
+	assert.Equal(t, []state.Workflow{
+		{
+			Plan: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.InProgressJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.RejectedJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+	}, resp.States)
+}
+
+func TestFetchRootError(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	ga := &githubActivities{}
+	ta := &terraformActivities{}
+	env.RegisterActivity(ga)
+	env.RegisterActivity(ta)
+
+	// set activity expectations
+	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+		Repo:         testGithubRepo,
+		Root:         testLocalRoot.Root,
+		DeploymentId: testDeploymentID,
+	}).Return(activities.FetchRootResponse{
+		LocalRoot: testLocalRoot,
+	}, assert.AnError)
+
+	// execute workflow
+	env.ExecuteWorkflow(testTerraformWorkflow, request{})
+	assert.True(t, env.IsWorkflowCompleted())
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.Error(t, err)
+
+	// assert results are expected
+	env.AssertExpectations(t)
 }

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -1,6 +1,8 @@
 package workflows
 
 import (
+	"net/url"
+
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/uber-go/tally/v4"
@@ -14,8 +16,8 @@ type TerraformActivities struct {
 	activities.Terraform
 }
 
-func NewTerraformActivities(scope tally.Scope) (*TerraformActivities, error) {
-	terraformActivities := activities.NewTerraform()
+func NewTerraformActivities(scope tally.Scope, serverURL *url.URL) (*TerraformActivities, error) {
+	terraformActivities := activities.NewTerraform(serverURL)
 	return &TerraformActivities{
 		Terraform: *terraformActivities,
 	}, nil


### PR DESCRIPTION
* Wrapped state mutation in a specific state store which also handles notifying the parent of a change.
* Added job id generation which will likely need to be passed through to the tf jobs.
* Added an activity to get workerInfo (ie. the server URL) since this is really the best way to pass data between worker initialization and the workflow

- [x] Add tests