### PR TITLE
Replace Approve Policies status check with Policy Check when pre workflow hook fails

### DIFF
--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -203,14 +203,14 @@ func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo m
 
 	if err := c.PreWorkflowHooksCommandRunner.RunPreHooks(ctx, cmdCtx); err != nil {
 		// Replace approve policies command with policy check if preworkflow hook fails since we don't use
-		// approve policies statuses and a consecutive approve_policies command would only set the policy checks status
-		// to success, not set the failed approve_policies to success.
-		if cmd.Name == command.ApprovePolicies {
-			cmd.Name = command.PolicyCheck
+		// approve policies statuses
+		cmdName := cmd.Name
+		if cmdName == command.ApprovePolicies {
+			cmdName = command.PolicyCheck
 		}
 
 		c.Logger.ErrorContext(ctx, "Error running pre-workflow hooks", fields.PullRequestWithErr(pull, err))
-		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, cmd.Name, "")
+		c.CommitStatusUpdater.UpdateCombined(ctx, cmdCtx.HeadRepo, cmdCtx.Pull, models.FailedCommitStatus, cmdName, "")
 		return
 	}
 


### PR DESCRIPTION
In this PR, we replace the Policy Check command with Approve Policies when pre workflow hook fails since we don't support Approve Policies commit statuses. 