### PR TITLE
Ensure cleanup is always called.

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -24,7 +24,6 @@ type Comment struct {
 	Timestamp time.Time
 }
 
-
 func NewCommentEventWorkerProxy(
 	logger logging.Logger,
 	snsWriter Writer,

--- a/server/neptune/workflows/internal/config/logger/logger.go
+++ b/server/neptune/workflows/internal/config/logger/logger.go
@@ -12,11 +12,11 @@ func Info(ctx workflow.Context, msg string) {
 	logger.Info(msg, kvs...)
 }
 
-func Warn(ctx workflow.Context, msg string) {
+func Warn(ctx workflow.Context, msg string, additionalKVs ...interface{}) {
 	logger := workflow.GetLogger(ctx)
 	kvs := context.ExtractFieldsAsList(ctx)
 
-	logger.Warn(msg, kvs...)
+	logger.Warn(msg, append(kvs, additionalKVs)...)
 }
 
 func Error(ctx workflow.Context, msg string, additionalKVs ...interface{}) {

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -1,0 +1,40 @@
+package terraform
+
+import (
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"go.temporal.io/sdk/workflow"
+)
+
+type RootFetcher struct {
+	Request Request
+	Ga      githubActivities
+	Ta      terraformActivities
+}
+
+// Fetch returns a local root and a cleanup function
+func (r *RootFetcher) Fetch(ctx workflow.Context) (*root.LocalRoot, func() error, error) {
+	var fetchRootResponse activities.FetchRootResponse
+	err := workflow.ExecuteActivity(ctx, r.Ga.FetchRoot, activities.FetchRootRequest{
+		Repo:         r.Request.Repo,
+		Root:         r.Request.Root,
+		DeploymentId: r.Request.DeploymentId,
+		Revision:     r.Request.Revision,
+	}).Get(ctx, &fetchRootResponse)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return fetchRootResponse.LocalRoot, func() error {
+		var cleanupResponse activities.CleanupResponse
+		err = workflow.ExecuteActivity(ctx, r.Ta.Cleanup, activities.CleanupRequest{
+			LocalRoot: fetchRootResponse.LocalRoot,
+		}).Get(ctx, &cleanupResponse)
+		if err != nil {
+			return errors.Wrap(err, "cleaning up")
+		}
+		return nil
+	}, nil
+}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -76,6 +76,7 @@ type Runner struct {
 	JobRunner           jobRunner
 	Request             Request
 	Store               *state.WorkflowStore
+	RootFetcher         *RootFetcher
 }
 
 func newRunner(ctx workflow.Context, request Request) *Runner {
@@ -101,6 +102,11 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 				Activity: ta,
 			},
 		),
+		RootFetcher: &RootFetcher{
+			Request: request,
+			Ga:      ga,
+			Ta:      ta,
+		},
 		Store: state.NewWorkflowStore(
 			func(s *state.Workflow) error {
 				return workflow.SignalExternalWorkflow(ctx, parent.ID, parent.RunID, state.WorkflowStateChangeSignal, s).Get(ctx, nil)
@@ -191,33 +197,26 @@ func (r *Runner) Run(ctx workflow.Context) error {
 		return errors.Wrap(err, "getting worker info")
 	}
 
-	var fetchRootResponse activities.FetchRootResponse
-	err = workflow.ExecuteActivity(ctx, r.GithubActivities.FetchRoot, activities.FetchRootRequest{
-		Repo:         r.Request.Repo,
-		Root:         r.Request.Root,
-		DeploymentId: r.Request.DeploymentId,
-		Revision:     r.Request.Revision,
-	}).Get(ctx, &fetchRootResponse)
+	root, cleanup, err := r.RootFetcher.Fetch(ctx)
+	defer func() {
+		err := cleanup()
+
+		if err != nil {
+			logger.Warn(ctx, "error cleaning up local root", "err", err)
+		}
+	}()
 
 	if err != nil {
 		return errors.Wrap(err, "fetching root")
 	}
 
-	if err := r.Plan(ctx, fetchRootResponse.LocalRoot, response.ServerURL); err != nil {
+	if err := r.Plan(ctx, root, response.ServerURL); err != nil {
 		return errors.Wrap(err, "running plan job")
 	}
 
-	if err := r.Apply(ctx, fetchRootResponse.LocalRoot, response.ServerURL); err != nil {
+	if err := r.Apply(ctx, root, response.ServerURL); err != nil {
 		return errors.Wrap(err, "running apply job")
 	}
 
-	// Cleanup
-	var cleanupResponse activities.CleanupResponse
-	err = workflow.ExecuteActivity(ctx, r.TerraformActivities.Cleanup, activities.CleanupRequest{
-		LocalRoot: fetchRootResponse.LocalRoot,
-	}).Get(ctx, &cleanupResponse)
-	if err != nil {
-		return errors.Wrap(err, "cleaning up")
-	}
 	return nil
 }

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -103,13 +103,20 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 
 	var s []state.Workflow
 
+	runnerReq := terraform.Request{
+		Root:         testLocalRoot.Root,
+		Repo:         testGithubRepo,
+		DeploymentId: testDeploymentID,
+	}
+
 	subject := &terraform.Runner{
 		GithubActivities:    gAct,
 		TerraformActivities: tAct,
-		Request: terraform.Request{
-			Root:         testLocalRoot.Root,
-			Repo:         testGithubRepo,
-			DeploymentId: testDeploymentID,
+		Request:             runnerReq,
+		RootFetcher: &terraform.RootFetcher{
+			Request: runnerReq,
+			Ta: tAct,
+			Ga: gAct,
 		},
 		JobRunner: runner,
 		Store: state.NewWorkflowStoreWithGenerator(
@@ -387,7 +394,7 @@ func TestFetchRootError(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-func TestCleanupError(t *testing.T) {
+func TestCleanupErrorReturnsNoError(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	ga := &githubActivities{}
@@ -415,5 +422,5 @@ func TestCleanupError(t *testing.T) {
 	env.AssertExpectations(t)
 	var resp response
 	err := env.GetWorkflowResult(&resp)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Previous implementation wouldn't clean up if there was an error in the workflow.

I also ensured that workflow doesn't fail if cleanup fails to happen since this shouldn't be the case.