### PR TITLE
Move job stream closing into its own activity

### DIFF
--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/neptune/logger"
 )
 
 type OutputLine struct {
@@ -69,11 +69,12 @@ func (s *StreamHandler) Handle() {
 }
 
 // Activity context since it's called from within an activity
-func (s *StreamHandler) Close(ctx context.Context, jobID string) {
+func (s *StreamHandler) Close(ctx context.Context, jobID string) error {
 	s.ReceiverRegistry.Close(ctx, jobID)
 
 	// Update job status and persist to storage if configured
 	if err := s.Store.Close(ctx, jobID, Complete); err != nil {
-		logger.Error(ctx, fmt.Sprintf("updating jobs status to complete, %v", err))
+		return errors.Wrapf(err, "closing job stream with ID: %s", jobID)
 	}
+	return nil
 }

--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -74,7 +74,7 @@ func (s *StreamHandler) Close(ctx context.Context, jobID string) error {
 
 	// Update job status and persist to storage if configured
 	if err := s.Store.Close(ctx, jobID, Complete); err != nil {
-		return errors.Wrapf(err, "closing job stream with ID: %s", jobID)
+		return errors.Wrapf(err, "closing job store for ID: %s", jobID)
 	}
 	return nil
 }

--- a/server/neptune/workflows/internal/activities/job.go
+++ b/server/neptune/workflows/internal/activities/job.go
@@ -22,7 +22,7 @@ type CloseJobRequest struct {
 func (t *jobActivities) CloseJob(ctx context.Context, request CloseJobRequest) error {
 	err := t.StreamCloser.Close(ctx, request.JobID)
 	if err != nil {
-		logger.Error(ctx, errors.Wrapf(err, "closing job with id: %s", request.JobID).Error())
+		logger.Error(ctx, errors.Wrapf(err, "closing job").Error())
 	}
 	return err
 }

--- a/server/neptune/workflows/internal/activities/job.go
+++ b/server/neptune/workflows/internal/activities/job.go
@@ -1,0 +1,28 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/logger"
+)
+
+type streamCloser interface {
+	Close(ctx context.Context, jobID string) error
+}
+
+type jobActivities struct {
+	StreamCloser streamCloser
+}
+
+type CloseJobRequest struct {
+	JobID string
+}
+
+func (t *jobActivities) CloseJob(ctx context.Context, request CloseJobRequest) error {
+	err := t.StreamCloser.Close(ctx, request.JobID)
+	if err != nil {
+		logger.Error(ctx, errors.Wrapf(err, "closing job with id: %s", request.JobID).Error())
+	}
+	return err
+}

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -50,6 +50,7 @@ type Terraform struct {
 	*workerInfoActivity
 	*notifyActivities
 	*cleanupActivities
+	*jobActivities
 }
 
 func NewTerraform(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler streamHandler) (*Terraform, error) {
@@ -92,6 +93,9 @@ func NewTerraform(config config.TerraformConfig, dataDir string, serverURL *url.
 			TerraformClient:  tfClient,
 			StreamHandler:    streamHandler,
 			DefaultTFVersion: defaultTfVersion,
+		},
+		jobActivities: &jobActivities{
+			StreamCloser: streamHandler,
 		},
 	}, nil
 }

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"path/filepath"
 	"sync"
@@ -220,7 +219,7 @@ type TerraformCloseJobRequest struct {
 func (t *terraformActivities) TerraformCloseJob(ctx context.Context, request TerraformCloseJobRequest) error {
 	err := t.StreamHandler.Close(ctx, request.JobID)
 	if err != nil {
-		logger.Error(ctx, fmt.Sprintf("closing job with id: %s", request.JobID))
+		logger.Error(ctx, errors.Wrapf(err, "closing job with id: %s", request.JobID).Error())
 	}
 	return err
 }

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -212,18 +212,6 @@ func (t *terraformActivities) TerraformApply(ctx context.Context, request Terraf
 	return TerraformApplyResponse{}, nil
 }
 
-type TerraformCloseJobRequest struct {
-	JobID string
-}
-
-func (t *terraformActivities) TerraformCloseJob(ctx context.Context, request TerraformCloseJobRequest) error {
-	err := t.StreamHandler.Close(ctx, request.JobID)
-	if err != nil {
-		logger.Error(ctx, errors.Wrapf(err, "closing job with id: %s", request.JobID).Error())
-	}
-	return err
-}
-
 func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jobID string, request *terraform.RunCommandRequest) error {
 	reader, writer := io.Pipe()
 

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
 	"sync"
@@ -221,9 +222,7 @@ type TerraformCloseJobResponse struct{}
 func (t *terraformActivities) TerraformCloseJob(ctx context.Context, request TerraformCloseJobRequest) (TerraformCloseJobResponse, error) {
 	err := t.StreamHandler.Close(ctx, request.JobID)
 	if err != nil {
-		logger.Error(ctx, "closing job", map[string]interface{}{
-			"jobId": request.JobID,
-		})
+		logger.Error(ctx, fmt.Sprintf("closing job with id: %s", request.JobID))
 	}
 	return TerraformCloseJobResponse{}, err
 }

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -217,14 +217,12 @@ type TerraformCloseJobRequest struct {
 	JobID string
 }
 
-type TerraformCloseJobResponse struct{}
-
-func (t *terraformActivities) TerraformCloseJob(ctx context.Context, request TerraformCloseJobRequest) (TerraformCloseJobResponse, error) {
+func (t *terraformActivities) TerraformCloseJob(ctx context.Context, request TerraformCloseJobRequest) error {
 	err := t.StreamHandler.Close(ctx, request.JobID)
 	if err != nil {
 		logger.Error(ctx, fmt.Sprintf("closing job with id: %s", request.JobID))
 	}
-	return TerraformCloseJobResponse{}, err
+	return err
 }
 
 func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jobID string, request *terraform.RunCommandRequest) error {

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -27,7 +27,9 @@ func (t *testStreamHandler) Stream(jobID string, msg string) {
 
 }
 
-func (t *testStreamHandler) Close(ctx context.Context, jobID string) {}
+func (t *testStreamHandler) Close(ctx context.Context, jobID string) error {
+	return nil
+}
 
 type multiCallTfClient struct {
 	clients []*testTfClient

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -153,13 +153,6 @@ func (r *jobRunner) plan(ctx *job.ExecutionContext, extraArgs []string) (activit
 		return resp, errors.Wrap(err, "running terraform plan activity")
 	}
 
-	// Close terraform job
-	// let's not fail this workfklow if closing the job fails since it's not critical to close the job for the tf workflow
-	var closeJobResp activities.TerraformCloseJobResponse
-	err = workflow.ExecuteActivity(ctx, r.Activity.TerraformCloseJob, activities.TerraformCloseJobRequest{
-		JobID: ctx.JobID,
-	}).Get(ctx, &closeJobResp)
-
 	return resp, nil
 }
 

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -182,7 +182,6 @@ func (r *jobRunner) runOptionalSteps(ctx *job.ExecutionContext, localRoot *root.
 	return nil
 }
 
-// Executes the TerraformCloseJob activity
 func (r *jobRunner) closeTerraformJob(ctx *job.ExecutionContext) {
 	var resp string
 	workflow.ExecuteActivity(ctx, r.Activity.CloseJob, activities.CloseJobRequest{

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -15,7 +15,7 @@ type terraformActivities interface {
 	TerraformInit(ctx context.Context, request activities.TerraformInitRequest) (activities.TerraformInitResponse, error)
 	TerraformPlan(ctx context.Context, request activities.TerraformPlanRequest) (activities.TerraformPlanResponse, error)
 	TerraformApply(ctx context.Context, request activities.TerraformApplyRequest) (activities.TerraformApplyResponse, error)
-	TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) (activities.TerraformCloseJobResponse, error)
+	TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) error
 }
 
 // stepRunner runs individual run steps
@@ -183,10 +183,10 @@ func (r *jobRunner) runOptionalSteps(ctx *job.ExecutionContext, localRoot *root.
 
 // Executes the TerraformCloseJob activity
 func (r *jobRunner) closeTerraformJob(ctx *job.ExecutionContext) {
-	var closeJobResp activities.TerraformCloseJobResponse
+	var resp string
 
 	// let's not fail this workfklow if closing the job fails since it's not critical to close the job for the tf workflow
 	_ = workflow.ExecuteActivity(ctx, r.Activity.TerraformCloseJob, activities.TerraformCloseJobRequest{
 		JobID: ctx.JobID,
-	}).Get(ctx, &closeJobResp)
+	}).Get(ctx, &resp)
 }

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -15,7 +15,7 @@ type terraformActivities interface {
 	TerraformInit(ctx context.Context, request activities.TerraformInitRequest) (activities.TerraformInitResponse, error)
 	TerraformPlan(ctx context.Context, request activities.TerraformPlanRequest) (activities.TerraformPlanResponse, error)
 	TerraformApply(ctx context.Context, request activities.TerraformApplyRequest) (activities.TerraformApplyResponse, error)
-	TerraformCloseJob(ctx context.Context, request activities.CloseJobRequest) error
+	CloseJob(ctx context.Context, request activities.CloseJobRequest) error
 }
 
 // stepRunner runs individual run steps
@@ -185,9 +185,7 @@ func (r *jobRunner) runOptionalSteps(ctx *job.ExecutionContext, localRoot *root.
 // Executes the TerraformCloseJob activity
 func (r *jobRunner) closeTerraformJob(ctx *job.ExecutionContext) {
 	var resp string
-
-	// let's not fail this workfklow if closing the job fails since it's not critical to close the job for the tf workflow
-	_ = workflow.ExecuteActivity(ctx, r.Activity.TerraformCloseJob, activities.CloseJobRequest{
+	workflow.ExecuteActivity(ctx, r.Activity.CloseJob, activities.CloseJobRequest{
 		JobID: ctx.JobID,
 	}).Get(ctx, &resp)
 }

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -183,8 +183,7 @@ func (r *jobRunner) runOptionalSteps(ctx *job.ExecutionContext, localRoot *root.
 }
 
 func (r *jobRunner) closeTerraformJob(ctx *job.ExecutionContext) {
-	var resp string
 	workflow.ExecuteActivity(ctx, r.Activity.CloseJob, activities.CloseJobRequest{
 		JobID: ctx.JobID,
-	}).Get(ctx, &resp)
+	}).Get(ctx, nil)
 }

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -15,7 +15,7 @@ type terraformActivities interface {
 	TerraformInit(ctx context.Context, request activities.TerraformInitRequest) (activities.TerraformInitResponse, error)
 	TerraformPlan(ctx context.Context, request activities.TerraformPlanRequest) (activities.TerraformPlanResponse, error)
 	TerraformApply(ctx context.Context, request activities.TerraformApplyRequest) (activities.TerraformApplyResponse, error)
-	TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) error
+	TerraformCloseJob(ctx context.Context, request activities.CloseJobRequest) error
 }
 
 // stepRunner runs individual run steps
@@ -186,7 +186,7 @@ func (r *jobRunner) closeTerraformJob(ctx *job.ExecutionContext) {
 	var resp string
 
 	// let's not fail this workfklow if closing the job fails since it's not critical to close the job for the tf workflow
-	_ = workflow.ExecuteActivity(ctx, r.Activity.TerraformCloseJob, activities.TerraformCloseJobRequest{
+	_ = workflow.ExecuteActivity(ctx, r.Activity.TerraformCloseJob, activities.CloseJobRequest{
 		JobID: ctx.JobID,
 	}).Get(ctx, &resp)
 }

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -277,10 +277,12 @@ func getTestRootFor(stepName string) root.Root {
 	return root.Root{
 		Name: ProjectName,
 		Path: "project",
-		Plan: job_model.Job{
-			Steps: []job_model.Step{
-				{
-					StepName: stepName,
+		Plan: job_model.Plan{
+			Terraform: job_model.Terraform{
+				Steps: []job_model.Step{
+					{
+						StepName: stepName,
+					},
 				},
 			},
 		},

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -2,7 +2,6 @@ package job_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -158,46 +157,6 @@ func TestJobRunner_Plan(t *testing.T) {
 		err := env.GetWorkflowResult(&resp)
 		assert.NoError(t, err)
 	})
-
-	t.Run("should not fail plan operation when close job fails", func(t *testing.T) {
-		ts := testsuite.WorkflowTestSuite{}
-		env := ts.NewTestWorkflowEnvironment()
-		testTerraformActivity := &testTerraformActivity{
-			t: t,
-			plan: struct {
-				req  activities.TerraformPlanRequest
-				resp activities.TerraformPlanResponse
-				err  error
-			}{
-				req: activities.TerraformPlanRequest{
-					JobID: JobID,
-					Args:  []terraform_model.Argument{},
-					Envs:  map[string]string{},
-					Path:  ProjectPath,
-				},
-			},
-			close: struct {
-				req activities.CloseJobRequest
-				err error
-			}{
-				req: activities.CloseJobRequest{
-					JobID: JobID,
-				},
-				err: errors.New("error"),
-			},
-		}
-		env.RegisterActivity(testTerraformActivity)
-		env.RegisterWorkflow(testJobPlanWorkflow)
-
-		env.ExecuteWorkflow(testJobPlanWorkflow, terraform.Request{
-			Root: getTestRootFor("plan"),
-			Repo: repo,
-		})
-
-		var resp activities.TerraformPlanResponse
-		err := env.GetWorkflowResult(&resp)
-		assert.NoError(t, err)
-	})
 }
 
 func TestJobRunner_Apply(t *testing.T) {
@@ -225,42 +184,6 @@ func TestJobRunner_Apply(t *testing.T) {
 				req: activities.CloseJobRequest{
 					JobID: JobID,
 				},
-			},
-		}
-		env.RegisterActivity(testTerraformActivity)
-		env.RegisterWorkflow(testJobApplyWorkflow)
-
-		env.ExecuteWorkflow(testJobApplyWorkflow, terraform.Request{
-			Root: getTestRootFor("apply"),
-			Repo: repo,
-		})
-	})
-
-	t.Run("should not fail apply operation when close job fails", func(t *testing.T) {
-		ts := testsuite.WorkflowTestSuite{}
-		env := ts.NewTestWorkflowEnvironment()
-		testTerraformActivity := &testTerraformActivity{
-			t: t,
-			apply: struct {
-				req  activities.TerraformApplyRequest
-				resp activities.TerraformApplyResponse
-				err  error
-			}{
-				req: activities.TerraformApplyRequest{
-					JobID: JobID,
-					Args:  []terraform_model.Argument{},
-					Envs:  map[string]string{},
-					Path:  ProjectPath,
-				},
-			},
-			close: struct {
-				req activities.CloseJobRequest
-				err error
-			}{
-				req: activities.CloseJobRequest{
-					JobID: JobID,
-				},
-				err: errors.New("error"),
 			},
 		}
 		env.RegisterActivity(testTerraformActivity)

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -47,7 +47,7 @@ type testTerraformActivity struct {
 		err  error
 	}
 	close struct {
-		req activities.TerraformCloseJobRequest
+		req activities.CloseJobRequest
 		err error
 	}
 }
@@ -66,7 +66,7 @@ func (t *testTerraformActivity) TerraformApply(ctx context.Context, request acti
 	return t.apply.resp, t.apply.err
 }
 
-func (t *testTerraformActivity) TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) error {
+func (t *testTerraformActivity) CloseJob(ctx context.Context, request activities.CloseJobRequest) error {
 	assert.Equal(t.t, t.close.req, request)
 	return t.close.err
 }
@@ -138,10 +138,10 @@ func TestJobRunner_Plan(t *testing.T) {
 				},
 			},
 			close: struct {
-				req activities.TerraformCloseJobRequest
+				req activities.CloseJobRequest
 				err error
 			}{
-				req: activities.TerraformCloseJobRequest{
+				req: activities.CloseJobRequest{
 					JobID: JobID,
 				},
 			},
@@ -177,10 +177,10 @@ func TestJobRunner_Plan(t *testing.T) {
 				},
 			},
 			close: struct {
-				req activities.TerraformCloseJobRequest
+				req activities.CloseJobRequest
 				err error
 			}{
-				req: activities.TerraformCloseJobRequest{
+				req: activities.CloseJobRequest{
 					JobID: JobID,
 				},
 				err: errors.New("error"),
@@ -219,10 +219,10 @@ func TestJobRunner_Apply(t *testing.T) {
 				},
 			},
 			close: struct {
-				req activities.TerraformCloseJobRequest
+				req activities.CloseJobRequest
 				err error
 			}{
-				req: activities.TerraformCloseJobRequest{
+				req: activities.CloseJobRequest{
 					JobID: JobID,
 				},
 			},
@@ -254,10 +254,10 @@ func TestJobRunner_Apply(t *testing.T) {
 				},
 			},
 			close: struct {
-				req activities.TerraformCloseJobRequest
+				req activities.CloseJobRequest
 				err error
 			}{
-				req: activities.TerraformCloseJobRequest{
+				req: activities.CloseJobRequest{
 					JobID: JobID,
 				},
 				err: errors.New("error"),

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -47,9 +47,8 @@ type testTerraformActivity struct {
 		err  error
 	}
 	close struct {
-		req  activities.TerraformCloseJobRequest
-		resp activities.TerraformCloseJobResponse
-		err  error
+		req activities.TerraformCloseJobRequest
+		err error
 	}
 }
 
@@ -67,9 +66,9 @@ func (t *testTerraformActivity) TerraformApply(ctx context.Context, request acti
 	return t.apply.resp, t.apply.err
 }
 
-func (t *testTerraformActivity) TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) (activities.TerraformCloseJobResponse, error) {
+func (t *testTerraformActivity) TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) error {
 	assert.Equal(t.t, t.close.req, request)
-	return t.close.resp, t.close.err
+	return t.close.err
 }
 
 // test workflow that runs the plan job
@@ -139,9 +138,8 @@ func TestJobRunner_Plan(t *testing.T) {
 				},
 			},
 			close: struct {
-				req  activities.TerraformCloseJobRequest
-				resp activities.TerraformCloseJobResponse
-				err  error
+				req activities.TerraformCloseJobRequest
+				err error
 			}{
 				req: activities.TerraformCloseJobRequest{
 					JobID: JobID,
@@ -179,9 +177,8 @@ func TestJobRunner_Plan(t *testing.T) {
 				},
 			},
 			close: struct {
-				req  activities.TerraformCloseJobRequest
-				resp activities.TerraformCloseJobResponse
-				err  error
+				req activities.TerraformCloseJobRequest
+				err error
 			}{
 				req: activities.TerraformCloseJobRequest{
 					JobID: JobID,
@@ -222,9 +219,8 @@ func TestJobRunner_Apply(t *testing.T) {
 				},
 			},
 			close: struct {
-				req  activities.TerraformCloseJobRequest
-				resp activities.TerraformCloseJobResponse
-				err  error
+				req activities.TerraformCloseJobRequest
+				err error
 			}{
 				req: activities.TerraformCloseJobRequest{
 					JobID: JobID,
@@ -258,9 +254,8 @@ func TestJobRunner_Apply(t *testing.T) {
 				},
 			},
 			close: struct {
-				req  activities.TerraformCloseJobRequest
-				resp activities.TerraformCloseJobResponse
-				err  error
+				req activities.TerraformCloseJobRequest
+				err error
 			}{
 				req: activities.TerraformCloseJobRequest{
 					JobID: JobID,

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -1,0 +1,335 @@
+package job_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	terraform_model "github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	job_model "github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+const JobID = "1234"
+
+type testTerraformActivity struct {
+	t    *testing.T
+	plan struct {
+		req  activities.TerraformPlanRequest
+		resp activities.TerraformPlanResponse
+		err  error
+	}
+	apply struct {
+		req  activities.TerraformApplyRequest
+		resp activities.TerraformApplyResponse
+		err  error
+	}
+	close struct {
+		req  activities.TerraformCloseJobRequest
+		resp activities.TerraformCloseJobResponse
+		err  error
+	}
+}
+
+func (t *testTerraformActivity) TerraformInit(ctx context.Context, request activities.TerraformInitRequest) (activities.TerraformInitResponse, error) {
+	return activities.TerraformInitResponse{}, nil
+}
+
+func (t *testTerraformActivity) TerraformPlan(ctx context.Context, request activities.TerraformPlanRequest) (activities.TerraformPlanResponse, error) {
+	assert.Equal(t.t, t.plan.req, request)
+	return t.plan.resp, t.plan.err
+}
+
+func (t *testTerraformActivity) TerraformApply(ctx context.Context, request activities.TerraformApplyRequest) (activities.TerraformApplyResponse, error) {
+	assert.Equal(t.t, t.apply.req, request)
+	return t.apply.resp, t.apply.err
+}
+
+func (t *testTerraformActivity) TerraformCloseJob(ctx context.Context, request activities.TerraformCloseJobRequest) (activities.TerraformCloseJobResponse, error) {
+	assert.Equal(t.t, t.close.req, request)
+	return t.close.resp, t.close.err
+}
+
+func testJobWorkflow(ctx workflow.Context, r terraform.Request) (activities.TerraformPlanResponse, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 100 * time.Second,
+	})
+
+	localRoot := root.LocalRoot{
+		Root: r.Root,
+		Repo: r.Repo,
+		Path: ProjectPath,
+	}
+
+	jobExecutionCtx := &job_model.ExecutionContext{
+		Context:   ctx,
+		Path:      ProjectPath,
+		Envs:      map[string]string{},
+		TfVersion: localRoot.Root.TfVersion,
+	}
+
+	var a *testTerraformActivity
+	jobRunner := job.NewRunner(&job.CmdStepRunner{}, &job.EnvStepRunner{}, a)
+	return jobRunner.Plan(jobExecutionCtx, &localRoot, JobID)
+}
+
+func TestJobRunner_Plan(t *testing.T) {
+	t.Run("should close job after plan operation", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+		testTerraformActivity := &testTerraformActivity{
+			t: t,
+			plan: struct {
+				req  activities.TerraformPlanRequest
+				resp activities.TerraformPlanResponse
+				err  error
+			}{
+				req: activities.TerraformPlanRequest{
+					JobID: JobID,
+					Args:  []terraform_model.Argument{},
+					Envs:  map[string]string{},
+					Path:  ProjectPath,
+				},
+			},
+			close: struct {
+				req  activities.TerraformCloseJobRequest
+				resp activities.TerraformCloseJobResponse
+				err  error
+			}{
+				req: activities.TerraformCloseJobRequest{
+					JobID: JobID,
+				},
+			},
+		}
+		env.RegisterActivity(testTerraformActivity)
+		env.RegisterWorkflow(testJobWorkflow)
+
+		env.ExecuteWorkflow(testJobWorkflow, terraform.Request{
+			Root: root.Root{
+				Name: ProjectName,
+				Path: "project",
+				Plan: job_model.Job{
+					Steps: []job_model.Step{
+						{
+							StepName: "plan",
+						},
+					},
+				},
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+				HeadCommit: github.Commit{
+					Ref: github.Ref{
+						Name: RefName,
+						Type: RefType,
+					},
+					Author: github.User{
+						Username: UserName,
+					},
+				},
+			},
+		})
+
+		var resp activities.TerraformPlanResponse
+		err := env.GetWorkflowResult(&resp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not fail plan operation when close job fails", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+		testTerraformActivity := &testTerraformActivity{
+			t: t,
+			plan: struct {
+				req  activities.TerraformPlanRequest
+				resp activities.TerraformPlanResponse
+				err  error
+			}{
+				req: activities.TerraformPlanRequest{
+					JobID: JobID,
+					Args:  []terraform_model.Argument{},
+					Envs:  map[string]string{},
+					Path:  ProjectPath,
+				},
+			},
+			close: struct {
+				req  activities.TerraformCloseJobRequest
+				resp activities.TerraformCloseJobResponse
+				err  error
+			}{
+				req: activities.TerraformCloseJobRequest{
+					JobID: JobID,
+				},
+				err: errors.New("error"),
+			},
+		}
+		env.RegisterActivity(testTerraformActivity)
+		env.RegisterWorkflow(testJobWorkflow)
+
+		env.ExecuteWorkflow(testJobWorkflow, terraform.Request{
+			Root: root.Root{
+				Name: ProjectName,
+				Path: "project",
+				Plan: job_model.Job{
+					Steps: []job_model.Step{
+						{
+							StepName: "plan",
+						},
+					},
+				},
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+				HeadCommit: github.Commit{
+					Ref: github.Ref{
+						Name: RefName,
+						Type: RefType,
+					},
+					Author: github.User{
+						Username: UserName,
+					},
+				},
+			},
+		})
+
+		var resp activities.TerraformPlanResponse
+		err := env.GetWorkflowResult(&resp)
+		assert.NoError(t, err)
+	})
+}
+
+func TestJobRunner_Apply(t *testing.T) {
+	t.Run("should close job after apply operation", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+		testTerraformActivity := &testTerraformActivity{
+			t: t,
+			apply: struct {
+				req  activities.TerraformApplyRequest
+				resp activities.TerraformApplyResponse
+				err  error
+			}{
+				req: activities.TerraformApplyRequest{
+					JobID: JobID,
+					Args:  []terraform_model.Argument{},
+					Envs:  map[string]string{},
+					Path:  ProjectPath,
+				},
+			},
+			close: struct {
+				req  activities.TerraformCloseJobRequest
+				resp activities.TerraformCloseJobResponse
+				err  error
+			}{
+				req: activities.TerraformCloseJobRequest{
+					JobID: JobID,
+				},
+			},
+		}
+		env.RegisterActivity(testTerraformActivity)
+		env.RegisterWorkflow(testJobWorkflow)
+
+		env.ExecuteWorkflow(testJobWorkflow, terraform.Request{
+			Root: root.Root{
+				Name: ProjectName,
+				Path: "project",
+				Plan: job_model.Job{
+					Steps: []job_model.Step{
+						{
+							StepName: "apply",
+						},
+					},
+				},
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+				HeadCommit: github.Commit{
+					Ref: github.Ref{
+						Name: RefName,
+						Type: RefType,
+					},
+					Author: github.User{
+						Username: UserName,
+					},
+				},
+			},
+		})
+
+		var resp activities.TerraformPlanResponse
+		err := env.GetWorkflowResult(&resp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not fail apply operation when close job fails", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+		testTerraformActivity := &testTerraformActivity{
+			t: t,
+			apply: struct {
+				req  activities.TerraformApplyRequest
+				resp activities.TerraformApplyResponse
+				err  error
+			}{
+				req: activities.TerraformApplyRequest{
+					JobID: JobID,
+					Args:  []terraform_model.Argument{},
+					Envs:  map[string]string{},
+					Path:  ProjectPath,
+				},
+			},
+			close: struct {
+				req  activities.TerraformCloseJobRequest
+				resp activities.TerraformCloseJobResponse
+				err  error
+			}{
+				req: activities.TerraformCloseJobRequest{
+					JobID: JobID,
+				},
+			},
+		}
+		env.RegisterActivity(testTerraformActivity)
+		env.RegisterWorkflow(testJobWorkflow)
+
+		env.ExecuteWorkflow(testJobWorkflow, terraform.Request{
+			Root: root.Root{
+				Name: ProjectName,
+				Path: "project",
+				Plan: job_model.Job{
+					Steps: []job_model.Step{
+						{
+							StepName: "apply",
+						},
+					},
+				},
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+				HeadCommit: github.Commit{
+					Ref: github.Ref{
+						Name: RefName,
+						Type: RefType,
+					},
+					Author: github.User{
+						Username: UserName,
+					},
+				},
+			},
+		})
+
+		var resp activities.TerraformPlanResponse
+		err := env.GetWorkflowResult(&resp)
+		assert.NoError(t, err)
+	})
+}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -212,7 +212,6 @@ func (r *Runner) Run(ctx workflow.Context) error {
 	}
 
 	planResponse, err := r.Plan(ctx, root, response.ServerURL)
-
 	if err != nil {
 		return errors.Wrap(err, "running plan job")
 	}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -212,6 +212,7 @@ func (r *Runner) Run(ctx workflow.Context) error {
 	}
 
 	planResponse, err := r.Plan(ctx, root, response.ServerURL)
+
 	if err != nil {
 		return errors.Wrap(err, "running plan job")
 	}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -98,6 +98,7 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			&runner.EnvStepRunner{
 				CmdStepRunner: cmdStepRunner,
 			},
+			ta,
 		),
 		RootFetcher: &RootFetcher{
 			Request: request,
@@ -211,7 +212,7 @@ func (r *Runner) Run(ctx workflow.Context) error {
 	}
 
 	planResponse, err := r.Plan(ctx, root, response.ServerURL)
-	
+
 	if err != nil {
 		return errors.Wrap(err, "running plan job")
 	}


### PR DESCRIPTION
In this PR, we remove job stream closing from the terraform plan and apply activity and move it into its own activity. As a result, we can move this logic one step above in the job runner which closes the job stream after running the plan and apply jobs.  

TODO:

- [x] Add tests