### PR TITLE
Remove outdated information from policy check output

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -383,10 +383,6 @@ type PolicyCheckSuccess struct {
 	PolicyCheckOutput string
 	// LockURL is the full URL to the lock held by this policy check.
 	LockURL string
-	// RePlanCmd is the command that users should run to re-plan this project.
-	RePlanCmd string
-	// ApplyCmd is the command that users should run to apply this plan.
-	ApplyCmd string
 	// HasDiverged is true if we're using the checkout merge strategy and the
 	// branch we're merging into has been updated since we cloned and merged
 	// it.

--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -243,8 +243,6 @@ func (p *DefaultProjectCommandRunner) doPolicyCheck(ctx command.ProjectContext) 
 
 	return &models.PolicyCheckSuccess{
 		PolicyCheckOutput: outputs,
-		RePlanCmd:         ctx.RePlanCmd,
-		ApplyCmd:          ctx.ApplyCmd,
 
 		// set this to false right now because we don't have this information
 		// TODO: refactor the templates in a sane way so we don't need this

--- a/server/vcs/markdown/markdown_renderer_test.go
+++ b/server/vcs/markdown/markdown_renderer_test.go
@@ -427,8 +427,6 @@ $$$
 					PolicyCheckSuccess: &models.PolicyCheckSuccess{
 						PolicyCheckOutput: "2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions",
 						LockURL:           "lock-url",
-						RePlanCmd:         "atlantis plan -d path -w workspace",
-						ApplyCmd:          "atlantis apply -d path -w workspace",
 					},
 					Workspace:   "workspace",
 					RepoRelDir:  "path",
@@ -561,8 +559,6 @@ $$$
 					PolicyCheckSuccess: &models.PolicyCheckSuccess{
 						PolicyCheckOutput: "4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions",
 						LockURL:           "lock-url",
-						ApplyCmd:          "atlantis apply -d path -w workspace",
-						RePlanCmd:         "atlantis plan -d path -w workspace",
 					},
 				},
 				{
@@ -572,8 +568,6 @@ $$$
 					PolicyCheckSuccess: &models.PolicyCheckSuccess{
 						PolicyCheckOutput: "4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions",
 						LockURL:           "lock-url2",
-						ApplyCmd:          "atlantis apply -d path2 -w workspace",
-						RePlanCmd:         "atlantis plan -d path2 -w workspace",
 					},
 				},
 			},
@@ -748,8 +742,6 @@ $$$
 					PolicyCheckSuccess: &models.PolicyCheckSuccess{
 						PolicyCheckOutput: "4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions",
 						LockURL:           "lock-url",
-						ApplyCmd:          "atlantis apply -d path -w workspace",
-						RePlanCmd:         "atlantis plan -d path -w workspace",
 					},
 				},
 				{

--- a/server/vcs/markdown/markdown_renderer_test.go
+++ b/server/vcs/markdown/markdown_renderer_test.go
@@ -442,11 +442,6 @@ $$$diff
 2 tests, 1 passed, 0 warnings, 0 failure, 0 exceptions
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-    * $atlantis apply -d path -w workspace$
-* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
-* :repeat: To re-run policies **plan** this project again by commenting:
-    * $atlantis plan -d path -w workspace$
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
@@ -593,11 +588,6 @@ $$$diff
 4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-    * $atlantis apply -d path -w workspace$
-* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
-* :repeat: To re-run policies **plan** this project again by commenting:
-    * $atlantis plan -d path -w workspace$
 
 ---
 ### 2. project: $projectname$ dir: $path2$ workspace: $workspace$
@@ -605,11 +595,6 @@ $$$diff
 4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-    * $atlantis apply -d path2 -w workspace$
-* :put_litter_in_its_place: To **delete** this plan click [here](lock-url2)
-* :repeat: To re-run policies **plan** this project again by commenting:
-    * $atlantis plan -d path2 -w workspace$
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
@@ -791,11 +776,6 @@ $$$diff
 4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
 $$$
 
-* :arrow_forward: To **apply** this plan, comment:
-    * $atlantis apply -d path -w workspace$
-* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
-* :repeat: To re-run policies **plan** this project again by commenting:
-    * $atlantis plan -d path -w workspace$
 
 ---
 ### 2. dir: $path2$ workspace: $workspace$

--- a/server/vcs/markdown/templates/policyCheckSuccessUnwrapped.tmpl
+++ b/server/vcs/markdown/templates/policyCheckSuccessUnwrapped.tmpl
@@ -1,11 +1,6 @@
 ```diff
 {{.PolicyCheckOutput}}
 ```
-
-{{ if ne .ApplyCmd  "" }}* :arrow_forward: To **apply** this plan, comment:
-    * `{{.ApplyCmd}}`{{end}}
-{{ if ne .LockURL  "" }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}}){{end}}
-{{ if ne .RePlanCmd  "" }}* :repeat: To re-run policies **plan** this project again by commenting:
-    * `{{.RePlanCmd}}`{{end}}{{ if .HasDiverged }}
+{{ if .HasDiverged }}
 
 :warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}

--- a/server/vcs/markdown/templates/policyCheckSuccessWrapped.tmpl
+++ b/server/vcs/markdown/templates/policyCheckSuccessWrapped.tmpl
@@ -3,12 +3,6 @@
 ```diff
 {{.PolicyCheckOutput}}
 ```
-
-{{ if ne .ApplyCmd  "" }}* :arrow_forward: To **apply** this plan, comment:
-    * `{{.ApplyCmd}}`{{end}}
-{{ if ne .LockURL  "" }}* :put_litter_in_its_place: To **delete** this plan click [here]({{.LockURL}}){{end}}
-{{ if ne .RePlanCmd  "" }}* :repeat: To re-run policies **plan** this project again by commenting:
-    * `{{.RePlanCmd}}`{{end}}
 </details>{{ if .HasDiverged }}
 
 :warning: The branch we're merging into is ahead, it is recommended to pull new commits first.{{end}}


### PR DESCRIPTION
One of our customers suggested that the instructions in the policy check output are no longer relevant since it's already included in the plan output. 