### PR TITLE
Support checks actions in deploy workflow.

### DIFF
--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -2,12 +2,9 @@ package queue
 
 import (
 	"container/list"
-)
 
-type Message struct {
-	Revision   string
-	CheckRunID int64
-}
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+)
 
 // Queue is a standard queue implementation
 type Queue struct {
@@ -24,18 +21,18 @@ func (q *Queue) IsEmpty() bool {
 	return q.queue.Len() == 0
 }
 
-func (q *Queue) Push(msg Message) {
+func (q *Queue) Push(msg terraform.DeploymentInfo) {
 	q.queue.PushBack(msg)
 }
 
-func (q *Queue) Peek() Message {
+func (q *Queue) Peek() terraform.DeploymentInfo {
 	result := q.queue.Front()
-	return result.Value.(Message)
+	return result.Value.(terraform.DeploymentInfo)
 }
 
-func (q *Queue) Pop() Message {
+func (q *Queue) Pop() terraform.DeploymentInfo {
 	result := q.queue.Remove(q.queue.Front())
 
 	// naughty casting
-	return result.(Message)
+	return result.(terraform.DeploymentInfo)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,11 +26,11 @@ func TestQueue(t *testing.T) {
 	assert.True(t, q.IsEmpty())
 }
 
-func wrap(msg string) queue.Message {
-	return queue.Message{Revision: msg}
+func wrap(msg string) terraform.DeploymentInfo {
+	return terraform.DeploymentInfo{Revision: msg}
 
 }
 
-func unwrap(msg queue.Message) string {
+func unwrap(msg terraform.DeploymentInfo) string {
 	return msg.Revision
 }

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -2,10 +2,13 @@ package revision
 
 import (
 	"context"
+
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -15,18 +18,19 @@ type NewRevisionRequest struct {
 }
 
 type Queue interface {
-	Push(queue.Message)
+	Push(terraform.DeploymentInfo)
 }
 
 type Activities interface {
 	CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
 }
 
-func NewReceiver(ctx workflow.Context, queue Queue, repo github.Repo, activities Activities) *Receiver {
+func NewReceiver(ctx workflow.Context, queue Queue, repo github.Repo, root root.Root, activities Activities) *Receiver {
 	return &Receiver{
 		queue:      queue,
 		ctx:        ctx,
 		repo:       repo,
+		root:       root,
 		activities: activities,
 	}
 }
@@ -36,6 +40,7 @@ type Receiver struct {
 	ctx        workflow.Context
 	activities Activities
 	repo       github.Repo
+	root       root.Root
 }
 
 func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
@@ -51,12 +56,19 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		MaximumAttempts: 5,
 	})
 
-	var resp activities.CreateCheckRunResponse
+	// generate an id for this deployment and pass that to our check run
+	id, err := sideeffect.GenerateUUID(ctx)
 
-	err := workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
-		Title: "atlantis/deploy",
-		Sha:   request.Revision,
-		Repo:  n.repo,
+	if err != nil {
+		logger.Error(ctx, "generating deployment id", "err", err)
+	}
+
+	var resp activities.CreateCheckRunResponse
+	err = workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
+		Title:      "atlantis/deploy",
+		Sha:        request.Revision,
+		Repo:       n.repo,
+		ExternalID: id.String(),
 	}).Get(ctx, &resp)
 
 	// don't block on error here, we'll just try again later when we have our result.
@@ -64,7 +76,9 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		logger.Error(ctx, err.Error())
 	}
 
-	n.queue.Push(queue.Message{
+	n.queue.Push(terraform.DeploymentInfo{
+		ID:         id,
+		Root:       n.root,
 		Revision:   request.Revision,
 		CheckRunID: resp.ID,
 	})

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -3,15 +3,17 @@ package revision
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
+
+type idGenerator func(ctx workflow.Context) (uuid.UUID, error)
 
 type NewRevisionRequest struct {
 	Revision string
@@ -25,22 +27,24 @@ type Activities interface {
 	CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
 }
 
-func NewReceiver(ctx workflow.Context, queue Queue, repo github.Repo, root root.Root, activities Activities) *Receiver {
+func NewReceiver(ctx workflow.Context, queue Queue, repo github.Repo, root root.Root, activities Activities, generator idGenerator) *Receiver {
 	return &Receiver{
-		queue:      queue,
-		ctx:        ctx,
-		repo:       repo,
-		root:       root,
-		activities: activities,
+		queue:       queue,
+		ctx:         ctx,
+		repo:        repo,
+		root:        root,
+		activities:  activities,
+		idGenerator: generator,
 	}
 }
 
 type Receiver struct {
-	queue      Queue
-	ctx        workflow.Context
-	activities Activities
-	repo       github.Repo
-	root       root.Root
+	queue       Queue
+	ctx         workflow.Context
+	activities  Activities
+	repo        github.Repo
+	root        root.Root
+	idGenerator idGenerator
 }
 
 func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
@@ -57,7 +61,7 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 	})
 
 	// generate an id for this deployment and pass that to our check run
-	id, err := sideeffect.GenerateUUID(ctx)
+	id, err := n.idGenerator(ctx)
 
 	if err != nil {
 		logger.Error(ctx, "generating deployment id", "err", err)

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
@@ -24,6 +25,10 @@ func (q *testQueue) Push(msg terraform.DeploymentInfo) {
 	q.Queue = append(q.Queue, msg)
 }
 
+type request struct {
+	Id uuid.UUID
+}
+
 type response struct {
 	Queue   []terraform.DeploymentInfo
 	Timeout bool
@@ -35,7 +40,7 @@ func (a *testActivities) CreateCheckRun(ctx context.Context, request activities.
 	return activities.CreateCheckRunResponse{}, nil
 }
 
-func testWorkflow(ctx workflow.Context) (response, error) {
+func testWorkflow(ctx workflow.Context, r request) (response, error) {
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
@@ -45,7 +50,9 @@ func testWorkflow(ctx workflow.Context) (response, error) {
 
 	var a *testActivities
 
-	receiver := revision.NewReceiver(ctx, queue, github.Repo{Name: "nish"}, root.Root{Name: "root"}, a)
+	receiver := revision.NewReceiver(ctx, queue, github.Repo{Name: "nish"}, root.Root{Name: "root"}, a, func(ctx workflow.Context) (uuid.UUID, error) {
+		return r.Id, nil
+	})
 	selector := workflow.NewSelector(ctx)
 
 	selector.AddReceive(workflow.GetSignalChannel(ctx, "test-signal"), receiver.Receive)
@@ -80,13 +87,18 @@ func TestEnqueue(t *testing.T) {
 
 	env.RegisterActivity(a)
 
+	id := uuid.Must(uuid.NewUUID())
+
 	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
-		Title: "atlantis/deploy",
-		Sha:   rev,
-		Repo:  github.Repo{Name: "nish"},
+		Title:      "atlantis/deploy",
+		Sha:        rev,
+		Repo:       github.Repo{Name: "nish"},
+		ExternalID: id.String(),
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
-	env.ExecuteWorkflow(testWorkflow)
+	env.ExecuteWorkflow(testWorkflow, request{
+		Id: id,
+	})
 	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
 
@@ -99,6 +111,7 @@ func TestEnqueue(t *testing.T) {
 			Revision:   rev,
 			CheckRunID: 1,
 			Root:       root.Root{Name: "root"},
+			ID:         id,
 		},
 	}, resp.Queue)
 	assert.False(t, resp.Timeout)

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -1,0 +1,13 @@
+package terraform
+
+import (
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+)
+
+type DeploymentInfo struct {
+	ID         uuid.UUID
+	CheckRunID int64
+	Revision   string
+	Root       root.Root
+}

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -2,11 +2,7 @@ package terraform
 
 import (
 	"github.com/pkg/errors"
-	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/workflow"
@@ -15,7 +11,7 @@ import (
 type Workflow func(ctx workflow.Context, request terraform.Request) error
 
 type stateReceiver interface {
-	Receive(ctx workflow.Context, c workflow.ReceiveChannel, checkRunID int64)
+	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)
 }
 
 func NewWorkflowRunner(repo github.Repo, a receiverActivities, w Workflow) *WorkflowRunner {
@@ -35,31 +31,22 @@ type WorkflowRunner struct {
 	Workflow      Workflow
 }
 
-func (r *WorkflowRunner) Run(ctx workflow.Context, checkRunID int64, revision string, root root.Root) error {
-	id, err := sideeffect.GenerateUUID(ctx)
-
-	ctx = workflow.WithValue(ctx, internalContext.DeploymentIDKey, id)
-
-	logger.Info(ctx, "Generated id")
-
-	if err != nil {
-		return errors.Wrap(err, "generating id")
-	}
-
+func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo) error {
+	id := deploymentInfo.ID
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID: id.String(),
 	})
 	terraformWorkflowRequest := terraform.Request{
 		Repo:         r.Repo,
-		Root:         root,
+		Root:         deploymentInfo.Root,
 		DeploymentId: id.String(),
 	}
 
 	future := workflow.ExecuteChildWorkflow(ctx, r.Workflow, terraformWorkflowRequest)
-	return r.awaitWorkflow(ctx, future, checkRunID)
+	return r.awaitWorkflow(ctx, future, deploymentInfo)
 }
 
-func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.ChildWorkflowFuture, checkRunID int64) error {
+func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.ChildWorkflowFuture, deploymentInfo DeploymentInfo) error {
 	var childWE workflow.Execution
 	if err := future.GetChildWorkflowExecution().Get(ctx, &childWE); err != nil {
 		return errors.Wrap(err, "getting child workflow execution")
@@ -71,7 +58,7 @@ func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.Chi
 	// handle accordingly
 	ch := workflow.GetSignalChannel(ctx, state.WorkflowStateChangeSignal)
 	selector.AddReceive(ch, func(c workflow.ReceiveChannel, _ bool) {
-		r.StateReceiver.Receive(ctx, c, checkRunID)
+		r.StateReceiver.Receive(ctx, c, deploymentInfo)
 	})
 	var workflowComplete bool
 	var err error

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -51,12 +51,8 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 
 	if workflowState.Plan.Status == state.SuccessJobStatus && workflowState.Apply == nil {
 		request.Actions = []github.CheckRunAction{
-			github.PlanReviewAction{
-				ActionType: github.Approved,
-			},
-			github.PlanReviewAction{
-				ActionType: github.Reject,
-			},
+			github.CreatePlanReviewAction(github.Approved),
+			github.CreatePlanReviewAction(github.Reject),
 		}
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -50,7 +50,7 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 
 	if workflowState.Plan.Status == state.SuccessJobStatus && workflowState.Apply == nil {
 		request.Actions = []github.CheckRunAction{
-			github.CreatePlanReviewAction(github.Approved),
+			github.CreatePlanReviewAction(github.Approve),
 			github.CreatePlanReviewAction(github.Reject),
 		}
 	}

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -61,10 +61,9 @@ func TestStateReceive(t *testing.T) {
 	}
 
 	cases := []struct {
-		State                      *state.Workflow
-		ExpectedCheckRunState      github.CheckRunState
-		ExpectedCheckRunConclusion github.CheckRunConclusion
-		ExpectedActions            []github.CheckRunAction
+		State                 *state.Workflow
+		ExpectedCheckRunState github.CheckRunState
+		ExpectedActions       []github.CheckRunAction
 	}{
 		{
 			State: &state.Workflow{
@@ -82,8 +81,7 @@ func TestStateReceive(t *testing.T) {
 					Status: state.FailedJobStatus,
 				},
 			},
-			ExpectedCheckRunState:      github.CheckRunComplete,
-			ExpectedCheckRunConclusion: github.CheckRunFailure,
+			ExpectedCheckRunState: github.CheckRunFailure,
 		},
 		{
 			State: &state.Workflow{
@@ -92,8 +90,7 @@ func TestStateReceive(t *testing.T) {
 					Status: state.SuccessJobStatus,
 				},
 			},
-			ExpectedCheckRunState:      github.CheckRunComplete,
-			ExpectedCheckRunConclusion: github.CheckRunSuccess,
+			ExpectedCheckRunState: github.CheckRunPending,
 			ExpectedActions: []github.CheckRunAction{
 				github.CreatePlanReviewAction(github.Approved),
 				github.CreatePlanReviewAction(github.Reject),
@@ -123,8 +120,7 @@ func TestStateReceive(t *testing.T) {
 					Status: state.FailedJobStatus,
 				},
 			},
-			ExpectedCheckRunState:      github.CheckRunComplete,
-			ExpectedCheckRunConclusion: github.CheckRunFailure,
+			ExpectedCheckRunState: github.CheckRunFailure,
 		},
 		{
 			State: &state.Workflow{
@@ -137,8 +133,7 @@ func TestStateReceive(t *testing.T) {
 					Status: state.SuccessJobStatus,
 				},
 			},
-			ExpectedCheckRunState:      github.CheckRunComplete,
-			ExpectedCheckRunConclusion: github.CheckRunSuccess,
+			ExpectedCheckRunState: github.CheckRunSuccess,
 		},
 	}
 
@@ -151,9 +146,8 @@ func TestStateReceive(t *testing.T) {
 			env.RegisterActivity(a)
 
 			env.OnActivity(a.UpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
-				Title:      "atlantis/deploy",
-				State:      c.ExpectedCheckRunState,
-				Conclusion: c.ExpectedCheckRunConclusion,
+				Title: "atlantis/deploy",
+				State: c.ExpectedCheckRunState,
 				Repo: github.Repo{
 					Name: "hello",
 				},

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -92,7 +92,7 @@ func TestStateReceive(t *testing.T) {
 			},
 			ExpectedCheckRunState: github.CheckRunPending,
 			ExpectedActions: []github.CheckRunAction{
-				github.CreatePlanReviewAction(github.Approved),
+				github.CreatePlanReviewAction(github.Approve),
 				github.CreatePlanReviewAction(github.Reject),
 			},
 		},

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -64,6 +64,7 @@ func TestStateReceive(t *testing.T) {
 		State                      *state.Workflow
 		ExpectedCheckRunState      github.CheckRunState
 		ExpectedCheckRunConclusion github.CheckRunConclusion
+		ExpectedActions            []github.CheckRunAction
 	}{
 		{
 			State: &state.Workflow{
@@ -93,6 +94,10 @@ func TestStateReceive(t *testing.T) {
 			},
 			ExpectedCheckRunState:      github.CheckRunComplete,
 			ExpectedCheckRunConclusion: github.CheckRunSuccess,
+			ExpectedActions: []github.CheckRunAction{
+				github.CreatePlanReviewAction(github.Approved),
+				github.CreatePlanReviewAction(github.Reject),
+			},
 		},
 		{
 			State: &state.Workflow{
@@ -154,6 +159,7 @@ func TestStateReceive(t *testing.T) {
 				},
 				Summary: markdown.RenderWorkflowStateTmpl(c.State),
 				ID:      1,
+				Actions: c.ExpectedActions,
 			}).Return(activities.UpdateCheckRunResponse{}, nil)
 
 			env.ExecuteWorkflow(testStateReceiveWorkflow, stateReceiveRequest{

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -45,7 +45,9 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) error
 		}
 	})
 
-	receiver.Receive(ctx, ch, 1)
+	receiver.Receive(ctx, ch, terraform.DeploymentInfo{
+		CheckRunID: 1,
+	})
 
 	return nil
 }

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	temporalInternal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -93,7 +94,7 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	var a *workerActivities
 
 	revisionQueue := queue.NewQueue()
-	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, repo, root, a)
+	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, repo, root, a, sideeffect.GenerateUUID)
 	tfWorkflowRunner := terraform.NewWorkflowRunner(repo, a, tfWorkflow)
 
 	worker := &queue.Worker{

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -93,13 +93,11 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	var a *workerActivities
 
 	revisionQueue := queue.NewQueue()
-	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, repo, a)
+	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, repo, root, a)
 	tfWorkflowRunner := terraform.NewWorkflowRunner(repo, a, tfWorkflow)
 
 	worker := &queue.Worker{
 		Queue:                   revisionQueue,
-		Repo:                    repo,
-		Root:                    root,
 		TerraformWorkflowRunner: tfWorkflowRunner,
 	}
 

--- a/server/neptune/workflows/internal/deploy/workflow_test.go
+++ b/server/neptune/workflows/internal/deploy/workflow_test.go
@@ -102,6 +102,5 @@ func TestRunner(t *testing.T) {
 		err := env.GetWorkflowResult(&resp)
 		assert.NoError(t, err)
 		assert.Equal(t, response{WorkerCtxCancelled: true, ReceiverCalled: true}, resp)
-
 	})
 }

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -1,7 +1,34 @@
 package github
 
+import (
+	"fmt"
+
+	"github.com/google/go-github/v45/github"
+)
+
 type CheckRunState string
 type CheckRunConclusion string
+
+type CheckRunAction interface {
+	ToGithubAction() *github.CheckRunAction
+}
+
+type PlanReviewActionType string
+
+type PlanReviewAction struct {
+	ActionType PlanReviewActionType
+}
+
+func (a PlanReviewAction) ToGithubAction() *github.CheckRunAction {
+	return &github.CheckRunAction{
+		Label:       string(a.ActionType),
+		Description: fmt.Sprintf("%s this plan to proceed to the apply", string(a.ActionType)),
+
+		// we encode the action type as the id since there's a 20 char limit anyways
+		// and we can use the check run external id to map to the correct workflow
+		Identifier: string(a.ActionType),
+	}
+}
 
 const (
 	CheckRunSuccess  CheckRunConclusion = "success"
@@ -9,4 +36,7 @@ const (
 	CheckRunComplete CheckRunState      = "completed"
 	CheckRunPending  CheckRunState      = "in_progress"
 	CheckRunQueued   CheckRunState      = "queued"
+
+	Approved PlanReviewActionType = "approved"
+	Reject   PlanReviewActionType = "reject"
 )

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -9,26 +9,31 @@ import (
 type CheckRunState string
 type CheckRunConclusion string
 
-type CheckRunAction interface {
-	ToGithubAction() *github.CheckRunAction
+type CheckRunAction struct {
+	Description string
+	Label       string
+}
+
+func (a CheckRunAction) ToGithubAction() *github.CheckRunAction {
+	return &github.CheckRunAction{
+		Label:       a.Label,
+		Description: a.Description,
+
+		// we encode the label as the id since there's a 20 char limit anyways
+		// and we can use the check run external id to map to the correct workflow
+		Identifier: a.Label,
+	}
+}
+
+func CreatePlanReviewAction(t PlanReviewActionType) CheckRunAction {
+	return CheckRunAction{
+		Description: fmt.Sprintf("%s this plan to proceed to the apply", string(t)),
+		Label:       string(t),
+	}
+
 }
 
 type PlanReviewActionType string
-
-type PlanReviewAction struct {
-	ActionType PlanReviewActionType
-}
-
-func (a PlanReviewAction) ToGithubAction() *github.CheckRunAction {
-	return &github.CheckRunAction{
-		Label:       string(a.ActionType),
-		Description: fmt.Sprintf("%s this plan to proceed to the apply", string(a.ActionType)),
-
-		// we encode the action type as the id since there's a 20 char limit anyways
-		// and we can use the check run external id to map to the correct workflow
-		Identifier: string(a.ActionType),
-	}
-}
 
 const (
 	CheckRunSuccess  CheckRunConclusion = "success"

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -41,6 +41,6 @@ const (
 	CheckRunQueued  CheckRunState = "queued"
 	CheckRunUnknown CheckRunState = ""
 
-	Approved PlanReviewActionType = "approved"
+	Approve PlanReviewActionType = "approve"
 	Reject   PlanReviewActionType = "reject"
 )

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -7,7 +7,6 @@ import (
 )
 
 type CheckRunState string
-type CheckRunConclusion string
 
 type CheckRunAction struct {
 	Description string
@@ -36,11 +35,11 @@ func CreatePlanReviewAction(t PlanReviewActionType) CheckRunAction {
 type PlanReviewActionType string
 
 const (
-	CheckRunSuccess  CheckRunConclusion = "success"
-	CheckRunFailure  CheckRunConclusion = "failure"
-	CheckRunComplete CheckRunState      = "completed"
-	CheckRunPending  CheckRunState      = "in_progress"
-	CheckRunQueued   CheckRunState      = "queued"
+	CheckRunSuccess CheckRunState = "success"
+	CheckRunFailure CheckRunState = "failure"
+	CheckRunPending CheckRunState = "in_progress"
+	CheckRunQueued  CheckRunState = "queued"
+	CheckRunUnknown CheckRunState = ""
 
 	Approved PlanReviewActionType = "approved"
 	Reject   PlanReviewActionType = "reject"

--- a/server/neptune/workflows/internal/sideeffect/uuid.go
+++ b/server/neptune/workflows/internal/sideeffect/uuid.go
@@ -11,17 +11,17 @@ func GenerateUUID(ctx workflow.Context) (uuid.UUID, error) {
 	// UUIDErr allows us to extract both the id and the err from the sideeffect
 	// not sure if there is a better way to do this
 	type UUIDErr struct {
-		id  uuid.UUID
-		err error
+		ID  uuid.UUID
+		Err error
 	}
 
 	var result UUIDErr
 	encodedResult := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
-		uuid, err := uuid.NewUUID()
+		id, err := uuid.NewUUID()
 
 		return UUIDErr{
-			id:  uuid,
-			err: err,
+			ID:  id,
+			Err: err,
 		}
 	})
 
@@ -31,5 +31,5 @@ func GenerateUUID(ctx workflow.Context) (uuid.UUID, error) {
 		return uuid.UUID{}, errors.Wrap(err, "getting uuid from side effect")
 	}
 
-	return result.id, result.err
+	return result.ID, result.Err
 }


### PR DESCRIPTION
This does a number of things:
* Supports adding approve/reject actions in the checks UI
* Adds the deployment id as the external id for the check run itself. By doing this,
we will know which workflow to signal when we get the requested actions event.

