### PR TITLE
Add infradocs link to operation summary for aggregate operation checkruns

### DIFF
--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -11,6 +11,8 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs/types"
 )
 
+const InfraDocsOpSummaryURL = "https://infradocs.lyft.net/deploy/infrastructure-as-code/intro.html#understanding-operation-summary"
+
 // VCSStatusUpdater updates the status of a commit with the VCS host. We set
 // the status to signify whether the plan/apply succeeds.
 type VCSStatusUpdater struct {
@@ -23,13 +25,15 @@ func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo,
 	descrip := fmt.Sprintf("%s %s", strings.Title(cmdName.String()), d.statusDescription(status))
 
 	request := types.UpdateStatusRequest{
-		Repo:             repo,
-		PullNum:          pull.Num,
-		Ref:              pull.HeadCommit,
-		StatusName:       src,
-		State:            status,
-		Description:      descrip,
-		DetailsURL:       "",
+		Repo:        repo,
+		PullNum:     pull.Num,
+		Ref:         pull.HeadCommit,
+		StatusName:  src,
+		State:       status,
+		Description: descrip,
+
+		// Pass in a link to infra docs for aggregate operation checkruns to avoid routing users to a broken link
+		DetailsURL:       InfraDocsOpSummaryURL,
 		PullCreationTime: pull.CreatedAt,
 		StatusId:         statusId,
 		CommandName:      titleString(cmdName),
@@ -51,13 +55,15 @@ func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.
 	}
 
 	request := types.UpdateStatusRequest{
-		Repo:             repo,
-		PullNum:          pull.Num,
-		Ref:              pull.HeadCommit,
-		StatusName:       src,
-		State:            status,
-		Description:      fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
-		DetailsURL:       "",
+		Repo:        repo,
+		PullNum:     pull.Num,
+		Ref:         pull.HeadCommit,
+		StatusName:  src,
+		State:       status,
+		Description: fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
+
+		// Pass in a link to infra docs for aggregate operation checkruns to avoid routing users to a broken link
+		DetailsURL:       InfraDocsOpSummaryURL,
 		PullCreationTime: pull.CreatedAt,
 		StatusId:         statusId,
 		CommandName:      titleString(cmdName),

--- a/server/events/command/vcs_test.go
+++ b/server/events/command/vcs_test.go
@@ -86,6 +86,7 @@ func TestUpdateCombined(t *testing.T) {
 				StatusName:  expSrc,
 				Description: c.expDescrip,
 				CommandName: c.command.TitleString(),
+				DetailsURL:  command.InfraDocsOpSummaryURL,
 			})
 		})
 	}
@@ -163,6 +164,7 @@ func TestUpdateCombinedCount(t *testing.T) {
 				CommandName: c.command.TitleString(),
 				NumSuccess:  strconv.FormatInt(int64(c.numSuccess), 10),
 				NumTotal:    strconv.FormatInt(int64(c.numTotal), 10),
+				DetailsURL:  command.InfraDocsOpSummaryURL,
 			})
 		})
 	}


### PR DESCRIPTION
In this PR, we add links to infradocs `Understanding Operation Summary` section for checkruns that don't have a valid details URL to avoid redirecting users to a broken link when they try to visit the details section. 