### PR TITLE
Use correct project command runner for policy checking.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -805,7 +805,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		prPrjCmdRunner,
 		dbUpdater,
 		outputUpdater,
-		policyCheckCommandRunner,
+		events.NewPolicyCheckCommandRunner(dbUpdater, outputUpdater, commitStatusUpdater, prPrjCmdRunner, userConfig.ParallelPoolSize),
 		userConfig.ParallelPoolSize,
 	)
 


### PR DESCRIPTION
This is the reason we were seeing the locking issue when testing on staging.