### PR TITLE
Terraform Plan Activity

### DIFF
--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -2,6 +2,8 @@ package activities
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-version"
@@ -11,7 +13,12 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 )
 
-const DisableInputArg = "-input=false"
+const (
+	DisableInputArg = "-input=false"
+	RefreshArg      = "-refresh"
+	OutArg          = "-out"
+	PlanOutputFile  = "output.tfplan"
+)
 
 type TerraformClient interface {
 	RunCommand(ctx context.Context, jobID string, path string, args []string, customEnvVars map[string]string, v *version.Version) <-chan terraform.Line
@@ -59,28 +66,49 @@ func (t *terraformActivities) TerraformInit(ctx context.Context, request Terrafo
 	}
 
 	ch := t.TerraformClient.RunCommand(ctx, request.JobID, request.Path, cmd.Build(), request.Envs, tfVersion)
-	var lines []string
-	for line := range ch {
-		if line.Err != nil {
-			err = errors.Wrap(line.Err, "executing command")
-			break
-		}
-		lines = append(lines, line.Line)
+	_, err = t.readTerraformOutput(ch)
+	if err != nil {
+		return TerraformInitResponse{}, errors.Wrap(err, "processing command output")
 	}
-	output := strings.Join(lines, "\n")
-
-	// sanitize output by stripping out any ansi characters.
-	output = ansi.Strip(output)
 	return TerraformInitResponse{}, nil
 }
 
 // Terraform Plan
-
 type TerraformPlanRequest struct {
+	Step      job.Step
+	Envs      map[string]string
+	JobID     string
+	TfVersion string
+	Path      string
 }
 
-func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) error {
-	return nil
+type TerraformPlanResponse struct {
+	PlanFile string
+	Output   string
+}
+
+func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) (TerraformPlanResponse, error) {
+	tfVersion, err := t.resolveVersion(request.TfVersion)
+	if err != nil {
+		return TerraformPlanResponse{}, err
+	}
+	planFile := filepath.Join(request.Path, PlanOutputFile)
+	cmd, err := terraform.NewCommandArguments(
+		terraform.Plan,
+		[]string{DisableInputArg, fmt.Sprintf("%s=%s", RefreshArg, "true"), fmt.Sprintf("%s=%s", OutArg, planFile)},
+		request.Step.ExtraArgs,
+	)
+	if err != nil {
+		return TerraformPlanResponse{}, errors.Wrap(err, "building command arguments")
+	}
+	ch := t.TerraformClient.RunCommand(ctx, request.JobID, request.Path, cmd.Build(), request.Envs, tfVersion)
+	_, err = t.readTerraformOutput(ch)
+	if err != nil {
+		return TerraformPlanResponse{}, errors.Wrap(err, "processing command output")
+	}
+	return TerraformPlanResponse{
+		PlanFile: planFile,
+	}, nil
 }
 
 // Terraform Apply
@@ -107,4 +135,23 @@ func (t *terraformActivities) resolveVersion(v string) (*version.Version, error)
 		return version, nil
 	}
 	return t.DefaultTFVersion, nil
+}
+
+func (t *terraformActivities) readTerraformOutput(ch <-chan terraform.Line) (string, error) {
+	var err error
+	var lines []string
+	for line := range ch {
+		if line.Err != nil {
+			err = errors.Wrap(line.Err, "executing command")
+			break
+		}
+		lines = append(lines, line.Line)
+	}
+	if err != nil {
+		return "", err
+	}
+	output := strings.Join(lines, "\n")
+	// sanitize output by stripping out any ansi characters.
+	output = ansi.Strip(output)
+	return output, nil
 }

--- a/server/neptune/workflows/internal/terraform/job/job_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/job_runner.go
@@ -17,13 +17,15 @@ type jobRunner struct {
 	EnvStepRunner  stepRunner
 	CmdStepRunner  stepRunner
 	InitStepRunner stepRunner
+	PlanStepRunner stepRunner
 }
 
-func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner, initStepRunner stepRunner) *jobRunner {
+func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner, initStepRunner stepRunner, planStepRunner stepRunner) *jobRunner {
 	return &jobRunner{
 		CmdStepRunner:  runStepRunner,
 		EnvStepRunner:  envStepRunner,
 		InitStepRunner: initStepRunner,
+		PlanStepRunner: planStepRunner,
 	}
 }
 
@@ -49,6 +51,8 @@ func (r *jobRunner) Run(
 		switch step.StepName {
 		case "init":
 			out, err = r.InitStepRunner.Run(jobExecutionCtx, localRoot, step)
+		case "plan":
+			out, err = r.PlanStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "run":
 			out, err = r.CmdStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "env":

--- a/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
@@ -1,0 +1,33 @@
+package job
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"go.temporal.io/sdk/workflow"
+)
+
+type planActivities interface {
+	TerraformPlan(ctx context.Context, request activities.TerraformPlanRequest) (activities.TerraformPlanResponse, error)
+}
+
+type PlanStepRunner struct {
+	Activity planActivities
+}
+
+func (r *PlanStepRunner) Run(executionContext *job.ExecutionContext, _ *root.LocalRoot, step job.Step) (string, error) {
+	var resp activities.TerraformPlanResponse
+	err := workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformPlan, activities.TerraformPlanRequest{
+		Step:      step,
+		Envs:      executionContext.Envs,
+		TfVersion: executionContext.TfVersion,
+		Path:      executionContext.Path,
+	}).Get(executionContext, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "running terraform init activity")
+	}
+	return resp.Output, nil
+}

--- a/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
@@ -27,7 +27,7 @@ func (r *PlanStepRunner) Run(executionContext *job.ExecutionContext, _ *root.Loc
 		Path:      executionContext.Path,
 	}).Get(executionContext, &resp)
 	if err != nil {
-		return "", errors.Wrap(err, "running terraform init activity")
+		return "", errors.Wrap(err, "running terraform plan activity")
 	}
 	return resp.Output, nil
 }

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -93,6 +93,9 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			&runner.InitStepRunner{
 				Activity: ta,
 			},
+			&runner.PlanStepRunner{
+				Activity: ta,
+			},
 		),
 		Store: state.NewWorkflowStore(
 			func(s *state.Workflow) error {


### PR DESCRIPTION
Adding the tf plan activity. Few things to note:

- currently matches tf init's existing decision to build output and skip returning it until we create a better way to support command responses
- re-processed tf version to keep activity request/responses minimal
- unlike old way that uses project name/workspace when creating tf plan filename, let's just gonna use `output.tfplan` since we should only be dealing with one root per plan
- no longer supporting pre-existing tfvars