### PR TITLE
Add support for setting default checkrun details URL

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -107,20 +107,21 @@ const (
 	LyftWorkerQueueUrlFlag       = "lyft-worker-queue-url"
 
 	// NOTE: Must manually set these as defaults in the setDefaults function.
-	DefaultADBasicUser      = ""
-	DefaultADBasicPassword  = ""
-	DefaultAutoplanFileList = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl"
-	DefaultCheckoutStrategy = "branch"
-	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
-	DefaultDataDir          = "~/.atlantis"
-	DefaultGHHostname       = "github.com"
-	DefaultGitlabHostname   = "gitlab.com"
-	DefaultLogLevel         = "info"
-	DefaultParallelPoolSize = 15
-	DefaultStatsNamespace   = "atlantis"
-	DefaultPort             = 4141
-	DefaultTFDownloadURL    = "https://releases.hashicorp.com"
-	DefaultVCSStatusName    = "atlantis"
+	DefaultADBasicUser            = ""
+	DefaultADBasicPassword        = ""
+	DefaultAutoplanFileList       = "**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl"
+	DefaultCheckoutStrategy       = "branch"
+	DefaultCheckrunDetailsURLFlag = "default-checkrun-details-url"
+	DefaultBitbucketBaseURL       = bitbucketcloud.BaseURL
+	DefaultDataDir                = "~/.atlantis"
+	DefaultGHHostname             = "github.com"
+	DefaultGitlabHostname         = "gitlab.com"
+	DefaultLogLevel               = "info"
+	DefaultParallelPoolSize       = 15
+	DefaultStatsNamespace         = "atlantis"
+	DefaultPort                   = 4141
+	DefaultTFDownloadURL          = "https://releases.hashicorp.com"
+	DefaultVCSStatusName          = "atlantis"
 )
 
 var stringFlags = map[string]stringFlag{
@@ -185,6 +186,9 @@ var stringFlags = map[string]stringFlag{
 	DataDirFlag: {
 		description:  "Path to directory to store Atlantis data.",
 		defaultValue: DefaultDataDir,
+	},
+	DefaultCheckrunDetailsURLFlag: {
+		description: "URL to redirect to if details URL is not set in the checkrun UI",
 	},
 	FFOwnerFlag: {
 		description: "Owner of the repo used to house feature flag configuration.",
@@ -448,30 +452,31 @@ func (c *GatewayCreator) NewServer(userConfig server.UserConfig, config server.C
 		return nil, err
 	}
 	cfg := gateway.Config{
-		DataDir:             userConfig.DataDir,
-		AutoplanFileList:    userConfig.AutoplanFileList,
-		AppCfg:              appConfig,
-		RepoAllowList:       userConfig.RepoAllowlist,
-		MaxProjectsPerPR:    userConfig.MaxProjectsPerPR,
-		EnablePlatformMode:  userConfig.EnablePlatformMode,
-		FFOwner:             userConfig.FFOwner,
-		FFRepo:              userConfig.FFRepo,
-		FFBranch:            userConfig.FFBranch,
-		FFPath:              userConfig.FFPath,
-		GithubHostname:      userConfig.GithubHostname,
-		GithubWebhookSecret: userConfig.GithubWebhookSecret,
-		GithubAppID:         userConfig.GithubAppID,
-		GithubAppKeyFile:    userConfig.GithubAppKeyFile,
-		GithubAppSlug:       userConfig.GithubAppSlug,
-		GithubStatusName:    userConfig.VCSStatusName,
-		LogLevel:            userConfig.ToLogLevel(),
-		StatsNamespace:      userConfig.StatsNamespace,
-		Port:                userConfig.Port,
-		RepoConfig:          userConfig.RepoConfig,
-		TFDownloadURL:       userConfig.TFDownloadURL,
-		SNSTopicArn:         userConfig.LyftGatewaySnsTopicArn,
-		SSLKeyFile:          userConfig.SSLKeyFile,
-		SSLCertFile:         userConfig.SSLCertFile,
+		DataDir:                   userConfig.DataDir,
+		AutoplanFileList:          userConfig.AutoplanFileList,
+		AppCfg:                    appConfig,
+		RepoAllowList:             userConfig.RepoAllowlist,
+		MaxProjectsPerPR:          userConfig.MaxProjectsPerPR,
+		EnablePlatformMode:        userConfig.EnablePlatformMode,
+		FFOwner:                   userConfig.FFOwner,
+		FFRepo:                    userConfig.FFRepo,
+		FFBranch:                  userConfig.FFBranch,
+		FFPath:                    userConfig.FFPath,
+		GithubHostname:            userConfig.GithubHostname,
+		GithubWebhookSecret:       userConfig.GithubWebhookSecret,
+		GithubAppID:               userConfig.GithubAppID,
+		GithubAppKeyFile:          userConfig.GithubAppKeyFile,
+		GithubAppSlug:             userConfig.GithubAppSlug,
+		GithubStatusName:          userConfig.VCSStatusName,
+		LogLevel:                  userConfig.ToLogLevel(),
+		StatsNamespace:            userConfig.StatsNamespace,
+		Port:                      userConfig.Port,
+		RepoConfig:                userConfig.RepoConfig,
+		TFDownloadURL:             userConfig.TFDownloadURL,
+		SNSTopicArn:               userConfig.LyftGatewaySnsTopicArn,
+		SSLKeyFile:                userConfig.SSLKeyFile,
+		SSLCertFile:               userConfig.SSLCertFile,
+		DefaultCheckrunDetailsURL: userConfig.DefaultCheckrunDetailsURL,
 	}
 	return gateway.NewServer(cfg)
 }

--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -14,8 +14,9 @@ import (
 // VCSStatusUpdater updates the status of a commit with the VCS host. We set
 // the status to signify whether the plan/apply succeeds.
 type VCSStatusUpdater struct {
-	Client       vcs.Client
-	TitleBuilder vcs.StatusTitleBuilder
+	Client            vcs.Client
+	TitleBuilder      vcs.StatusTitleBuilder
+	DefaultDetailsURL string
 }
 
 func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.CommitStatus, cmdName fmt.Stringer, statusId string) (string, error) {
@@ -29,7 +30,7 @@ func (d *VCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo,
 		StatusName:       src,
 		State:            status,
 		Description:      descrip,
-		DetailsURL:       "",
+		DetailsURL:       d.DefaultDetailsURL,
 		PullCreationTime: pull.CreatedAt,
 		StatusId:         statusId,
 		CommandName:      titleString(cmdName),
@@ -57,7 +58,7 @@ func (d *VCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.
 		StatusName:       src,
 		State:            status,
 		Description:      fmt.Sprintf("%d/%d projects %s successfully.", numSuccess, numTotal, cmdVerb),
-		DetailsURL:       "",
+		DetailsURL:       d.DefaultDetailsURL,
 		PullCreationTime: pull.CreatedAt,
 		StatusId:         statusId,
 		CommandName:      titleString(cmdName),

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -50,30 +50,31 @@ import (
 
 // TODO: let's make this struct nicer using actual OOP instead of just a god type struct
 type Config struct {
-	DataDir             string
-	AutoplanFileList    string
-	AppCfg              githubapp.Config
-	RepoAllowList       string
-	MaxProjectsPerPR    int
-	EnablePlatformMode  bool
-	FFOwner             string
-	FFRepo              string
-	FFBranch            string
-	FFPath              string
-	GithubHostname      string
-	GithubWebhookSecret string
-	GithubAppID         int64
-	GithubAppKeyFile    string
-	GithubAppSlug       string
-	GithubStatusName    string
-	LogLevel            logging.LogLevel
-	StatsNamespace      string
-	Port                int
-	RepoConfig          string
-	TFDownloadURL       string
-	SNSTopicArn         string
-	SSLKeyFile          string
-	SSLCertFile         string
+	DataDir                   string
+	AutoplanFileList          string
+	AppCfg                    githubapp.Config
+	RepoAllowList             string
+	MaxProjectsPerPR          int
+	EnablePlatformMode        bool
+	FFOwner                   string
+	FFRepo                    string
+	FFBranch                  string
+	FFPath                    string
+	GithubHostname            string
+	GithubWebhookSecret       string
+	GithubAppID               int64
+	GithubAppKeyFile          string
+	GithubAppSlug             string
+	GithubStatusName          string
+	LogLevel                  logging.LogLevel
+	StatsNamespace            string
+	Port                      int
+	RepoConfig                string
+	TFDownloadURL             string
+	SNSTopicArn               string
+	SSLKeyFile                string
+	SSLCertFile               string
+	DefaultCheckrunDetailsURL string
 }
 
 type Server struct {

--- a/server/server.go
+++ b/server/server.go
@@ -358,7 +358,13 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing webhooks")
 	}
 	vcsClient := vcs.NewClientProxy(githubClient, gitlabClient, bitbucketCloudClient, bitbucketServerClient, azuredevopsClient)
-	commitStatusUpdater := &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: userConfig.VCSStatusName}}
+	commitStatusUpdater := &command.VCSStatusUpdater{
+		Client: vcsClient,
+		TitleBuilder: vcs.StatusTitleBuilder{
+			TitlePrefix: userConfig.VCSStatusName,
+		},
+		DefaultDetailsURL: userConfig.DefaultCheckrunDetailsURL,
+	}
 
 	binDir, err := mkSubDir(userConfig.DataDir, BinDirName)
 

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -85,6 +85,9 @@ type UserConfig struct {
 	LyftGatewaySnsTopicArn   string          `mapstructure:"lyft-gateway-sns-topic-arn"`
 	LyftMode                 string          `mapstructure:"lyft-mode"`
 	LyftWorkerQueueURL       string          `mapstructure:"lyft-worker-queue-url"`
+
+	// Supports adding a default URL to the checkrun UI when details URL is not set
+	DefaultCheckrunDetailsURL string `mapstructure:"default-checkrun-details-url"`
 }
 
 // ToLogLevel returns the LogLevel object corresponding to the user-passed


### PR DESCRIPTION
In this PR, we add support for setting the default checkrun details URL. Tested it out on staging: https://github.com/lyft/orchestration-sandbox/pull/954/checks