### PR TITLE
Add gateway support for sending check run signals

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -81,6 +81,12 @@ func (h unsupportedPushEventHandler) Handle(ctx context.Context, event event_typ
 	return fmt.Errorf("push events are not supported in this context")
 }
 
+type unsupportedCheckRunEventHandler struct {}
+
+func (h unsupportedCheckRunEventHandler) Handle(ctx context.Context, event event_types.CheckRun) error {
+	return fmt.Errorf("check run events are not supported in this context")
+}
+
 func NewRequestResolvers(
 	providerResolverInitializer map[models.VCSHostType]func() RequestResolver,
 	supportedProviders []models.VCSHostType,
@@ -151,6 +157,7 @@ func NewVCSEventsController(
 				commentHandler,
 				prHandler,
 				pushHandler,
+				unsupportedCheckRunEventHandler{},
 				allowDraftPRs,
 				repoConverter,
 				pullConverter,

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -60,6 +60,12 @@ func (h noopPushEventHandler) Handle(ctx context.Context, event event_types.Push
 	return nil
 }
 
+type noopCheckRunEventHandler struct{}
+
+func (h noopCheckRunEventHandler) Handle(ctx context.Context, event event_types.CheckRun) error {
+	return nil
+}
+
 type NoopTFDownloader struct{}
 
 func (m *NoopTFDownloader) GetFile(dst, src string, opts ...getter.ClientOption) error {
@@ -996,6 +1002,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 				commentHandler,
 				prHandler,
 				noopPushEventHandler{},
+				noopCheckRunEventHandler{},
 				false,
 				repoConverter,
 				pullConverter,

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -90,6 +90,7 @@ func NewVCSEventsController(
 				commentHandler,
 				prHandler,
 				pushHandler,
+				checkRunHandler,
 				allowDraftPRs,
 				repoConverter,
 				pullConverter,

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -74,6 +74,11 @@ func NewVCSEventsController(
 		RootConfigBuilder: rootConfigBuilder,
 	}
 
+	checkRunHandler := &gateway_handlers.CheckRunHandler{
+		Logger:         logger,
+		TemporalClient: temporalClient,
+	}
+
 	// lazy map of resolver providers to their resolver
 	// laziness ensures we only instantiate the providers we support.
 	providerResolverInitializer := map[models.VCSHostType]func() events_controllers.RequestResolver{

--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -1,0 +1,85 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+)
+
+type CheckRunAction interface {
+	GetType() string
+}
+
+type WrappedCheckRunAction string
+
+func (a WrappedCheckRunAction) GetType() string {
+	return string(a)
+}
+
+type RequestedActionChecksAction struct {
+	Identifier string
+}
+
+func (a RequestedActionChecksAction) GetType() string {
+	return "requested_action"
+}
+
+type CheckRun struct {
+	Action     CheckRunAction
+	ExternalID string
+}
+
+type CheckRunHandler struct {
+	Logger         logging.Logger
+	TemporalClient signaler
+}
+
+func (h *CheckRunHandler) Handle(ctx context.Context, event CheckRun) error {
+	if event.Action.GetType() != "requested_action" {
+		h.Logger.Debug("ignoring checks event that isn't a requested action")
+		return nil
+	}
+
+	action, ok := event.Action.(RequestedActionChecksAction)
+
+	if !ok {
+		return fmt.Errorf("event action type does not match string type.  This is likely a code bug")
+	}
+
+	status, err := toPlanReviewStatus(action)
+
+	if err != nil {
+		return errors.Wrap(err, "converting action to plan status")
+	}
+
+	err = h.TemporalClient.SignalWorkflow(
+		ctx,
+		event.ExternalID,
+		// keeping this empty is fine since temporal will find the currently running workflow
+		"",
+		workflows.TerraformPlanReviewSignalName,
+		workflows.TerraformPlanReviewSignalRequest{
+			Status: status,
+		})
+
+	if err != nil {
+		return errors.Wrapf(err, "signaling workflow with id: %s", event.ExternalID)
+	}
+
+	return nil
+
+}
+
+func toPlanReviewStatus(action RequestedActionChecksAction) (workflows.TerraformPlanReviewStatus, error) {
+	switch action.Identifier {
+	case "approve":
+		return workflows.ApprovedPlanReviewStatus, nil
+	case "reject":
+		return workflows.RejectedPlanReviewStatus, nil
+	}
+
+	return workflows.RejectedPlanReviewStatus, fmt.Errorf("unknown action id %s", action.Identifier)
+}

--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -70,6 +70,8 @@ func (h *CheckRunHandler) Handle(ctx context.Context, event CheckRun) error {
 
 	err = h.TemporalClient.SignalWorkflow(
 		ctx,
+
+		// assumed that we're using the check run external id as our workflow id
 		event.ExternalID,
 		// keeping this empty is fine since temporal will find the currently running workflow
 		"",
@@ -90,9 +92,9 @@ func (h *CheckRunHandler) Handle(ctx context.Context, event CheckRun) error {
 
 func toPlanReviewStatus(action RequestedActionChecksAction) (workflows.TerraformPlanReviewStatus, error) {
 	switch action.Identifier {
-	case "approve":
+	case "Approve":
 		return workflows.ApprovedPlanReviewStatus, nil
-	case "reject":
+	case "Reject":
 		return workflows.RejectedPlanReviewStatus, nil
 	}
 

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -90,7 +90,7 @@ func TestCheckRunHandler(t *testing.T) {
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
-				Identifier: "approve",
+				Identifier: "Approve",
 			},
 			ExternalID: workflowID,
 			User:       user,
@@ -120,7 +120,7 @@ func TestCheckRunHandler(t *testing.T) {
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
-				Identifier: "approve",
+				Identifier: "Approve",
 			},
 			ExternalID: workflowID,
 			User:       user,

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -1,0 +1,134 @@
+package event_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckRunHandler(t *testing.T) {
+	t.Run("unrelated check run", func(t *testing.T) {
+		signaler := &testSignaler{}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Name: "something",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.NoError(t, err)
+		assert.False(t, signaler.called)
+	})
+
+	t.Run("unsupported action", func(t *testing.T) {
+		signaler := &testSignaler{}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Action: event.WrappedCheckRunAction("test"),
+			Name:   "atlantis/deploy",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.NoError(t, err)
+		assert.False(t, signaler.called)
+	})
+
+	t.Run("wrong requested actions object", func(t *testing.T) {
+		signaler := &testSignaler{}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Action: event.WrappedCheckRunAction("requested_action"),
+			Name:   "atlantis/deploy",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.Error(t, err)
+		assert.False(t, signaler.called)
+	})
+
+	t.Run("unsupported action id", func(t *testing.T) {
+		signaler := &testSignaler{}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Action: event.RequestedActionChecksAction{
+				Identifier: "some random thing",
+			},
+			Name: "atlantis/deploy",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.Error(t, err)
+		assert.False(t, signaler.called)
+	})
+
+	t.Run("signal success", func(t *testing.T) {
+		user := "nish"
+		workflowID := "wfid"
+		signaler := &testSignaler{
+			t:                  t,
+			expectedWorkflowID: workflowID,
+			expectedSignalName: workflows.TerraformPlanReviewSignalName,
+			expectedSignalArg: workflows.TerraformPlanReviewSignalRequest{
+				Status: workflows.ApprovedPlanReviewStatus,
+				User:   user,
+			},
+		}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Action: event.RequestedActionChecksAction{
+				Identifier: "approve",
+			},
+			ExternalID: workflowID,
+			User:       user,
+			Name:       "atlantis/deploy",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.NoError(t, err)
+		assert.True(t, signaler.called)
+	})
+
+	t.Run("signal error", func(t *testing.T) {
+		user := "nish"
+		workflowID := "wfid"
+		signaler := &testSignaler{
+			t:                  t,
+			expectedWorkflowID: workflowID,
+			expectedSignalName: workflows.TerraformPlanReviewSignalName,
+			expectedSignalArg: workflows.TerraformPlanReviewSignalRequest{
+				Status: workflows.ApprovedPlanReviewStatus,
+				User:   user,
+			},
+			expectedErr: assert.AnError,
+		}
+		subject := event.CheckRunHandler{
+			Logger:         logging.NewNoopCtxLogger(t),
+			TemporalClient: signaler,
+		}
+		e := event.CheckRun{
+			Action: event.RequestedActionChecksAction{
+				Identifier: "approve",
+			},
+			ExternalID: workflowID,
+			User:       user,
+			Name:       "atlantis/deploy",
+		}
+		err := subject.Handle(context.Background(), e)
+		assert.Error(t, err)
+		assert.True(t, signaler.called)
+	})
+
+}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -36,6 +36,7 @@ type Push struct {
 type signaler interface {
 	SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 		options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (client.WorkflowRun, error)
+	SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
 }
 
 type scheduler interface {

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -51,6 +51,13 @@ type testSignaler struct {
 	called bool
 }
 
+func (s *testSignaler) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	s.called = true
+	// TODO finish this
+
+	return nil
+}
+
 func (s *testSignaler) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 	options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (client.WorkflowRun, error) {
 

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -41,6 +41,7 @@ const testRoot = "testroot"
 type testSignaler struct {
 	t                    *testing.T
 	expectedWorkflowID   string
+	expectedRunID        string
 	expectedSignalName   string
 	expectedSignalArg    interface{}
 	expectedOptions      client.StartWorkflowOptions
@@ -53,9 +54,12 @@ type testSignaler struct {
 
 func (s *testSignaler) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
 	s.called = true
-	// TODO finish this
+	assert.Equal(s.t, s.expectedWorkflowID, workflowID)
+	assert.Equal(s.t, s.expectedRunID, runID)
+	assert.Equal(s.t, s.expectedSignalName, signalName)
+	assert.Equal(s.t, s.expectedSignalArg, arg)
 
-	return nil
+	return s.expectedErr
 }
 
 func (s *testSignaler) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -69,6 +69,15 @@ func TestStateReceive(t *testing.T) {
 			State: &state.Workflow{
 				Plan: &state.Job{
 					Output: jobOutput,
+					Status: state.WaitingJobStatus,
+				},
+			},
+			ExpectedCheckRunState: github.CheckRunPending,
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
 					Status: state.InProgressJobStatus,
 				},
 			},
@@ -88,6 +97,19 @@ func TestStateReceive(t *testing.T) {
 				Plan: &state.Job{
 					Output: jobOutput,
 					Status: state.SuccessJobStatus,
+				},
+			},
+			ExpectedCheckRunState: github.CheckRunPending,
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output: jobOutput,
+					Status: state.WaitingJobStatus,
 				},
 			},
 			ExpectedCheckRunState: github.CheckRunPending,

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -41,6 +41,6 @@ const (
 	CheckRunQueued  CheckRunState = "queued"
 	CheckRunUnknown CheckRunState = ""
 
-	Approve PlanReviewActionType = "approve"
-	Reject  PlanReviewActionType = "reject"
+	Approve PlanReviewActionType = "Approve"
+	Reject  PlanReviewActionType = "Reject"
 )

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -48,7 +48,7 @@ func (s *WorkflowStore) InitPlanJob(jobID fmt.Stringer, serverURL fmt.Stringer) 
 		Output: &JobOutput{
 			URL: outputURL,
 		},
-		Status: InProgressJobStatus,
+		Status: WaitingJobStatus,
 	}
 
 	return s.notifier(s.state)
@@ -64,7 +64,7 @@ func (s *WorkflowStore) InitApplyJob(jobID fmt.Stringer, serverURL fmt.Stringer)
 		Output: &JobOutput{
 			URL: outputURL,
 		},
-		Status: InProgressJobStatus,
+		Status: WaitingJobStatus,
 	}
 
 	return s.notifier(s.state)

--- a/server/neptune/workflows/internal/terraform/state/store_test.go
+++ b/server/neptune/workflows/internal/terraform/state/store_test.go
@@ -30,7 +30,7 @@ func TestInitPlanJob(t *testing.T) {
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Plan: &state.Job{
-				Status: state.InProgressJobStatus,
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
@@ -61,7 +61,7 @@ func TestInitApplyJob(t *testing.T) {
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Apply: &state.Job{
-				Status: state.InProgressJobStatus,
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
@@ -91,7 +91,7 @@ func TestUpdateApplyJob(t *testing.T) {
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Apply: &state.Job{
-				Status: state.InProgressJobStatus,
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
@@ -127,7 +127,7 @@ func TestUpdatePlanJob(t *testing.T) {
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Plan: &state.Job{
-				Status: state.InProgressJobStatus,
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -7,6 +7,7 @@ type JobStatus string
 const WorkflowStateChangeSignal = "terraform-workflow-state-change"
 
 const (
+	WaitingJobStatus    JobStatus = "waiting"
 	InProgressJobStatus JobStatus = "in-progress"
 	RejectedJobStatus   JobStatus = "rejected"
 	FailedJobStatus     JobStatus = "failed"

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -119,6 +119,10 @@ func (r *Runner) Plan(ctx workflow.Context, root *root.LocalRoot, serverURL *url
 		return errors.Wrap(err, "initializing job")
 	}
 
+	if err := r.Store.UpdatePlanJobWithStatus(state.InProgressJobStatus); err != nil {
+		return errors.Wrap(err, "updating job with in-progress status")
+	}
+
 	_, err = r.JobRunner.Run(ctx, r.Request.Root.Plan, root)
 
 	if err != nil {
@@ -144,7 +148,7 @@ func (r *Runner) Apply(ctx workflow.Context, root *root.LocalRoot, serverURL *ur
 	}
 
 	if err := r.Store.InitApplyJob(jobID, serverURL); err != nil {
-		return errors.Wrap(err, "initializing apply job")
+		return errors.Wrap(err, "initializing job")
 	}
 
 	// Wait for plan review signal
@@ -154,21 +158,26 @@ func (r *Runner) Apply(ctx workflow.Context, root *root.LocalRoot, serverURL *ur
 
 	if planReview.Status == Rejected {
 		if err := r.Store.UpdateApplyJobWithStatus(state.RejectedJobStatus); err != nil {
-			return errors.Wrap(err, "updating apply job with rejected status")
+			return errors.Wrap(err, "updating job with rejected status")
 		}
 		return nil
 	}
+
+	if err := r.Store.UpdateApplyJobWithStatus(state.InProgressJobStatus); err != nil {
+		return errors.Wrap(err, "updating job with in-progress status")
+	}
+
 	_, err = r.JobRunner.Run(ctx, r.Request.Root.Apply, root)
 	if err != nil {
 
 		if err := r.Store.UpdateApplyJobWithStatus(state.FailedJobStatus); err != nil {
-			return errors.Wrap(err, "updating apply job with failed status")
+			return errors.Wrap(err, "updating job with failed status")
 		}
-		return errors.Wrap(err, "running plan job")
+		return errors.Wrap(err, "running job")
 	}
 
 	if err := r.Store.UpdateApplyJobWithStatus(state.SuccessJobStatus); err != nil {
-		return errors.Wrap(err, "updating apply job with success status")
+		return errors.Wrap(err, "updating job with success status")
 	}
 
 	return nil

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -33,6 +33,9 @@ type jobRunner interface {
 type PlanStatus int
 type PlanReviewSignalRequest struct {
 	Status PlanStatus
+
+	// TODO: Output this info to the checks UI
+	User string
 }
 
 const (

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -31,13 +31,17 @@ type jobRunner interface {
 }
 
 type PlanStatus int
-type PlanReview struct {
+type PlanReviewSignalRequest struct {
 	Status PlanStatus
 }
 
 const (
 	Approved PlanStatus = iota
 	Rejected
+)
+
+const (
+	PlanReviewSignalName = "planreview"
 )
 
 func Workflow(ctx workflow.Context, request Request) error {
@@ -141,8 +145,8 @@ func (r *Runner) Apply(ctx workflow.Context, root *root.LocalRoot, serverURL *ur
 	}
 
 	// Wait for plan review signal
-	var planReview PlanReview
-	signalChan := workflow.GetSignalChannel(ctx, "planreview-repo-steps")
+	var planReview PlanReviewSignalRequest
+	signalChan := workflow.GetSignalChannel(ctx, PlanReviewSignalName)
 	_ = signalChan.Receive(ctx, &planReview)
 
 	if planReview.Status == Rejected {

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -180,7 +180,7 @@ func TestSuccess(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReview{
+		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
 			Status: terraform.Approved,
 		})
 	}, 5*time.Second)
@@ -265,7 +265,7 @@ func TestPlanRejection(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReview{
+		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
 			Status: terraform.Rejected,
 		})
 	}, 5*time.Second)
@@ -372,7 +372,7 @@ func TestCleanupError(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReview{
+		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
 			Status: terraform.Approved,
 		})
 	}, 5*time.Second)

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -180,7 +180,7 @@ func TestSuccess(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
+		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
 			Status: terraform.Approved,
 		})
 	}, 5*time.Second)
@@ -198,6 +198,14 @@ func TestSuccess(t *testing.T) {
 	assert.Equal(t, []state.Workflow{
 		{
 			Plan: &state.Job{
+				Status: state.WaitingJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
 				Status: state.InProgressJobStatus,
 				Output: &state.JobOutput{
 					URL: outputURL,
@@ -207,6 +215,20 @@ func TestSuccess(t *testing.T) {
 		{
 			Plan: &state.Job{
 				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: outputURL,
 				},
@@ -263,9 +285,9 @@ func TestPlanRejection(t *testing.T) {
 		LocalRoot: testLocalRoot,
 	}, nil)
 
-	// send approval of plan
+	// send rejection of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
+		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
 			Status: terraform.Rejected,
 		})
 	}, 5*time.Second)
@@ -281,6 +303,14 @@ func TestPlanRejection(t *testing.T) {
 	// assert results are expected
 	env.AssertExpectations(t)
 	assert.Equal(t, []state.Workflow{
+		{
+			Plan: &state.Job{
+				Status: state.WaitingJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+		},
 		{
 			Plan: &state.Job{
 				Status: state.InProgressJobStatus,
@@ -305,7 +335,7 @@ func TestPlanRejection(t *testing.T) {
 				},
 			},
 			Apply: &state.Job{
-				Status: state.InProgressJobStatus,
+				Status: state.WaitingJobStatus,
 				Output: &state.JobOutput{
 					URL: outputURL,
 				},
@@ -372,7 +402,7 @@ func TestCleanupError(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview-repo-steps", terraform.PlanReviewSignalRequest{
+		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
 			Status: terraform.Approved,
 		})
 	}, 5*time.Second)

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -14,6 +14,15 @@ import (
 // Export anything that callers need such as requests, signals, etc.
 type TerraformRequest = terraform.Request
 
+type TerraformPlanReviewSignalRequest = terraform.PlanReviewSignalRequest
+
+type TerraformPlanReviewStatus = terraform.PlanStatus
+
+const ApprovedPlanReviewStatus = terraform.Approved
+const RejectedPlanReviewStatus = terraform.Rejected
+
+const TerraformPlanReviewSignalName = terraform.PlanReviewSignalName
+
 type TerraformActivities struct {
 	activities.Terraform
 }

--- a/server/vcs/provider/github/converter/check_run_event.go
+++ b/server/vcs/provider/github/converter/check_run_event.go
@@ -1,0 +1,26 @@
+package converter
+
+import (
+	"github.com/google/go-github/v45/github"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+)
+
+type ChecksEvent struct{}
+
+func (p ChecksEvent) Convert(e *github.CheckRunEvent) (event.CheckRun, error) {
+	var action event.CheckRunAction
+	switch e.GetAction() {
+	case "requested_action":
+		action = event.RequestedActionChecksAction{
+			Identifier: e.GetRequestedAction().Identifier,
+		}
+	default:
+		action = event.WrappedCheckRunAction(e.GetAction())
+	}
+
+	return event.CheckRun{
+		Action:     action,
+		ExternalID: e.CheckRun.GetExternalID(),
+	}, nil
+
+}

--- a/server/vcs/provider/github/converter/check_run_event_test.go
+++ b/server/vcs/provider/github/converter/check_run_event_test.go
@@ -1,0 +1,122 @@
+package converter_test
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github/converter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvert_CheckRunEvent(t *testing.T) {
+	subject := converter.CheckRunEvent{
+		RepoConverter: converter.RepoConverter{
+			GithubUser:  "user",
+			GithubToken: "token",
+		},
+	}
+
+	repoFullName := "owner/repo"
+	repoOwner := "owner"
+	repoName := "repo"
+	cloneURL := "https://github.com/owner/repo.git"
+	requestedActionsID := "some_id"
+	externalID := "external id"
+	checkRunName := "some name"
+	login := "nish"
+
+	repo := &github.Repository{
+		FullName:      github.String(repoFullName),
+		Owner:         &github.User{Login: github.String(repoOwner)},
+		Name:          github.String(repoName),
+		CloneURL:      github.String(cloneURL),
+		DefaultBranch: github.String("main"),
+	}
+
+	t.Run("success with requested actions", func(t *testing.T) {
+		expectedResult := event.CheckRun{
+			Name: checkRunName,
+			Action: event.RequestedActionChecksAction{
+				Identifier: requestedActionsID,
+			},
+			ExternalID: externalID,
+			Repo: models.Repo{
+				FullName:          repoFullName,
+				Owner:             repoOwner,
+				Name:              repoName,
+				CloneURL:          "https://user:token@github.com/owner/repo.git",
+				SanitizedCloneURL: "https://user:<redacted>@github.com/owner/repo.git",
+				VCSHost: models.VCSHost{
+					Type:     models.Github,
+					Hostname: "github.com",
+				},
+				DefaultBranch: "main",
+			},
+			User: login,
+		}
+
+		result, err := subject.Convert(
+			&github.CheckRunEvent{
+				Repo:   repo,
+				Action: github.String("requested_action"),
+				RequestedAction: &github.RequestedAction{
+					Identifier: requestedActionsID,
+				},
+				CheckRun: &github.CheckRun{
+					ExternalID: github.String(externalID),
+					Name:       github.String(checkRunName),
+				},
+				Sender: &github.User{
+					Login: github.String(login),
+				},
+			},
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+	})
+
+	t.Run("success with requested actions", func(t *testing.T) {
+		expectedResult := event.CheckRun{
+			Name:       checkRunName,
+			Action:     event.WrappedCheckRunAction("created"),
+			ExternalID: externalID,
+			Repo: models.Repo{
+				FullName:          repoFullName,
+				Owner:             repoOwner,
+				Name:              repoName,
+				CloneURL:          "https://user:token@github.com/owner/repo.git",
+				SanitizedCloneURL: "https://user:<redacted>@github.com/owner/repo.git",
+				VCSHost: models.VCSHost{
+					Type:     models.Github,
+					Hostname: "github.com",
+				},
+				DefaultBranch: "main",
+			},
+			User: login,
+		}
+
+		result, err := subject.Convert(
+			&github.CheckRunEvent{
+				Repo:   repo,
+				Action: github.String("created"),
+				RequestedAction: &github.RequestedAction{
+					Identifier: requestedActionsID,
+				},
+				CheckRun: &github.CheckRun{
+					ExternalID: github.String(externalID),
+					Name:       github.String(checkRunName),
+				},
+				Sender: &github.User{
+					Login: github.String(login),
+				},
+			},
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+	})
+
+}


### PR DESCRIPTION
We use the external id property of the check run in order to signal the correctly running workflow.

I also created a new waiting state for each operation which is what's used on initialization.  This makes more sense for example when we are waiting on a dependency before proceeding with the operation (ie. plan approval)