### PR TITLE
Refactor command arguments.

### DIFF
--- a/server/neptune/terraform/command_test.go
+++ b/server/neptune/terraform/command_test.go
@@ -9,28 +9,55 @@ import (
 
 func TestCommandArguments_Build(t *testing.T) {
 	t.Run("empty extra args", func(t *testing.T) {
-		c, err := terraform.NewCommandArguments(terraform.Init, []string{"-input=false"}, []string{})
+		c, err := terraform.NewCommandArguments(terraform.Init, []terraform.Argument{
+			{
+				Key:   "input",
+				Value: "false",
+			},
+		})
 		assert.Nil(t, err)
 
 		assert.Equal(t, []string{"init", "-input=false"}, c.Build())
 	})
 
 	t.Run("empty command args with extra args", func(t *testing.T) {
-		c, err := terraform.NewCommandArguments(terraform.Init, []string{}, []string{"-input=false"})
+		c, err := terraform.NewCommandArguments(terraform.Init, []terraform.Argument{},
+			terraform.Argument{
+				Key:   "input",
+				Value: "false",
+			})
 		assert.Nil(t, err)
 
 		assert.Equal(t, []string{"init", "-input=false"}, c.Build())
 	})
 
 	t.Run("empty command args and empty extra args", func(t *testing.T) {
-		c, err := terraform.NewCommandArguments(terraform.Init, []string{}, []string{})
+		c, err := terraform.NewCommandArguments(terraform.Init, []terraform.Argument{})
 		assert.Nil(t, err)
 
 		assert.Equal(t, []string{"init"}, c.Build())
 	})
 
 	t.Run("extra args replaces command args", func(t *testing.T) {
-		c, err := terraform.NewCommandArguments(terraform.Init, []string{"-input=false", "-a=b"}, []string{"-input=true", "-c=d"})
+		c, err := terraform.NewCommandArguments(terraform.Init, []terraform.Argument{
+			{
+				Key:   "input",
+				Value: "false",
+			},
+			{
+				Key:   "a",
+				Value: "b",
+			},
+		},
+
+			terraform.Argument{
+				Key:   "input",
+				Value: "true",
+			},
+			terraform.Argument{
+				Key:   "c",
+				Value: "d",
+			})
 		assert.Nil(t, err)
 
 		assert.Equal(t, []string{"init", "-input=true", "-a=b", "-c=d"}, c.Build())

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -112,8 +112,8 @@ func TestTerraformInit_ExtraArgsTakesPrecedenceOverCommandArgs(t *testing.T) {
 	req := activities.TerraformInitRequest{
 		Args: []terraform.Argument{
 			{
-				Key: "input",
-				Value: "false",
+				Key:   "input",
+				Value: "true",
 			},
 		},
 		Envs:      map[string]string{},

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/neptune/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -70,9 +69,6 @@ func TestTerraformInit_TfVersionInRequestTakesPrecedence(t *testing.T) {
 	}
 
 	req := activities.TerraformInitRequest{
-		Step: job.Step{
-			StepName: "init",
-		},
 		Envs:      map[string]string{},
 		JobID:     jobID,
 		Path:      path,
@@ -114,9 +110,11 @@ func TestTerraformInit_ExtraArgsTakesPrecedenceOverCommandArgs(t *testing.T) {
 	}
 
 	req := activities.TerraformInitRequest{
-		Step: job.Step{
-			StepName:  "init",
-			ExtraArgs: []string{"-input=true"},
+		Args: []terraform.Argument{
+			{
+				Key: "input",
+				Value: "false",
+			},
 		},
 		Envs:      map[string]string{},
 		JobID:     jobID,
@@ -159,9 +157,6 @@ func TestTerraformPlan(t *testing.T) {
 	}
 
 	req := activities.TerraformPlanRequest{
-		Step: job.Step{
-			StepName: "plan",
-		},
 		Envs:      map[string]string{},
 		JobID:     jobID,
 		Path:      path,

--- a/server/neptune/workflows/internal/terraform/job/init_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/init_step_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
@@ -19,9 +20,14 @@ type InitStepRunner struct {
 }
 
 func (r *InitStepRunner) Run(executionContext *job.ExecutionContext, localRoot *root.LocalRoot, step job.Step) (string, error) {
+	args, err := terraform.NewArgumentList(step.ExtraArgs)
+
+	if err != nil {
+		return "", errors.Wrapf(err, "creating argument list")
+	}
 	var resp activities.TerraformInitResponse
-	err := workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformInit, activities.TerraformInitRequest{
-		Step:      step,
+	err = workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformInit, activities.TerraformInitRequest{
+		Args:      args,
 		Envs:      executionContext.Envs,
 		TfVersion: executionContext.TfVersion,
 		Path:      executionContext.Path,

--- a/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/plan_step_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
@@ -19,9 +20,14 @@ type PlanStepRunner struct {
 }
 
 func (r *PlanStepRunner) Run(executionContext *job.ExecutionContext, _ *root.LocalRoot, step job.Step) (string, error) {
+	args, err := terraform.NewArgumentList(step.ExtraArgs)
+
+	if err != nil {
+		return "", errors.Wrapf(err, "creating argument list")
+	}
 	var resp activities.TerraformPlanResponse
-	err := workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformPlan, activities.TerraformPlanRequest{
-		Step:      step,
+	err = workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformPlan, activities.TerraformPlanRequest{
+		Args:      args,
 		Envs:      executionContext.Envs,
 		TfVersion: executionContext.TfVersion,
 		Path:      executionContext.Path,


### PR DESCRIPTION
Didn't really make sense that we were forcing callers to pass in a list of strings where they have to remember the format.  We should make it easier to build args and contain the string format where we can.  In the case of extra args, this is typed up as a comment so it makes sense for now to support that as a list of strings while providing tooling/validation to convert it.