### PR TITLE
terraform apply activity

### DIFF
--- a/server/neptune/terraform/subcommand.go
+++ b/server/neptune/terraform/subcommand.go
@@ -68,6 +68,7 @@ func newArgument(arg string) (Argument, error) {
 
 type SubCommand struct {
 	op    Operation
+	input string
 	args  []Argument
 	flags []Flag
 }
@@ -82,6 +83,12 @@ func NewSubCommand(op Operation) *SubCommand {
 // and sets them appropriately on the receiver
 func (c *SubCommand) WithArgs(args ...Argument) *SubCommand {
 	c.args = c.dedup(args)
+	return c
+}
+
+// WithInput adds a single command input
+func (c *SubCommand) WithInput(input string) *SubCommand {
+	c.input = input
 	return c
 }
 
@@ -106,6 +113,11 @@ func (c *SubCommand) Build() []string {
 		result = append(result, f.build())
 	}
 
+	// append input if it exists
+	if c.input != "" {
+		result = append(result, c.input)
+	}
+
 	return result
 }
 
@@ -124,7 +136,6 @@ func (c *SubCommand) dedup(args []Argument) []Argument {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-
 
 	for _, k := range keys {
 		finalArgs = append(finalArgs, Argument{

--- a/server/neptune/terraform/subcommand_test.go
+++ b/server/neptune/terraform/subcommand_test.go
@@ -18,6 +18,14 @@ func TestCommandArguments_Build(t *testing.T) {
 		assert.Equal(t, []string{"show", "-json"}, c.Build())
 	})
 
+	t.Run("with input", func(t *testing.T) {
+		c := terraform.NewSubCommand(terraform.Apply)
+
+		c.WithInput("input.tfplan")
+
+		assert.Equal(t, []string{"apply", "input.tfplan"}, c.Build())
+	})
+
 	t.Run("with args", func(t *testing.T) {
 		c := terraform.NewSubCommand(terraform.Init)
 

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -95,7 +95,7 @@ func (t *terraformActivities) TerraformPlan(ctx context.Context, request Terrafo
 	if err != nil {
 		return TerraformPlanResponse{}, err
 	}
-	planFile := filepath.Join(request.Path, PlanOutputFile)
+	planFile := buildPlanFilePath(request.Path)
 
 	args := []terraform.Argument{
 		DisableInputArg,
@@ -120,12 +120,52 @@ func (t *terraformActivities) TerraformPlan(ctx context.Context, request Terrafo
 }
 
 // Terraform Apply
-
 type TerraformApplyRequest struct {
+	Args      []terraform.Argument
+	Envs      map[string]string
+	JobID     string
+	TfVersion string
+	Path      string
 }
 
-func (t *terraformActivities) TerraformApply(ctx context.Context, request TerraformApplyRequest) error {
-	return nil
+type TerraformApplyResponse struct {
+	Output string
+}
+
+func (t *terraformActivities) TerraformApply(ctx context.Context, request TerraformApplyRequest) (TerraformApplyResponse, error) {
+	// Fail requests using a target flag, as Atlantis cannot support this functionality
+	if containsTargetFlag(request.Args) {
+		return TerraformApplyResponse{}, errors.New("request contains invalid -target flag")
+	}
+
+	tfVersion, err := t.resolveVersion(request.TfVersion)
+	if err != nil {
+		return TerraformApplyResponse{}, err
+	}
+
+	planFile := buildPlanFilePath(request.Path)
+	args := []terraform.Argument{DisableInputArg}
+	args = append(args, request.Args...)
+
+	cmd := terraform.NewSubCommand(terraform.Apply).WithInput(planFile).WithArgs(args...)
+	if err != nil {
+		return TerraformApplyResponse{}, errors.Wrap(err, "building command arguments")
+	}
+	ch := t.TerraformClient.RunCommand(ctx, request.JobID, request.Path, cmd, request.Envs, tfVersion)
+	_, err = t.readCommandOutput(ch)
+	if err != nil {
+		return TerraformApplyResponse{}, errors.Wrap(err, "processing command output")
+	}
+	return TerraformApplyResponse{}, nil
+}
+
+func containsTargetFlag(args []terraform.Argument) bool {
+	for _, arg := range args {
+		if arg.Key == "target" {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *terraformActivities) resolveVersion(v string) (*version.Version, error) {
@@ -162,4 +202,8 @@ func (t *terraformActivities) readCommandOutput(ch <-chan terraform.Line) (strin
 	// sanitize output by stripping out any ansi characters.
 	output = ansi.Strip(output)
 	return output, nil
+}
+
+func buildPlanFilePath(path string) string {
+	return filepath.Join(path, PlanOutputFile)
 }

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -120,6 +120,7 @@ func (t *terraformActivities) TerraformPlan(ctx context.Context, request Terrafo
 }
 
 // Terraform Apply
+
 type TerraformApplyRequest struct {
 	Args      []terraform.Argument
 	Envs      map[string]string
@@ -148,9 +149,6 @@ func (t *terraformActivities) TerraformApply(ctx context.Context, request Terraf
 	args = append(args, request.Args...)
 
 	cmd := terraform.NewSubCommand(terraform.Apply).WithInput(planFile).WithArgs(args...)
-	if err != nil {
-		return TerraformApplyResponse{}, errors.Wrap(err, "building command arguments")
-	}
 	ch := t.TerraformClient.RunCommand(ctx, request.JobID, request.Path, cmd, request.Envs, tfVersion)
 	_, err = t.readCommandOutput(ch)
 	if err != nil {

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -193,3 +193,108 @@ func TestTerraformPlan(t *testing.T) {
 	assert.Nil(t, resp.Get(&planResp))
 	assert.Equal(t, planResp.PlanFile, "some/path/output.tfplan")
 }
+
+func TestTerraformApply(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+
+	ctx := context.Background()
+	path := "some/path"
+	jobID := "1234"
+	defVersion := "1.0.2"
+	reqVersion := "1.2.2"
+
+	defaultTfVersion, err := version.NewVersion(defVersion)
+	assert.Nil(t, err)
+
+	reqTfVersion, err := version.NewVersion(reqVersion)
+	assert.Nil(t, err)
+
+	expectedCmd := terraform.NewSubCommand(terraform.Apply).
+		WithArgs(terraform.Argument{
+			Key:   "input",
+			Value: "false",
+		}).
+		WithInput("some/path/output.tfplan")
+
+	testTfClient := testTfClient{
+		t:             t,
+		ctx:           ctx,
+		jobID:         jobID,
+		path:          path,
+		cmd:           expectedCmd,
+		customEnvVars: map[string]string{},
+		version:       reqTfVersion,
+		resp:          []terraform.Line{},
+	}
+
+	req := activities.TerraformApplyRequest{
+		Envs:      map[string]string{},
+		JobID:     jobID,
+		Path:      path,
+		TfVersion: reqVersion,
+	}
+
+	tfActivity := activities.NewTerraformActivities(&testTfClient, defaultTfVersion)
+	env.RegisterActivity(tfActivity)
+
+	resp, err := env.ExecuteActivity(tfActivity.TerraformApply, req)
+	assert.NoError(t, err)
+
+	var applyResp activities.TerraformApplyResponse
+	assert.Nil(t, resp.Get(&applyResp))
+}
+
+func TestTerraformApply_TargetFailure(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+
+	ctx := context.Background()
+	path := "some/path"
+	jobID := "1234"
+	defVersion := "1.0.2"
+	reqVersion := "1.2.2"
+
+	defaultTfVersion, err := version.NewVersion(defVersion)
+	assert.Nil(t, err)
+
+	reqTfVersion, err := version.NewVersion(reqVersion)
+	assert.Nil(t, err)
+
+	expectedCmd := terraform.NewSubCommand(terraform.Apply).
+		WithArgs(terraform.Argument{
+			Key:   "input",
+			Value: "false",
+		}).
+		WithInput("some/path/output.tfplan")
+
+	testTfClient := testTfClient{
+		t:             t,
+		ctx:           ctx,
+		jobID:         jobID,
+		path:          path,
+		cmd:           expectedCmd,
+		customEnvVars: map[string]string{},
+		version:       reqTfVersion,
+		resp:          []terraform.Line{},
+	}
+
+	req := activities.TerraformApplyRequest{
+		Envs:      map[string]string{},
+		JobID:     jobID,
+		Path:      path,
+		TfVersion: reqVersion,
+		Args: []terraform.Argument{
+			{
+				Key:   "target",
+				Value: "anything",
+			},
+		},
+	}
+
+	tfActivity := activities.NewTerraformActivities(&testTfClient, defaultTfVersion)
+	env.RegisterActivity(tfActivity)
+
+	_, err = env.ExecuteActivity(tfActivity.TerraformApply, req)
+	assert.ErrorContains(t, err, "request contains invalid -target flag")
+}

--- a/server/neptune/workflows/internal/terraform/job/apply_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/apply_step_runner.go
@@ -1,0 +1,39 @@
+package job
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"go.temporal.io/sdk/workflow"
+)
+
+type applyActivities interface {
+	TerraformApply(ctx context.Context, request activities.TerraformApplyRequest) (activities.TerraformApplyResponse, error)
+}
+
+type ApplyStepRunner struct {
+	Activity applyActivities
+}
+
+func (r *ApplyStepRunner) Run(executionContext *job.ExecutionContext, _ *root.LocalRoot, step job.Step) (string, error) {
+	args, err := terraform.NewArgumentList(step.ExtraArgs)
+
+	if err != nil {
+		return "", errors.Wrapf(err, "creating argument list")
+	}
+	var resp activities.TerraformApplyResponse
+	err = workflow.ExecuteActivity(executionContext.Context, r.Activity.TerraformApply, activities.TerraformApplyRequest{
+		Args:      args,
+		Envs:      executionContext.Envs,
+		TfVersion: executionContext.TfVersion,
+		Path:      executionContext.Path,
+	}).Get(executionContext, &resp)
+	if err != nil {
+		return "", errors.Wrap(err, "running terraform apply activity")
+	}
+	return resp.Output, nil
+}

--- a/server/neptune/workflows/internal/terraform/job/job_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/job_runner.go
@@ -14,18 +14,20 @@ type stepRunner interface {
 }
 
 type jobRunner struct {
-	EnvStepRunner  stepRunner
-	CmdStepRunner  stepRunner
-	InitStepRunner stepRunner
-	PlanStepRunner stepRunner
+	EnvStepRunner   stepRunner
+	CmdStepRunner   stepRunner
+	InitStepRunner  stepRunner
+	PlanStepRunner  stepRunner
+	ApplyStepRunner stepRunner
 }
 
-func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner, initStepRunner stepRunner, planStepRunner stepRunner) *jobRunner {
+func NewRunner(runStepRunner stepRunner, envStepRunner stepRunner, initStepRunner stepRunner, planStepRunner stepRunner, applyStepRunner stepRunner) *jobRunner {
 	return &jobRunner{
-		CmdStepRunner:  runStepRunner,
-		EnvStepRunner:  envStepRunner,
-		InitStepRunner: initStepRunner,
-		PlanStepRunner: planStepRunner,
+		CmdStepRunner:   runStepRunner,
+		EnvStepRunner:   envStepRunner,
+		InitStepRunner:  initStepRunner,
+		PlanStepRunner:  planStepRunner,
+		ApplyStepRunner: applyStepRunner,
 	}
 }
 
@@ -53,6 +55,8 @@ func (r *jobRunner) Run(
 			out, err = r.InitStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "plan":
 			out, err = r.PlanStepRunner.Run(jobExecutionCtx, localRoot, step)
+		case "apply":
+			out, err = r.ApplyStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "run":
 			out, err = r.CmdStepRunner.Run(jobExecutionCtx, localRoot, step)
 		case "env":

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -104,6 +104,9 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			&runner.PlanStepRunner{
 				Activity: ta,
 			},
+			&runner.ApplyStepRunner{
+				Activity: ta,
+			},
 		),
 		RootFetcher: &RootFetcher{
 			Request: request,


### PR DESCRIPTION
Adding the tf apply activity. Few things to note:

- currently matches tf init/plan's existing decision to build output and skip returning it until we create a better way to support command responses
- re-processed tf version to keep activity request/responses minimal
- fails on receiving a `-target` input request since we don't support them in Atlantis