### PR TITLE
Add statsd custom tag separator support.

### DIFF
--- a/server/core/config/raw/metrics.go
+++ b/server/core/config/raw/metrics.go
@@ -11,8 +11,9 @@ type Metrics struct {
 }
 
 type Statsd struct {
-	Port string `yaml:"port" json:"port"`
-	Host string `yaml:"host" json:"host"`
+	Port         string `yaml:"port" json:"port"`
+	Host         string `yaml:"host" json:"host"`
+	TagSeparator string `yaml:"tag_separator" json:"tag_separator"`
 }
 
 func (s *Statsd) Validate() error {
@@ -34,8 +35,9 @@ func (m Metrics) ToValid() valid.Metrics {
 	if m.Statsd != nil {
 		return valid.Metrics{
 			Statsd: &valid.Statsd{
-				Host: m.Statsd.Host,
-				Port: m.Statsd.Port,
+				Host:         m.Statsd.Host,
+				Port:         m.Statsd.Port,
+				TagSeparator: m.Statsd.TagSeparator,
 			},
 		}
 	}

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -93,8 +93,9 @@ type Metrics struct {
 }
 
 type Statsd struct {
-	Port string
-	Host string
+	Port         string
+	Host         string
+	TagSeparator string
 }
 
 type Temporal struct {

--- a/server/metrics/scope.go
+++ b/server/metrics/scope.go
@@ -59,5 +59,14 @@ func newReporter(cfg valid.Metrics, logger logging.Logger) (tally.StatsReporter,
 		return nil, errors.Wrap(err, "initializing statsd client")
 	}
 
-	return tallystatsd.NewReporter(client, tallystatsd.Options{}), nil
+	base := tallystatsd.NewReporter(client, tallystatsd.Options{})
+
+	if statsdCfg.TagSeparator != "" {
+		return base, nil
+	}
+
+	return &pointTagReporter{
+		StatsReporter: base,
+		separator:     statsdCfg.TagSeparator,
+	}, nil
 }

--- a/server/metrics/scope.go
+++ b/server/metrics/scope.go
@@ -65,7 +65,7 @@ func newReporter(cfg valid.Metrics, logger logging.Logger) (tally.StatsReporter,
 		return base, nil
 	}
 
-	return &pointTagReporter{
+	return &customTagReporter{
 		StatsReporter: base,
 		separator:     statsdCfg.TagSeparator,
 	}, nil

--- a/server/metrics/statsd.go
+++ b/server/metrics/statsd.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"strings"
+	"time"
+
+	"github.com/uber-go/tally/v4"
+)
+
+type pointTagReporter struct {
+	tally.StatsReporter
+
+	separator string
+}
+
+// https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md#influx-statsd
+func (r *pointTagReporter) taggedName(name string, tags map[string]string) string {
+	var b strings.Builder
+	b.WriteString(name)
+	for k, v := range tags {
+		b.WriteString(r.separator)
+		b.WriteString(replaceChars(k))
+		b.WriteByte('=')
+		b.WriteString(replaceChars(v))
+	}
+	return b.String()
+}
+
+func (r *pointTagReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	r.StatsReporter.ReportCounter(r.taggedName(name, tags), nil, value)
+}
+
+func (r *pointTagReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	r.StatsReporter.ReportGauge(r.taggedName(name, tags), nil, value)
+}
+
+func (r *pointTagReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	r.StatsReporter.ReportTimer(r.taggedName(name, tags), nil, interval)
+}
+
+func (r *pointTagReporter) ReportHistogramValueSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound float64, samples int64) {
+	r.StatsReporter.ReportHistogramValueSamples(r.taggedName(name, tags), nil, buckets, bucketLowerBound, bucketUpperBound, samples)
+}
+
+func (r *pointTagReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound time.Duration, samples int64) {
+	r.StatsReporter.ReportHistogramDurationSamples(r.taggedName(name, tags), nil, buckets, bucketLowerBound, bucketUpperBound, samples)
+}
+
+// Replace problematic characters in tags.
+func replaceChars(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.', ':', '|', '-', '=':
+			b.WriteByte('_')
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}

--- a/server/metrics/statsd.go
+++ b/server/metrics/statsd.go
@@ -7,14 +7,14 @@ import (
 	"github.com/uber-go/tally/v4"
 )
 
-type pointTagReporter struct {
+type customTagReporter struct {
 	tally.StatsReporter
 
 	separator string
 }
 
 // https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md#influx-statsd
-func (r *pointTagReporter) taggedName(name string, tags map[string]string) string {
+func (r *customTagReporter) taggedName(name string, tags map[string]string) string {
 	var b strings.Builder
 	b.WriteString(name)
 	for k, v := range tags {
@@ -26,23 +26,23 @@ func (r *pointTagReporter) taggedName(name string, tags map[string]string) strin
 	return b.String()
 }
 
-func (r *pointTagReporter) ReportCounter(name string, tags map[string]string, value int64) {
+func (r *customTagReporter) ReportCounter(name string, tags map[string]string, value int64) {
 	r.StatsReporter.ReportCounter(r.taggedName(name, tags), nil, value)
 }
 
-func (r *pointTagReporter) ReportGauge(name string, tags map[string]string, value float64) {
+func (r *customTagReporter) ReportGauge(name string, tags map[string]string, value float64) {
 	r.StatsReporter.ReportGauge(r.taggedName(name, tags), nil, value)
 }
 
-func (r *pointTagReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+func (r *customTagReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
 	r.StatsReporter.ReportTimer(r.taggedName(name, tags), nil, interval)
 }
 
-func (r *pointTagReporter) ReportHistogramValueSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound float64, samples int64) {
+func (r *customTagReporter) ReportHistogramValueSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound float64, samples int64) {
 	r.StatsReporter.ReportHistogramValueSamples(r.taggedName(name, tags), nil, buckets, bucketLowerBound, bucketUpperBound, samples)
 }
 
-func (r *pointTagReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound time.Duration, samples int64) {
+func (r *customTagReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound time.Duration, samples int64) {
 	r.StatsReporter.ReportHistogramDurationSamples(r.taggedName(name, tags), nil, buckets, bucketLowerBound, bucketUpperBound, samples)
 }
 

--- a/server/metrics/statsd_internal_test.go
+++ b/server/metrics/statsd_internal_test.go
@@ -39,7 +39,7 @@ func TestPointTagReporter(t *testing.T) {
 			t.Parallel()
 
 			m := &mockReporter{}
-			p := pointTagReporter{
+			p := customTagReporter{
 				StatsReporter: m,
 				separator:     ",",
 			}

--- a/server/metrics/statsd_internal_test.go
+++ b/server/metrics/statsd_internal_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally/v4"
+)
+
+type mockReporter struct {
+	tally.StatsReporter
+
+	actualName string
+}
+
+func (m *mockReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	m.actualName = name
+}
+
+func TestPointTagReporter(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+	}{
+		{
+			name: "foo.Bar.baz",
+			tags: map[string]string{"bar": "baz", "hello": "world"},
+		},
+		{
+			name: "foo",
+			tags: map[string]string{"bar": "baz.bar.Bug", "hello": "world-ok"},
+		},
+	}
+	for idx, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			m := &mockReporter{}
+			p := pointTagReporter{
+				StatsReporter: m,
+				separator:     ",",
+			}
+			p.ReportCounter(tt.name, tt.tags, 10)
+
+			actualTags := map[string]string{}
+			for _, v := range strings.Split(m.actualName, ",")[1:] {
+				ss := strings.Split(v, "=")
+				actualTags[ss[0]] = ss[1]
+			}
+
+			sanitizedTags := map[string]string{}
+			for k, v := range tt.tags {
+				sanitizedTags[k] = replaceChars(v)
+			}
+
+			assert.Equal(t, sanitizedTags, actualTags)
+			assert.True(t, strings.HasPrefix(m.actualName, tt.name))
+		})
+	}
+}


### PR DESCRIPTION
Temporal SDK metrics are lacking tags right now internally until we add something like this.