### PR TITLE
Update temporal client metrics scope.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/vcs/bitbucketcloud"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/gateway"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker"
 	neptune "github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
@@ -505,10 +504,6 @@ func (t *TemporalWorker) NewServer(userConfig server.UserConfig, config server.C
 			return nil, errors.Wrapf(err, "parsing %s file", userConfig.RepoConfig)
 		}
 	}
-	scope, closer, err := metrics.NewScope(globalCfg.Metrics, ctxLogger, userConfig.StatsNamespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create metrics scope")
-	}
 	parsedURL, err := server.ParseAtlantisURL(userConfig.AtlantisURL)
 	if err != nil {
 		return nil, errors.Wrapf(err,
@@ -538,13 +533,13 @@ func (t *TemporalWorker) NewServer(userConfig server.UserConfig, config server.C
 			DownloadURL:            userConfig.TFDownloadURL,
 			LogFilters:             globalCfg.TerraformLogFilter,
 		},
-		JobCfg:      globalCfg.Jobs,
-		DataDir:     userConfig.DataDir,
-		TemporalCfg: globalCfg.Temporal,
-		App:         appConfig,
-		CtxLogger:   ctxLogger,
-		Scope:       scope,
-		StatsCloser: closer,
+		JobCfg:         globalCfg.Jobs,
+		DataDir:        userConfig.DataDir,
+		TemporalCfg:    globalCfg.Temporal,
+		App:            appConfig,
+		CtxLogger:      ctxLogger,
+		StatsNamespace: userConfig.StatsNamespace,
+		Metrics:        globalCfg.Metrics,
 	}
 	return temporalworker.NewServer(cfg)
 }

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -432,6 +432,8 @@ func (s *Server) Shutdown() error {
 		return cli.NewExitError(fmt.Sprintf("while shutting down: %s", err), 1)
 	}
 
+	s.TemporalClient.Close()
+
 	return nil
 }
 

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -112,7 +112,13 @@ func NewServer(config Config) (*Server, error) {
 		}
 	}
 
-	statsScope, closer, err := metrics.NewScope(globalCfg.Metrics, ctxLogger, config.StatsNamespace)
+	statsReporter, err := metrics.NewReporter(globalCfg.Metrics, ctxLogger)
+
+	if err != nil {
+		return nil, err
+	}
+
+	statsScope, closer := metrics.NewScopeWithReporter(globalCfg.Metrics, ctxLogger, config.StatsNamespace, statsReporter)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +277,11 @@ func NewServer(config Config) (*Server, error) {
 		RepoConverter: repoConverter,
 	}
 
-	temporalClient, err := temporal.NewClient(statsScope, ctxLogger, globalCfg.Temporal)
+	opts := &temporal.Options{
+		StatsReporter: statsReporter,
+	}
+	opts = opts.WithClientInterceptors(temporal.NewMetricsInterceptor(statsScope))
+	temporalClient, err := temporal.NewClient(ctxLogger, globalCfg.Temporal, opts)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing temporal client")

--- a/server/neptune/temporal/client.go
+++ b/server/neptune/temporal/client.go
@@ -43,7 +43,6 @@ func NewClient(logger logur.Logger, cfg valid.Temporal, options *Options) (clien
 		Interceptors:       options.Interceptors,
 	}
 
-	// default to app scope unless specified otherwise
 	var clientScope tally.Scope
 	var clientScopeCloser io.Closer
 	if options.StatsReporter != nil {
@@ -51,9 +50,8 @@ func NewClient(logger logur.Logger, cfg valid.Temporal, options *Options) (clien
 			Prefix:   StatsNamespace,
 			Reporter: options.StatsReporter,
 		}, time.Second)
+		opts.MetricsHandler = temporaltally.NewMetricsHandler(clientScope)
 	}
-
-	opts.MetricsHandler = temporaltally.NewMetricsHandler(clientScope)
 
 	if cfg.UseSystemCACert {
 		certs, err := x509.SystemCertPool()

--- a/server/neptune/temporal/client.go
+++ b/server/neptune/temporal/client.go
@@ -1,25 +1,59 @@
 package temporal
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/uber-go/tally/v4"
 	"go.temporal.io/sdk/client"
 	temporaltally "go.temporal.io/sdk/contrib/tally"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/workflow"
 	"logur.dev/logur"
 )
 
-func NewClient(scope tally.Scope, logger logur.Logger, cfg valid.Temporal) (client.Client, error) {
+const StatsNamespace = "temporalclient"
+
+type Options struct {
+	Interceptors  []interceptor.ClientInterceptor
+	StatsReporter tally.StatsReporter
+}
+
+func (o *Options) WithClientInterceptors(i ...interceptor.ClientInterceptor) *Options {
+	o.Interceptors = i
+	return o
+}
+
+func (o *Options) WithStatsReporter(reporter tally.StatsReporter) *Options {
+	o.StatsReporter = reporter
+	return o
+}
+
+func NewClient(logger logur.Logger, cfg valid.Temporal, options *Options) (client.Client, error) {
 	opts := client.Options{
 		Namespace:          cfg.Namespace,
-		MetricsHandler:     temporaltally.NewMetricsHandler(scope),
 		Logger:             logur.LoggerToKV(logger),
 		ContextPropagators: []workflow.ContextPropagator{&ctxPropagator{}},
+		Interceptors:       options.Interceptors,
 	}
+
+	// default to app scope unless specified otherwise
+	var clientScope tally.Scope
+	var clientScopeCloser io.Closer
+	if options.StatsReporter != nil {
+		clientScope, clientScopeCloser = tally.NewRootScope(tally.ScopeOptions{
+			Prefix:   StatsNamespace,
+			Reporter: options.StatsReporter,
+		}, time.Second)
+	}
+
+	opts.MetricsHandler = temporaltally.NewMetricsHandler(clientScope)
 
 	if cfg.UseSystemCACert {
 		certs, err := x509.SystemCertPool()
@@ -39,5 +73,154 @@ func NewClient(scope tally.Scope, logger logur.Logger, cfg valid.Temporal) (clie
 
 	}
 
-	return client.Dial(opts)
+	client, err := client.Dial(opts)
+	if err != nil {
+		return client, err
+	}
+
+	return &CustomClosingClient{
+		Client:      client,
+		statsCloser: clientScopeCloser,
+	}, nil
+}
+
+type CustomClosingClient struct {
+	client.Client
+	statsCloser io.Closer
+}
+
+func (c *CustomClosingClient) Close() {
+	c.Client.Close()
+
+	if c.statsCloser != nil {
+		c.statsCloser.Close()
+	}
+}
+
+func NewMetricsInterceptor(scope tally.Scope) interceptor.ClientInterceptor {
+	return &clientMetricsInterceptor{
+		scope: scope,
+	}
+}
+
+type clientMetricsInterceptor struct {
+	scope tally.Scope
+	// according to docs we should be embedding this for future changes
+	interceptor.ClientInterceptorBase
+}
+
+func (i *clientMetricsInterceptor) InterceptClient(
+	next interceptor.ClientOutboundInterceptor,
+) interceptor.ClientOutboundInterceptor {
+
+	return &clientMetricsOutboundInterceptor{
+		scope: i.scope,
+		ClientOutboundInterceptorBase: interceptor.ClientOutboundInterceptorBase{
+			Next: next,
+		},
+	}
+
+}
+
+type clientMetricsOutboundInterceptor struct {
+	scope tally.Scope
+	// according to docs we should be embedding this for future changes
+	interceptor.ClientOutboundInterceptorBase
+}
+
+func (i *clientMetricsOutboundInterceptor) ExecuteWorkflow(ctx context.Context, in *interceptor.ClientExecuteWorkflowInput) (client.WorkflowRun, error) {
+	s := i.scope.SubScope("execute_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	run, err := i.ClientOutboundInterceptorBase.Next.ExecuteWorkflow(ctx, in)
+
+	if err != nil {
+		s.Counter("error").Inc(1)
+		return run, err
+	}
+
+	s.Counter("success").Inc(1)
+	return run, err
+
+}
+
+func (i *clientMetricsOutboundInterceptor) SignalWorkflow(ctx context.Context, in *interceptor.ClientSignalWorkflowInput) error {
+	s := i.scope.SubScope("signal_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	if err := i.ClientOutboundInterceptorBase.Next.SignalWorkflow(ctx, in); err != nil {
+		s.Counter("error").Inc(1)
+		return err
+	}
+
+	s.Counter("success").Inc(1)
+	return nil
+}
+
+func (i *clientMetricsOutboundInterceptor) SignalWithStartWorkflow(ctx context.Context, in *interceptor.ClientSignalWithStartWorkflowInput) (client.WorkflowRun, error) {
+	s := i.scope.SubScope("signal_with_start_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	run, err := i.ClientOutboundInterceptorBase.Next.SignalWithStartWorkflow(ctx, in)
+
+	if err != nil {
+		s.Counter("error").Inc(1)
+		return run, err
+	}
+
+	s.Counter("success").Inc(1)
+	return run, err
+}
+
+func (i *clientMetricsOutboundInterceptor) CancelWorkflow(ctx context.Context, in *interceptor.ClientCancelWorkflowInput) error {
+	s := i.scope.SubScope("cancel_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	if err := i.ClientOutboundInterceptorBase.Next.CancelWorkflow(ctx, in); err != nil {
+		s.Counter("error").Inc(1)
+		return err
+	}
+
+	s.Counter("success").Inc(1)
+	return nil
+}
+
+func (i *clientMetricsOutboundInterceptor) TerminateWorkflow(ctx context.Context, in *interceptor.ClientTerminateWorkflowInput) error {
+	s := i.scope.SubScope("terminate_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	if err := i.ClientOutboundInterceptorBase.Next.TerminateWorkflow(ctx, in); err != nil {
+		s.Counter("error").Inc(1)
+		return err
+	}
+
+	s.Counter("success").Inc(1)
+	return nil
+}
+
+func (i *clientMetricsOutboundInterceptor) QueryWorkflow(ctx context.Context, in *interceptor.ClientQueryWorkflowInput) (converter.EncodedValue, error) {
+	s := i.scope.SubScope("query_workflow")
+
+	timer := s.Timer("latency").Start()
+	defer timer.Stop()
+
+	val, err := i.ClientOutboundInterceptorBase.Next.QueryWorkflow(ctx, in)
+
+	if err != nil {
+		s.Counter("error").Inc(1)
+		return val, err
+	}
+
+	s.Counter("success").Inc(1)
+	return val, err
 }

--- a/server/neptune/temporalworker/config/config.go
+++ b/server/neptune/temporalworker/config/config.go
@@ -1,13 +1,11 @@
 package config
 
 import (
-	"io"
 	"net/url"
 
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/uber-go/tally/v4"
 )
 
 type AuthConfig struct {
@@ -30,15 +28,16 @@ type TerraformConfig struct {
 
 // Config is TemporalWorker specific user config
 type Config struct {
-	AuthCfg      AuthConfig
-	ServerCfg    ServerConfig
-	TemporalCfg  valid.Temporal
-	TerraformCfg TerraformConfig
-	JobCfg       valid.Jobs
+	AuthCfg        AuthConfig
+	ServerCfg      ServerConfig
+	TemporalCfg    valid.Temporal
+	TerraformCfg   TerraformConfig
+	JobCfg         valid.Jobs
+	Metrics        valid.Metrics
+	//TODO: combine this with above
+	StatsNamespace string
 
 	DataDir     string
 	CtxLogger   logging.Logger
-	Scope       tally.Scope
 	App         githubapp.Config
-	StatsCloser io.Closer
 }

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/metrics"
 	neptune_http "github.com/runatlantis/atlantis/server/neptune/http"
 	"github.com/runatlantis/atlantis/server/neptune/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
@@ -53,8 +54,19 @@ type Server struct {
 }
 
 func NewServer(config *config.Config) (*Server, error) {
+	statsReporter, err := metrics.NewReporter(config.Metrics, config.CtxLogger)
+
+	if err != nil {
+		return nil, err
+	}
+
+	scope, statsCloser := metrics.NewScopeWithReporter(config.Metrics, config.CtxLogger, config.StatsNamespace, statsReporter)
+	if err != nil {
+		return nil, err
+	}
+
 	// Build dependencies required for output handler and jobs controller
-	jobStore, err := job.NewStorageBackedStore(config.JobCfg, config.CtxLogger, config.Scope)
+	jobStore, err := job.NewStorageBackedStore(config.JobCfg, config.CtxLogger, scope)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing job store")
 	}
@@ -62,10 +74,14 @@ func NewServer(config *config.Config) (*Server, error) {
 
 	// terraform job output handler
 	jobStreamHandler := job.NewStreamHandler(jobStore, receiverRegistry, config.TerraformCfg.LogFilters, config.CtxLogger)
-	jobsController := controllers.NewJobsController(jobStore, receiverRegistry, config.ServerCfg, config.Scope, config.CtxLogger)
+	jobsController := controllers.NewJobsController(jobStore, receiverRegistry, config.ServerCfg, scope, config.CtxLogger)
 
 	// temporal client + worker initialization
-	temporalClient, err := temporal.NewClient(config.Scope, config.CtxLogger, config.TemporalCfg)
+	opts := &temporal.Options{
+		StatsReporter: statsReporter,
+	}
+	opts = opts.WithClientInterceptors(temporal.NewMetricsInterceptor(scope))
+	temporalClient, err := temporal.NewClient(config.CtxLogger, config.TemporalCfg, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing temporal client")
 	}
@@ -92,7 +108,7 @@ func NewServer(config *config.Config) (*Server, error) {
 
 	deployActivities, err := workflows.NewDeployActivities(
 		config.App,
-		config.Scope.SubScope("deploy"),
+		scope.SubScope("deploy"),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing deploy activities")
@@ -110,7 +126,7 @@ func NewServer(config *config.Config) (*Server, error) {
 
 	githubActivities, err := workflows.NewGithubActivities(
 		config.App,
-		config.Scope.SubScope("app"),
+		scope.SubScope("app"),
 		config.DataDir,
 	)
 	if err != nil {
@@ -121,8 +137,8 @@ func NewServer(config *config.Config) (*Server, error) {
 		Logger:              config.CtxLogger,
 		HttpServerProxy:     httpServerProxy,
 		Port:                config.ServerCfg.Port,
-		StatsScope:          config.Scope,
-		StatsCloser:         config.StatsCloser,
+		StatsScope:          scope,
+		StatsCloser:         statsCloser,
 		TemporalClient:      temporalClient,
 		JobStreamHandler:    jobStreamHandler,
 		DeployActivities:    deployActivities,

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -204,6 +204,9 @@ func (s Server) Start() error {
 	if err := s.HttpServerProxy.Shutdown(ctx); err != nil {
 		return cli.NewExitError(fmt.Sprintf("while shutting down: %s", err), 1)
 	}
+
+	s.TemporalClient.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
This PR does a few things:
* Creates a custom metrics interceptor for each temporal client interface method (under our app stats scope)
* Modifies the temporal clients scope to be a generic `temporalclient`. The idea here is that this allows us to define a generic dashboard for all clients. The only thing that will differ is what namespace is used which is available in the metrics themselves.
* This also slightly changes how our scopes are defined in order to pass the reporter up the chain.
* Finally this adds support for closing the client which was missing before.