### PR TITLE
Fix show step runner error message.

### DIFF
--- a/server/core/runtime/show_step_runner.go
+++ b/server/core/runtime/show_step_runner.go
@@ -51,12 +51,13 @@ func (p *ShowStepRunner) Run(ctx context.Context, prjCtx command.ProjectContext,
 	)
 
 	if err != nil {
-		return "", errors.Wrap(err, "running terraform show")
+		return output, errors.Wrap(err, "running terraform show")
 	}
 
 	if err := ioutil.WriteFile(showResultFile, []byte(output), os.ModePerm); err != nil {
 		return "", errors.Wrap(err, "writing terraform show result")
 	}
 
-	return output, nil
+	// don't return the output if it's successful since this is too large
+	return "", nil
 }

--- a/server/core/runtime/show_step_runner_test.go
+++ b/server/core/runtime/show_step_runner_test.go
@@ -44,7 +44,7 @@ func TestShowStepRunnner(t *testing.T) {
 			ctx, prjCtx, path, []string{"show", "-json", filepath.Join(path, "test-default.tfplan")}, envs, tfVersion, prjCtx.Workspace,
 		)).ThenReturn("success", nil)
 
-		r, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
+		_, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
 
 		Ok(t, err)
 
@@ -52,7 +52,6 @@ func TestShowStepRunnner(t *testing.T) {
 
 		actualStr := string(actual)
 		Assert(t, actualStr == "success", fmt.Sprintf("expected '%s' to be success", actualStr))
-		Assert(t, r == "success", fmt.Sprintf("expected '%s' to be success", r))
 
 	})
 
@@ -72,7 +71,7 @@ func TestShowStepRunnner(t *testing.T) {
 			ctx, prjCtx, path, []string{"show", "-json", filepath.Join(path, "test-default.tfplan")}, envs, v, prjCtx.Workspace,
 		)).ThenReturn("success", nil)
 
-		r, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
+		_, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
 
 		Ok(t, err)
 
@@ -80,18 +79,18 @@ func TestShowStepRunnner(t *testing.T) {
 
 		actualStr := string(actual)
 		Assert(t, actualStr == "success", "got expected result")
-		Assert(t, r == "success", "returned expected result")
 
 	})
 
 	t.Run("failure running command", func(t *testing.T) {
 		When(mockExecutor.RunCommandWithVersion(
 			ctx, prjCtx, path, []string{"show", "-json", filepath.Join(path, "test-default.tfplan")}, envs, tfVersion, prjCtx.Workspace,
-		)).ThenReturn("success", errors.New("error"))
+		)).ThenReturn("err", errors.New("error"))
 
-		_, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
+		r, err := subject.Run(ctx, prjCtx, []string{}, path, envs)
 
 		Assert(t, err != nil, "error is returned")
+		Assert(t, r == "err", "returned expected result")
 
 	})
 

--- a/server/core/runtime/steps_runner.go
+++ b/server/core/runtime/steps_runner.go
@@ -51,7 +51,7 @@ func (r *stepsRunner) Run(ctx context.Context, cmdCtx command.ProjectContext, ab
 		case "plan":
 			out, err = r.PlanRunner.Run(ctx, cmdCtx, step.ExtraArgs, absPath, envs)
 		case "show":
-			_, err = r.ShowRunner.Run(ctx, cmdCtx, step.ExtraArgs, absPath, envs)
+			out, err = r.ShowRunner.Run(ctx, cmdCtx, step.ExtraArgs, absPath, envs)
 		case "policy_check":
 			out, err = r.PolicyCheckRunner.Run(ctx, cmdCtx, step.ExtraArgs, absPath, envs)
 		case "apply":


### PR DESCRIPTION
We combine std:out and std:err into one output.  For `terraform show` we don't want to necessarily return the output for it in the success case since it is so large. However, we want to return the error if it errors out.  I did something hacky here to basically just return the output when there's an error.