### PR TITLE
Terraform Client and Output Handler for Neptune

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -21,18 +21,18 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/palantir/go-githubapp/githubapp"
-	cfgParser "github.com/runatlantis/atlantis/server/core/config"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
-	"github.com/runatlantis/atlantis/server/metrics"
-
 	"github.com/docker/docker/pkg/fileutils"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server"
+	cfgParser "github.com/runatlantis/atlantis/server/core/config"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/metrics"
+	neptune_config "github.com/runatlantis/atlantis/server/neptune/config"
 	"github.com/runatlantis/atlantis/server/neptune/gateway"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker"
 	"github.com/spf13/cobra"
@@ -514,15 +514,22 @@ func (t *TemporalWorker) NewServer(userConfig server.UserConfig, config server.C
 	if err != nil {
 		return nil, err
 	}
-	cfg := &temporalworker.Config{
-		AuthCfg: temporalworker.AuthConfig{
+
+	cfg := &neptune_config.Config{
+		AuthCfg: neptune_config.AuthConfig{
 			SslCertFile: userConfig.SSLCertFile,
 			SslKeyFile:  userConfig.SSLKeyFile,
 		},
-		ServerCfg: temporalworker.ServerConfig{
+		ServerCfg: neptune_config.ServerConfig{
 			URL:     parsedURL,
 			Version: config.AtlantisVersion,
 			Port:    userConfig.Port,
+		},
+		TerraformCfg: neptune_config.TerraformConfig{
+			DefaultVersionFlagName: config.DefaultTFVersionFlag,
+			DefaultVersionStr:      userConfig.DefaultTFVersion,
+			DataDir:                userConfig.DataDir,
+			DownloadURL:            userConfig.TFDownloadURL,
 		},
 		TemporalCfg: globalCfg.Temporal,
 		App:         appConfig,

--- a/server/neptune/config/config.go
+++ b/server/neptune/config/config.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"io"
+	"net/url"
+
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/uber-go/tally/v4"
+)
+
+type AuthConfig struct {
+	SslCertFile string
+	SslKeyFile  string
+}
+
+type ServerConfig struct {
+	URL     *url.URL
+	Version string
+	Port    int
+}
+
+type TerraformConfig struct {
+	DefaultVersionStr      string
+	DefaultVersionFlagName string
+	DataDir                string
+	DownloadURL            string
+}
+
+// Config is TemporalWorker specific user config
+type Config struct {
+	AuthCfg            AuthConfig
+	ServerCfg          ServerConfig
+	TemporalCfg        valid.Temporal
+	LogStreamingJobCfg valid.Jobs
+	TerraformCfg       TerraformConfig
+
+	CtxLogger           logging.Logger
+	Scope               tally.Scope
+	App                 githubapp.Config
+	StatsCloser         io.Closer
+	TerraformLogFilters valid.TerraformLogFilters
+}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -3,6 +3,8 @@ package event
 import (
 	"context"
 	"fmt"
+
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -128,9 +130,11 @@ func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *va
 				Name: rootCfg.Name,
 				Plan: workflows.Job{
 					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Plan.Steps),
+					ID:    uuid.New().String(),
 				},
 				Apply: workflows.Job{
 					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Apply.Steps),
+					ID:    uuid.New().String(),
 				},
 				RepoRelPath: rootCfg.RepoRelDir,
 			},

--- a/server/neptune/temporalworker/job/output_handler.go
+++ b/server/neptune/temporalworker/job/output_handler.go
@@ -1,0 +1,108 @@
+package job
+
+import (
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/events/terraform/filter"
+	"github.com/runatlantis/atlantis/server/jobs"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type OutputLine struct {
+	JobID string
+	Line  string
+}
+
+type ouptutHandler interface {
+	// Send will enqueue the msg and wait for Handle() to receive the message.
+	Send(jobID string, msg string)
+
+	// Listens for msg from channel
+	Handle()
+
+	// Register registers a channel and blocks until it is caught up. Callers should call this asynchronously when attempting
+	// to read the channel in the same goroutine
+	Register(jobID string, receiver chan string)
+
+	// Persists job to storage backend and marks operation complete
+	CloseJob(jobID string)
+}
+
+// Wraps the original project command output handler with neptune specific logic
+type OutputHandler struct {
+	// Main channel that receives output from the terraform client
+	JobOutput chan *OutputLine
+
+	// Storage for plan/apply jobs
+	JobStore jobs.JobStore
+
+	// Registry to track active connections for a job
+	ReceiverRegistry jobs.ReceiverRegistry
+
+	Logger    logging.Logger
+	LogFilter filter.LogFilter
+}
+
+func (s *OutputHandler) Send(jobId string, msg string) {
+	s.JobOutput <- &OutputLine{
+		JobID: jobId,
+		Line:  msg,
+	}
+}
+
+func (s *OutputHandler) Handle() {
+	for msg := range s.JobOutput {
+		// Filter out log lines from job output
+		if s.LogFilter.ShouldFilterLine(msg.Line) {
+			continue
+		}
+
+		// Write logs to all active connections
+		for ch := range s.ReceiverRegistry.GetReceivers(msg.JobID) {
+			select {
+			case ch <- msg.Line:
+			default:
+				s.ReceiverRegistry.RemoveReceiver(msg.JobID, ch)
+			}
+		}
+
+		// Append new log to the output buffer for the job
+		err := s.JobStore.AppendOutput(msg.JobID, msg.Line)
+		if err != nil {
+			s.Logger.Warn(fmt.Sprintf("appending log: %s for job: %s: %v", msg.Line, msg.JobID, err))
+		}
+	}
+}
+
+func (s *OutputHandler) Register(jobID string, receiver chan string) {
+	job, err := s.JobStore.Get(jobID)
+	if err != nil || job == nil {
+		s.Logger.Error(fmt.Sprintf("getting job: %s, err: %v", jobID, err))
+		return
+	}
+
+	// Back fill contents from the output buffer
+	for _, line := range job.Output {
+		receiver <- line
+	}
+
+	// Close connection if job is complete
+	if job.Status == jobs.Complete {
+		close(receiver)
+		return
+	}
+
+	// add receiver to registry after backfilling contents from the buffer
+	s.ReceiverRegistry.AddReceiver(jobID, receiver)
+
+}
+
+func (s *OutputHandler) CloseJob(jobID string) {
+	// Close active connections and remove receivers from registry
+	s.ReceiverRegistry.CloseAndRemoveReceiversForJob(jobID)
+
+	// Update job status and persist to storage if configured
+	if err := s.JobStore.SetJobCompleteStatus(jobID, "", jobs.Complete); err != nil {
+		s.Logger.Error(fmt.Sprintf("updating jobs status to complete, %v", err))
+	}
+}

--- a/server/neptune/temporalworker/job/url_generator.go
+++ b/server/neptune/temporalworker/job/url_generator.go
@@ -1,0 +1,33 @@
+package job
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+type UrlGenerator struct {
+	// Underlying is the router that the routes have been constructed on.
+	Underlying *mux.Router
+	// ProjectJobsViewRouteName is the named route for the projects active jobs
+	ProjectJobsViewRouteName string
+	// AtlantisURL is the fully qualified URL that Atlantis is
+	// accessible from externally.
+	AtlantisURL *url.URL
+}
+
+func (r *UrlGenerator) GenerateJobURL(jobId string) (string, error) {
+	if jobId == "" {
+		return "", fmt.Errorf("no job id")
+	}
+	jobURL, err := r.Underlying.Get((r.ProjectJobsViewRouteName)).URL(
+		"job-id", jobId,
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "creating job url for %s", jobId)
+	}
+
+	return r.AtlantisURL.String() + jobURL.String(), nil
+}

--- a/server/neptune/terraform/async_client.go
+++ b/server/neptune/terraform/async_client.go
@@ -1,0 +1,193 @@
+package terraform
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"sync"
+
+	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/runtime/cache"
+	"github.com/runatlantis/atlantis/server/core/terraform"
+	"github.com/runatlantis/atlantis/server/core/terraform/helpers"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
+)
+
+// Setting the buffer size to 10mb
+const BufioScannerBufferSize = 10 * 1024 * 1024
+
+// versionRegex extracts the version from `terraform version` output.
+//     Terraform v0.12.0-alpha4 (2c36829d3265661d8edbd5014de8090ea7e2a076)
+//	   => 0.12.0-alpha4
+//
+//     Terraform v0.11.10
+//	   => 0.11.10
+var versionRegex = regexp.MustCompile("Terraform v(.*?)(\\s.*)?\n")
+
+func NewAsyncClient(
+	outputHandler *job.OutputHandler,
+	binDir string,
+	cacheDir string,
+	defaultVersionStr string,
+	defaultVersionFlagName string,
+	tfDownloadURL string,
+	tfDownloader terraform.Downloader,
+	usePluginCache bool,
+) (*AsyncClient, error) {
+	version, err := GetDefaultVersion(defaultVersionStr, defaultVersionFlagName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting default version")
+	}
+
+	loader := terraform.NewVersionLoader(&terraform.DefaultDownloader{}, tfDownloadURL)
+
+	versionCache := cache.NewExecutionVersionLayeredLoadingCache(
+		"terraform",
+		binDir,
+		loader.LoadVersion,
+	)
+
+	// warm the cache with this version
+	_, err = versionCache.Get(version)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting default terraform version %s", defaultVersionStr)
+	}
+
+	builder := &CommandBuilder{
+		defaultVersion: version,
+		versionCache:   versionCache,
+	}
+
+	if usePluginCache {
+		builder.terraformPluginCacheDir = cacheDir
+	}
+
+	return &AsyncClient{
+		StepOutputHandler: *outputHandler,
+		CommandBuilder:    builder,
+	}, nil
+
+}
+
+type AsyncClient struct {
+	StepOutputHandler job.OutputHandler
+	CommandBuilder    commandBuilder
+}
+
+func (c *AsyncClient) RunCommandAsync(ctx context.Context, jobID string, path string, args []string, customEnvVars map[string]string, v *version.Version) <-chan helpers.Line {
+	outCh := make(chan helpers.Line)
+
+	// We start a goroutine to do our work asynchronously and then immediately
+	// return our channels.
+	go func() {
+
+		// Ensure we close our channels when we exit.
+		defer func() {
+			close(outCh)
+		}()
+
+		cmd, err := c.CommandBuilder.Build(v, path, args)
+		if err != nil {
+			// prjCtx.Log.ErrorContext(prjCtx.RequestCtx, err.Error())
+			outCh <- helpers.Line{Err: err}
+			return
+		}
+		stdout, _ := cmd.StdoutPipe()
+		stderr, _ := cmd.StderrPipe()
+		envVars := cmd.Env
+		for key, val := range customEnvVars {
+			envVars = append(envVars, fmt.Sprintf("%s=%s", key, val))
+		}
+		cmd.Env = envVars
+
+		err = cmd.Start()
+		if err != nil {
+			err = errors.Wrapf(err, "running %q in %q", cmd.String(), path)
+			// prjCtx.Log.ErrorContext(prjCtx.RequestCtx, err.Error())
+			outCh <- helpers.Line{Err: err}
+			return
+		}
+
+		// Use a waitgroup to block until our stdout/err copying is complete.
+		wg := new(sync.WaitGroup)
+		wg.Add(2)
+		// Asynchronously copy from stdout/err to outCh.
+		go func() {
+			defer wg.Done()
+			c.WriteOutput(stdout, outCh, jobID)
+		}()
+		go func() {
+			defer wg.Done()
+			c.WriteOutput(stderr, outCh, jobID)
+		}()
+
+		// Wait for our copying to complete. This *must* be done before
+		// calling cmd.Wait(). (see https://github.com/golang/go/issues/19685)
+		wg.Wait()
+
+		// Wait for the command to complete.
+		err = cmd.Wait()
+
+		// We're done now. Send an error if there was one.
+		if err != nil {
+			err = errors.Wrapf(err, "running %q in %q", cmd.String(), path)
+			// prjCtx.Log.ErrorContext(prjCtx.RequestCtx, err.Error())
+			outCh <- helpers.Line{Err: err}
+		} else {
+			// prjCtx.Log.InfoContext(prjCtx.RequestCtx, fmt.Sprintf("successfully ran %q in %q", cmd.String(), path))
+		}
+	}()
+
+	return outCh
+}
+
+func (c *AsyncClient) WriteOutput(stdReader io.ReadCloser, outCh chan helpers.Line, jobID string) {
+	s := bufio.NewScanner(stdReader)
+	buf := []byte{}
+	s.Buffer(buf, BufioScannerBufferSize)
+
+	for s.Scan() {
+		message := s.Text()
+		outCh <- helpers.Line{Line: message}
+		c.StepOutputHandler.Send(jobID, message)
+	}
+}
+
+func GetDefaultVersion(overrideVersion string, versionFlagName string) (*version.Version, error) {
+	if overrideVersion != "" {
+		v, err := version.NewVersion(overrideVersion)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing version %s", overrideVersion)
+		}
+
+		return v, nil
+	}
+
+	// look for the binary directly on disk and query the version
+	// we shouldn't really be doing this, but don't want to break existing clients.
+	// this implementation assumes that versions in the format our cache assumes
+	// and if thats the case we won't be redownloading the version of this binary to our cache
+	localPath, err := exec.LookPath("terraform")
+	if err != nil {
+		return nil, fmt.Errorf("terraform not found in $PATH. Set --%s or download terraform from https://www.terraform.io/downloads.html", versionFlagName)
+	}
+
+	return getVersion(localPath)
+}
+
+func getVersion(tfBinary string) (*version.Version, error) {
+	versionOutBytes, err := exec.Command(tfBinary, "version").Output() // #nosec
+	versionOutput := string(versionOutBytes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "running terraform version: %s", versionOutput)
+	}
+	match := versionRegex.FindStringSubmatch(versionOutput)
+	if len(match) <= 1 {
+		return nil, fmt.Errorf("could not parse terraform version from %s", versionOutput)
+	}
+	return version.NewVersion(match[1])
+}

--- a/server/neptune/terraform/cmd.go
+++ b/server/neptune/terraform/cmd.go
@@ -1,0 +1,53 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/runtime/cache"
+)
+
+type commandBuilder interface {
+	Build(v *version.Version, path string, args []string) (*exec.Cmd, error)
+}
+
+type CommandBuilder struct {
+	defaultVersion          *version.Version
+	versionCache            cache.ExecutionVersionCache
+	terraformPluginCacheDir string
+}
+
+func (c *CommandBuilder) Build(v *version.Version, path string, args []string) (*exec.Cmd, error) {
+	if v == nil {
+		v = c.defaultVersion
+	}
+
+	binPath, err := c.versionCache.Get(v)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting version from cache %s", v.String())
+	}
+
+	// We add custom variables so that if `extra_args` is specified with env
+	// vars then they'll be substituted.
+	envVars := []string{
+		// Will de-emphasize specific commands to run in output.
+		"TF_IN_AUTOMATION=true",
+		fmt.Sprintf("ATLANTIS_TERRAFORM_VERSION=%s", v.String()),
+		fmt.Sprintf("DIR=%s", path),
+	}
+	if c.terraformPluginCacheDir != "" {
+		envVars = append(envVars, fmt.Sprintf("TF_PLUGIN_CACHE_DIR=%s", c.terraformPluginCacheDir))
+	}
+	// Append current Atlantis process's environment variables, ex.
+	// AWS_ACCESS_KEY.
+	envVars = append(envVars, os.Environ()...)
+	tfCmd := fmt.Sprintf("%s %s", binPath, strings.Join(args, " "))
+	cmd := exec.Command("sh", "-c", tfCmd)
+	cmd.Dir = path
+	cmd.Env = envVars
+	return cmd, nil
+}

--- a/server/neptune/workflows/github.go
+++ b/server/neptune/workflows/github.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/uber-go/tally/v4"
 )
@@ -11,8 +12,8 @@ type GithubActivities struct {
 	activities.Github
 }
 
-func NewGithubActiviies(appConfig githubapp.Config, scope tally.Scope) (*GithubActivities, error) {
-	githubActivities, err := activities.NewGithub(appConfig, scope)
+func NewGithubActiviies(appConfig githubapp.Config, scope tally.Scope, jobURLGenerator job.UrlGenerator) (*GithubActivities, error) {
+	githubActivities, err := activities.NewGithub(appConfig, scope, jobURLGenerator)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing github activities")
 	}

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -1,10 +1,28 @@
 package activities
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-version"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
+	legacy_tf "github.com/runatlantis/atlantis/server/core/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/config"
 	"github.com/runatlantis/atlantis/server/neptune/github"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
+	"github.com/runatlantis/atlantis/server/neptune/terraform"
+
 	"github.com/uber-go/tally/v4"
+)
+
+const (
+	// binDirName is the name of the directory inside our data dir where
+	// we download binaries.
+	BinDirName = "bin"
+	// terraformPluginCacheDir is the name of the dir inside our data dir
+	// where we tell terraform to cache plugins and modules.
+	TerraformPluginCacheDirName = "plugin-cache"
 )
 
 // Exported Activites should be here.
@@ -31,17 +49,51 @@ type Terraform struct {
 	*cleanupActivities
 }
 
-func NewTerraform() *Terraform {
+func NewTerraform(config config.TerraformConfig, scope tally.Scope, outputHandler *job.OutputHandler) (*Terraform, error) {
+	binDir, err := mkSubDir(config.DataDir, BinDirName)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheDir, err := mkSubDir(config.DataDir, TerraformPluginCacheDirName)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultTfVersion, err := version.NewVersion(config.DefaultVersionStr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing version %s", config.DefaultVersionStr)
+	}
+
+	tfClient, err := terraform.NewAsyncClient(
+		outputHandler,
+		binDir,
+		cacheDir,
+		config.DefaultVersionStr,
+		config.DefaultVersionFlagName,
+		config.DownloadURL,
+		&legacy_tf.DefaultDownloader{},
+		true,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Terraform{
 		executeCommandActivities: &executeCommandActivities{},
-	}
+		terraformActivities: &terraformActivities{
+			TerraformExecutor: tfClient,
+			DefaultTFVersion:  defaultTfVersion,
+			Scope:             scope.SubScope("terraform"),
+		},
+	}, nil
 }
 
 type Github struct {
 	*githubActivities
 }
 
-func NewGithub(config githubapp.Config, scope tally.Scope) (*Github, error) {
+func NewGithub(config githubapp.Config, scope tally.Scope, jobURLGenerator job.UrlGenerator) (*Github, error) {
 	clientCreator, err := githubapp.NewDefaultCachingClientCreator(
 		config,
 		githubapp.WithClientMiddleware(
@@ -53,7 +105,17 @@ func NewGithub(config githubapp.Config, scope tally.Scope) (*Github, error) {
 	}
 	return &Github{
 		githubActivities: &githubActivities{
-			ClientCreator: clientCreator,
+			ClientCreator:   clientCreator,
+			JobURLGenerator: jobURLGenerator,
 		},
 	}, nil
+}
+
+func mkSubDir(parentDir string, subDir string) (string, error) {
+	fullDir := filepath.Join(parentDir, subDir)
+	if err := os.MkdirAll(fullDir, 0700); err != nil {
+		return "", errors.Wrapf(err, "unable to creare dir %q", fullDir)
+	}
+
+	return fullDir, nil
 }

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -35,6 +35,7 @@ type Root struct {
 
 type Job struct {
 	Steps []Step
+	ID    string
 }
 
 // Step was taken from the Atlantis OG config, we might be able to clean this up/remove it

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -80,9 +80,15 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	// TODO: We should actually probably pass this with the revision because a revision
 	// can potentially change a root configuration
 	root := root.Root{
-		Name:  request.Root.Name,
-		Apply: job.Job{Steps: convertToInternalSteps(request.Root.Apply.Steps)},
-		Plan:  job.Job{Steps: convertToInternalSteps(request.Root.Plan.Steps)},
+		Name: request.Root.Name,
+		Apply: job.Job{
+			Steps: convertToInternalSteps(request.Root.Apply.Steps),
+			ID:    request.Root.Apply.ID,
+		},
+		Plan: job.Job{
+			Steps: convertToInternalSteps(request.Root.Plan.Steps),
+			ID:    request.Root.Plan.ID,
+		},
 	}
 
 	// inject dependencies

--- a/server/neptune/workflows/internal/job/context.go
+++ b/server/neptune/workflows/internal/job/context.go
@@ -10,8 +10,10 @@ type ExecutionContext struct {
 	Envs      map[string]string
 	TfVersion string
 	workflow.Context
+	JobID string
 }
 
 type Job struct {
 	Steps []Step
+	ID    string
 }

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -14,14 +14,16 @@ type stepRunner interface {
 }
 
 type jobRunner struct {
-	EnvStepRunner stepRunner
-	CmdStepRunner stepRunner
+	EnvStepRunner  stepRunner
+	CmdStepRunner  stepRunner
+	InitStepRunner stepRunner
 }
 
-func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner) *jobRunner {
+func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner, initStepRunner stepRunner) *jobRunner {
 	return &jobRunner{
-		CmdStepRunner: runStepRunner,
-		EnvStepRunner: envStepRunner,
+		CmdStepRunner:  runStepRunner,
+		EnvStepRunner:  envStepRunner,
+		InitStepRunner: initStepRunner,
 	}
 }
 
@@ -45,6 +47,8 @@ func (r *jobRunner) Run(
 		var err error
 
 		switch step.StepName {
+		case "init":
+			out, err = r.InitStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "run":
 			out, err = r.CmdStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "env":

--- a/server/neptune/workflows/internal/terraform/job/step/init/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/step/init/runner.go
@@ -1,0 +1,34 @@
+package init
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"go.temporal.io/sdk/workflow"
+)
+
+type initActivities interface {
+	TerraformInit(ctx context.Context, request activities.TerraformInitRequest) (activities.TerraformInitResponse, error)
+}
+
+type Runner struct {
+	Activity initActivities
+}
+
+func (r *Runner) Run(executionContext *job.ExecutionContext, localRoot *root.LocalRoot, step job.Step) (string, error) {
+	var resp activities.TerraformInitResponse
+	err := workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformInit, activities.TerraformInitRequest{
+		Step:      step,
+		Envs:      executionContext.Envs,
+		TfVersion: executionContext.TfVersion,
+		JobID:     "1234",
+		Path:      executionContext.Path,
+	}).Get(executionContext, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "running terraform init activity")
+	}
+	return resp.Output, nil
+}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -10,6 +10,7 @@ import (
 	job_runner "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job/step/cmd"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job/step/env"
+	init_step_runner "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job/step/init"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -76,6 +77,9 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			&env.Runner{
 				CmdRunner: cmdStepRunner,
 			},
+			&init_step_runner.Runner{
+				Activity: a,
+			},
 		),
 	}
 }
@@ -94,7 +98,7 @@ func (r *Runner) Run(ctx workflow.Context) error {
 		return errors.Wrap(err, "running plan job")
 	}
 
-	// Wait for plan review signal
+	// // Wait for plan review signal
 	var planReview PlanReview
 	signalChan := workflow.GetSignalChannel(ctx, "planreview-repo-steps")
 	more := signalChan.Receive(ctx, &planReview)
@@ -108,7 +112,7 @@ func (r *Runner) Run(ctx workflow.Context) error {
 	// Run apply steps
 	_, err = r.JobRunner.Run(ctx, r.Request.Root.Apply, cloneResponse.LocalRoot)
 	if err != nil {
-		return errors.Wrap(err, "running apply job")
+		return errors.Wrap(err, "running plan job")
 	}
 
 	// Cleanup

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -1,7 +1,12 @@
 package workflows
 
 import (
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/config"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	job_model "github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/uber-go/tally/v4"
 	"go.temporal.io/sdk/workflow"
@@ -10,12 +15,17 @@ import (
 // Export anything that callers need such as requests, signals, etc.
 type TerraformRequest = terraform.Request
 
+type JobExecutionContext = job_model.ExecutionContext
+
 type TerraformActivities struct {
 	activities.Terraform
 }
 
-func NewTerraformActivities(scope tally.Scope) (*TerraformActivities, error) {
-	terraformActivities := activities.NewTerraform()
+func NewTerraformActivities(config config.TerraformConfig, scope tally.Scope, outputHandler *job.OutputHandler) (*TerraformActivities, error) {
+	terraformActivities, err := activities.NewTerraform(config, scope, outputHandler)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing terraform activities")
+	}
 	return &TerraformActivities{
 		Terraform: *terraformActivities,
 	}, nil
@@ -23,4 +33,21 @@ func NewTerraformActivities(scope tally.Scope) (*TerraformActivities, error) {
 
 func Terraform(ctx workflow.Context, request TerraformRequest) error {
 	return terraform.Workflow(ctx, request)
+}
+
+func TestRequest() TerraformRequest {
+	return terraform.Request{
+		Root: root.Root{
+			Name: "test-root",
+			Path: "/Users/aayushgupta/terraform-test",
+			Plan: job_model.Job{
+				ID: "1234",
+				Steps: []job_model.Step{
+					{
+						StepName: "init",
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
In this PR, we copy over the async implementation of the existing terraform client to project neptune. In addiiton, we also copy over the jobs output handler implementation to neptune