### PR TITLE
Neptune force applies pt. 1

### DIFF
--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -18,6 +18,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/runatlantis/atlantis/server/vcs"
 	"net/url"
 	paths "path"
 	"regexp"
@@ -186,6 +187,7 @@ type PullRequest struct {
 	ClosedAt time.Time
 	// CreatedAt is the time the PR was created.
 	CreatedAt time.Time
+	HeadRef   vcs.Ref
 }
 
 type PullRequestState int

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -18,7 +18,6 @@ package models
 
 import (
 	"fmt"
-	"github.com/runatlantis/atlantis/server/vcs"
 	"net/url"
 	paths "path"
 	"regexp"
@@ -26,6 +25,7 @@ import (
 	"time"
 
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/vcs"
 
 	"github.com/pkg/errors"
 )

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -60,20 +60,20 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on master.
+	// Add a commit to branch 'branch' that's not on main.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
 	runCmd(t, repoDir, "git", "add", "branch-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 	branchCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
-	// Now switch back to master and advance the master branch by another
+	// Now switch back to main and advance the main branch by another
 	// commit.
-	runCmd(t, repoDir, "git", "checkout", "master")
-	runCmd(t, repoDir, "touch", "master-file")
-	runCmd(t, repoDir, "git", "add", "master-file")
-	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
-	masterCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-file")
+	runCmd(t, repoDir, "git", "add", "main-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
+	mainCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
 	// Finally, perform a merge in another branch ourselves, just so we know
 	// what the final state of the repo should be.
@@ -99,7 +99,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   NewBaseRepo(),
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -107,7 +107,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	// Check the commits.
 	actBaseCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD~1")
 	actHeadCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD^2")
-	Equals(t, masterCommit, actBaseCommit)
+	Equals(t, mainCommit, actBaseCommit)
 	Equals(t, branchCommit, actHeadCommit)
 
 	// Use ls to verify the repo looks good.
@@ -122,17 +122,17 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on master.
+	// Add a commit to branch 'branch' that's not on main.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
 	runCmd(t, repoDir, "git", "add", "branch-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
-	// Now switch back to master and advance the master branch by another commit.
-	runCmd(t, repoDir, "git", "checkout", "master")
-	runCmd(t, repoDir, "touch", "master-file")
-	runCmd(t, repoDir, "git", "add", "master-file")
-	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
+	// Now switch back to main and advance the main branch by another commit.
+	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "touch", "main-file")
+	runCmd(t, repoDir, "git", "add", "main-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
 
 	// Run the clone for the first time.
 	dataDir, cleanup2 := TempDir(t)
@@ -154,7 +154,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -166,7 +166,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -183,7 +183,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on master.
+	// Add a commit to branch 'branch' that's not on main.
 	// This will result in a fast-forwardable merge.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
@@ -210,7 +210,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -222,7 +222,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -238,15 +238,15 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on master.
+	// Add a commit to branch 'branch' that's not on main.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "sh", "-c", "echo hi >> file")
 	runCmd(t, repoDir, "git", "add", "file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
-	// Add a new commit to master that will cause a conflict if branch was
+	// Add a new commit to main that will cause a conflict if branch was
 	// merged.
-	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "git", "checkout", "main")
 	runCmd(t, repoDir, "sh", "-c", "echo conflict >> file")
 	runCmd(t, repoDir, "git", "add", "file")
 	runCmd(t, repoDir, "git", "commit", "-m", "commit")
@@ -271,7 +271,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	_, _, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 
 	ErrContains(t, "running git merge -q --no-ff -m atlantis-merge FETCH_HEAD", err)
@@ -355,7 +355,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 
 // Test that if the branch we're merging into has diverged and we're using
 // checkout-strategy=merge, we warn the user (see #804).
-func TestClone_MasterHasDiverged(t *testing.T) {
+func TestClone_MainHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
@@ -369,7 +369,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	// Atlantis checkout first PR.
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
-	runCmd(t, firstPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
+	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
 	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -377,7 +377,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
-	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "git", "checkout", "main")
 	runCmd(t, repoDir, "git", "checkout", "-b", "second-pr")
 	runCmd(t, repoDir, "touch", "file2")
 	runCmd(t, repoDir, "git", "add", "file2")
@@ -386,7 +386,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	// Atlantis checkout second PR.
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
-	runCmd(t, secondPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
+	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
 	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -394,13 +394,13 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
-	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "git", "checkout", "main")
 	runCmd(t, repoDir, "git", "merge", "first-pr")
 
 	baseRepo := NewBaseRepo()
 	repoPath := fmt.Sprintf("repos/%s/0/", baseRepo.FullName)
 
-	// Copy the second-pr repo to our data dir which has diverged remote master
+	// Copy the second-pr repo to our data dir which has diverged remote main
 	runCmd(t, repoDir, "mkdir", "-p", repoPath)
 	runCmd(t, repoDir, "cp", "-R", secondPRDir, repoPath+"default")
 
@@ -417,7 +417,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{CloneURL: repoDir}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "second-pr",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, hasDiverged, true)
@@ -428,13 +428,13 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	_, hasDiverged, err = wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "second-pr",
-		BaseBranch: "master",
+		BaseBranch: "main",
 	}, "default")
 	Ok(t, err)
 	Equals(t, hasDiverged, false)
 }
 
-func TestHasDiverged_MasterHasDiverged(t *testing.T) {
+func TestHasDiverged_MainHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
@@ -448,7 +448,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Atlantis checkout first PR.
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
-	runCmd(t, firstPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
+	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
 	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -456,7 +456,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
-	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "git", "checkout", "main")
 	runCmd(t, repoDir, "git", "checkout", "-b", "second-pr")
 	runCmd(t, repoDir, "touch", "file2")
 	runCmd(t, repoDir, "git", "add", "file2")
@@ -465,7 +465,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Atlantis checkout second PR.
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
-	runCmd(t, secondPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
+	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
 	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -473,10 +473,10 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
-	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "git", "checkout", "main")
 	runCmd(t, repoDir, "git", "merge", "first-pr")
 
-	// Copy the second-pr repo to our data dir which has diverged remote master
+	// Copy the second-pr repo to our data dir which has diverged remote main
 	runCmd(t, repoDir, "mkdir", "-p", "repos/0/")
 	runCmd(t, repoDir, "cp", "-R", secondPRDir, "repos/0/default")
 

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -60,20 +60,20 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on main.
+	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
 	runCmd(t, repoDir, "git", "add", "branch-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 	branchCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
-	// Now switch back to main and advance the main branch by another
+	// Now switch back to master and advance the master branch by another
 	// commit.
-	runCmd(t, repoDir, "git", "checkout", "main")
-	runCmd(t, repoDir, "touch", "main-file")
-	runCmd(t, repoDir, "git", "add", "main-file")
-	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
-	mainCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
+	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "touch", "master-file")
+	runCmd(t, repoDir, "git", "add", "master-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
+	masterCommit := runCmd(t, repoDir, "git", "rev-parse", "HEAD")
 
 	// Finally, perform a merge in another branch ourselves, just so we know
 	// what the final state of the repo should be.
@@ -99,7 +99,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   NewBaseRepo(),
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -107,7 +107,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 	// Check the commits.
 	actBaseCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD~1")
 	actHeadCommit := runCmd(t, cloneDir, "git", "rev-parse", "HEAD^2")
-	Equals(t, mainCommit, actBaseCommit)
+	Equals(t, masterCommit, actBaseCommit)
 	Equals(t, branchCommit, actHeadCommit)
 
 	// Use ls to verify the repo looks good.
@@ -122,17 +122,17 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on main.
+	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
 	runCmd(t, repoDir, "git", "add", "branch-file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
-	// Now switch back to main and advance the main branch by another commit.
-	runCmd(t, repoDir, "git", "checkout", "main")
-	runCmd(t, repoDir, "touch", "main-file")
-	runCmd(t, repoDir, "git", "add", "main-file")
-	runCmd(t, repoDir, "git", "commit", "-m", "main-commit")
+	// Now switch back to master and advance the master branch by another commit.
+	runCmd(t, repoDir, "git", "checkout", "master")
+	runCmd(t, repoDir, "touch", "master-file")
+	runCmd(t, repoDir, "git", "add", "master-file")
+	runCmd(t, repoDir, "git", "commit", "-m", "master-commit")
 
 	// Run the clone for the first time.
 	dataDir, cleanup2 := TempDir(t)
@@ -154,7 +154,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -166,7 +166,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -183,7 +183,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on main.
+	// Add a commit to branch 'branch' that's not on master.
 	// This will result in a fast-forwardable merge.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "touch", "branch-file")
@@ -210,7 +210,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -222,7 +222,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, false, hasDiverged)
@@ -238,15 +238,15 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
 
-	// Add a commit to branch 'branch' that's not on main.
+	// Add a commit to branch 'branch' that's not on master.
 	runCmd(t, repoDir, "git", "checkout", "branch")
 	runCmd(t, repoDir, "sh", "-c", "echo hi >> file")
 	runCmd(t, repoDir, "git", "add", "file")
 	runCmd(t, repoDir, "git", "commit", "-m", "branch-commit")
 
-	// Add a new commit to main that will cause a conflict if branch was
+	// Add a new commit to master that will cause a conflict if branch was
 	// merged.
-	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "sh", "-c", "echo conflict >> file")
 	runCmd(t, repoDir, "git", "add", "file")
 	runCmd(t, repoDir, "git", "commit", "-m", "commit")
@@ -271,7 +271,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	_, _, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "branch",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 
 	ErrContains(t, "running git merge -q --no-ff -m atlantis-merge FETCH_HEAD", err)
@@ -355,7 +355,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 
 // Test that if the branch we're merging into has diverged and we're using
 // checkout-strategy=merge, we warn the user (see #804).
-func TestClone_MainHasDiverged(t *testing.T) {
+func TestClone_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
@@ -369,7 +369,7 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	// Atlantis checkout first PR.
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
-	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, firstPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
 	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -377,7 +377,7 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
-	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "git", "checkout", "-b", "second-pr")
 	runCmd(t, repoDir, "touch", "file2")
 	runCmd(t, repoDir, "git", "add", "file2")
@@ -386,7 +386,7 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	// Atlantis checkout second PR.
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
-	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, secondPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
 	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -394,13 +394,13 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
-	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "git", "merge", "first-pr")
 
 	baseRepo := NewBaseRepo()
 	repoPath := fmt.Sprintf("repos/%s/0/", baseRepo.FullName)
 
-	// Copy the second-pr repo to our data dir which has diverged remote main
+	// Copy the second-pr repo to our data dir which has diverged remote master
 	runCmd(t, repoDir, "mkdir", "-p", repoPath)
 	runCmd(t, repoDir, "cp", "-R", secondPRDir, repoPath+"default")
 
@@ -417,7 +417,7 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	_, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{CloneURL: repoDir}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "second-pr",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, hasDiverged, true)
@@ -428,13 +428,13 @@ func TestClone_MainHasDiverged(t *testing.T) {
 	_, hasDiverged, err = wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
 		BaseRepo:   baseRepo,
 		HeadBranch: "second-pr",
-		BaseBranch: "main",
+		BaseBranch: "master",
 	}, "default")
 	Ok(t, err)
 	Equals(t, hasDiverged, false)
 }
 
-func TestHasDiverged_MainHasDiverged(t *testing.T) {
+func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// Initialize the git repo.
 	repoDir, cleanup := initRepo(t)
 	defer cleanup()
@@ -448,7 +448,7 @@ func TestHasDiverged_MainHasDiverged(t *testing.T) {
 	// Atlantis checkout first PR.
 	firstPRDir := repoDir + "/first-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "first-pr")
-	runCmd(t, firstPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, firstPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
 	runCmd(t, firstPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, firstPRDir, "git", "fetch", "head", "+refs/heads/first-pr")
 	runCmd(t, firstPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -456,7 +456,7 @@ func TestHasDiverged_MainHasDiverged(t *testing.T) {
 	runCmd(t, firstPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Simulate second PR.
-	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "git", "checkout", "-b", "second-pr")
 	runCmd(t, repoDir, "touch", "file2")
 	runCmd(t, repoDir, "git", "add", "file2")
@@ -465,7 +465,7 @@ func TestHasDiverged_MainHasDiverged(t *testing.T) {
 	// Atlantis checkout second PR.
 	secondPRDir := repoDir + "/second-pr"
 	runCmd(t, repoDir, "mkdir", "-p", "second-pr")
-	runCmd(t, secondPRDir, "git", "clone", "--branch", "main", "--single-branch", repoDir, ".")
+	runCmd(t, secondPRDir, "git", "clone", "--branch", "master", "--single-branch", repoDir, ".")
 	runCmd(t, secondPRDir, "git", "remote", "add", "head", repoDir)
 	runCmd(t, secondPRDir, "git", "fetch", "head", "+refs/heads/second-pr")
 	runCmd(t, secondPRDir, "git", "config", "--local", "user.email", "atlantisbot@runatlantis.io")
@@ -473,10 +473,10 @@ func TestHasDiverged_MainHasDiverged(t *testing.T) {
 	runCmd(t, secondPRDir, "git", "merge", "-q", "--no-ff", "-m", "atlantis-merge", "FETCH_HEAD")
 
 	// Merge first PR
-	runCmd(t, repoDir, "git", "checkout", "main")
+	runCmd(t, repoDir, "git", "checkout", "master")
 	runCmd(t, repoDir, "git", "merge", "first-pr")
 
-	// Copy the second-pr repo to our data dir which has diverged remote main
+	// Copy the second-pr repo to our data dir which has diverged remote master
 	runCmd(t, repoDir, "mkdir", "-p", "repos/0/")
 	runCmd(t, repoDir, "cp", "-R", secondPRDir, "repos/0/default")
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -62,7 +62,7 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator),
 		logger,
 	)
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -62,7 +62,7 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, rootConfigBuilder, scheduler, temporalClient),
 		logger,
 	)
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -58,11 +58,14 @@ func NewVCSEventsController(
 		pullEventWorkerProxy,
 	)
 
+	deploySignaler := &gateway_handlers.DeployWorkflowSignaler{
+		TemporalClient: temporalClient,
+	}
 	commentHandler := handlers.NewCommentEventWithCommandHandler(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, rootConfigBuilder, scheduler, temporalClient),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, rootConfigBuilder, scheduler, deploySignaler, vcsClient),
 		logger,
 	)
 
@@ -70,7 +73,7 @@ func NewVCSEventsController(
 		Allocator:         featureAllocator,
 		Scheduler:         scheduler,
 		Logger:            logger,
-		TemporalClient:    temporalClient,
+		DeploySignaler:    deploySignaler,
 		RootConfigBuilder: rootConfigBuilder,
 	}
 

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -51,6 +51,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 
 	if err != nil {
 		p.logger.ErrorContext(ctx, "unable to allocate platform mode")
+		p.forwardToSns(ctx, request)
 		return nil
 	}
 
@@ -60,7 +61,9 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 			return p.forceApply(ctx, event)
 		})
 	}
-
+	return p.forwardToSns(ctx, request)
+}
+func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *http.BufferedRequest) error {
 	buffer := bytes.NewBuffer([]byte{})
 
 	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -114,7 +114,7 @@ func (p *CommentEventWorkerProxy) startWorkflow(ctx context.Context, event Comme
 		options,
 		workflows.Deploy,
 		workflows.DeployRequest{
-			Trigger: "manual",
+			Trigger: workflows.ManualTrigger,
 			Repository: workflows.Repo{
 				URL:      event.BaseRepo.CloneURL,
 				FullName: event.BaseRepo.FullName,

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"time"
 
 	"github.com/pkg/errors"
@@ -89,7 +90,14 @@ func (p *CommentEventWorkerProxy) forceApply(ctx context.Context, event Comment)
 	for _, rootCfg := range rootCfgs {
 		p.logger.WarnContext(ctx, fmt.Sprintf("starting workflow"))
 		ctx = context.WithValue(ctx, contextInternal.ProjectKey, rootCfg.Name)
-		run, err := p.deploySignaler.SignalWithStartWorkflow(ctx, rootCfg, event.BaseRepo, event.Pull.HeadCommit, event.InstallationToken, event.Pull.HeadRef)
+		run, err := p.deploySignaler.SignalWithStartWorkflow(
+			ctx,
+			rootCfg,
+			event.BaseRepo,
+			event.Pull.HeadCommit,
+			event.InstallationToken,
+			event.Pull.HeadRef,
+			workflows.ManualTrigger)
 		if err != nil {
 			return errors.Wrap(err, "signalling workflow")
 		}

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -3,6 +3,12 @@ package event
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"go.temporal.io/sdk/client"
 	"time"
 
 	"github.com/pkg/errors"
@@ -14,29 +20,47 @@ import (
 
 // Comment is our internal representation of a vcs based comment event.
 type Comment struct {
-	Pull      models.PullRequest
-	BaseRepo  models.Repo
-	HeadRepo  models.Repo
-	User      models.User
-	PullNum   int
-	Comment   string
-	VCSHost   models.VCSHostType
-	Timestamp time.Time
+	Pull              models.PullRequest
+	BaseRepo          models.Repo
+	HeadRepo          models.Repo
+	User              models.User
+	PullNum           int
+	Comment           string
+	VCSHost           models.VCSHostType
+	Timestamp         time.Time
+	InstallationToken int64
 }
 
-func NewCommentEventWorkerProxy(
-	logger logging.Logger,
-	snsWriter Writer,
-) *CommentEventWorkerProxy {
-	return &CommentEventWorkerProxy{logger: logger, snsWriter: snsWriter}
+func NewCommentEventWorkerProxy(logger logging.Logger, snsWriter Writer, allocator feature.Allocator) *CommentEventWorkerProxy {
+	return &CommentEventWorkerProxy{logger: logger, snsWriter: snsWriter, allocator: allocator}
 }
 
 type CommentEventWorkerProxy struct {
-	logger    logging.Logger
-	snsWriter Writer
+	logger            logging.Logger
+	snsWriter         Writer
+	allocator         feature.Allocator
+	RootConfigBuilder rootConfigBuilder
+	Scheduler         scheduler
+	TemporalClient    signaler
 }
 
-func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, _ Comment, _ *command.Comment) error {
+func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, command *command.Comment) error {
+	shouldAllocate, err := p.allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{
+		RepoName: event.BaseRepo.FullName,
+	})
+
+	if err != nil {
+		p.logger.ErrorContext(ctx, "unable to allocate platform mode")
+		return nil
+	}
+
+	if shouldAllocate && command.ForceApply {
+		p.logger.WarnContext(ctx, "force apply comment")
+		return p.Scheduler.Schedule(ctx, func(ctx context.Context) error {
+			return p.handleForceApplyComment(ctx, event)
+		})
+	}
+
 	buffer := bytes.NewBuffer([]byte{})
 
 	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
@@ -50,4 +74,90 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 	p.logger.InfoContext(ctx, "proxied request to sns")
 
 	return nil
+}
+
+func (p *CommentEventWorkerProxy) handleForceApplyComment(ctx context.Context, event Comment) error {
+	p.logger.WarnContext(ctx, fmt.Sprintf("building force apply: %s %s %d", event.BaseRepo.FullName, event.Pull.HeadCommit, event.InstallationToken))
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.BaseRepo, event.Pull.HeadCommit, event.InstallationToken)
+	if err != nil {
+		return errors.Wrap(err, "generating roots")
+	}
+	for _, rootCfg := range rootCfgs {
+		p.logger.WarnContext(ctx, fmt.Sprintf("starting workflow"))
+		ctx = context.WithValue(ctx, contextInternal.ProjectKey, rootCfg.Name)
+		run, err := p.startWorkflow(ctx, event, rootCfg)
+		if err != nil {
+			return errors.Wrap(err, "signalling workflow")
+		}
+
+		p.logger.InfoContext(ctx, "Signaled workflow.", map[string]interface{}{
+			"workflow-id": run.GetID(), "run-id": run.GetRunID(),
+		})
+	}
+	return nil
+}
+
+func (p *CommentEventWorkerProxy) startWorkflow(ctx context.Context, event Comment, rootCfg *valid.MergedProjectCfg) (client.WorkflowRun, error) {
+	options := client.StartWorkflowOptions{TaskQueue: workflows.DeployTaskQueue}
+
+	var tfVersion string
+	if rootCfg.TerraformVersion != nil {
+		tfVersion = rootCfg.TerraformVersion.String()
+	}
+
+	run, err := p.TemporalClient.SignalWithStartWorkflow(
+		ctx,
+		fmt.Sprintf("%s||%s", event.BaseRepo.FullName, rootCfg.Name),
+		workflows.DeployNewRevisionSignalID,
+		workflows.DeployNewRevisionSignalRequest{
+			Revision: event.Pull.HeadCommit,
+		},
+		options,
+		workflows.Deploy,
+		// TODO: add other request params as we support them
+		workflows.DeployRequest{
+			Repository: workflows.Repo{
+				URL:      event.BaseRepo.CloneURL,
+				FullName: event.BaseRepo.FullName,
+				Name:     event.BaseRepo.Name,
+				Owner:    event.BaseRepo.Owner,
+				Credentials: workflows.AppCredentials{
+					InstallationToken: event.InstallationToken,
+				},
+				HeadCommit: workflows.HeadCommit{
+					Ref: workflows.Ref{
+						Name: event.Pull.HeadRef.Name,
+						Type: string(event.Pull.HeadRef.Type),
+					},
+				},
+			},
+			Root: workflows.Root{
+				Name: rootCfg.Name,
+				Plan: workflows.Job{
+					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Plan.Steps),
+				},
+				Apply: workflows.Job{
+					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Apply.Steps),
+				},
+				RepoRelPath: rootCfg.RepoRelDir,
+				TfVersion:   tfVersion,
+			},
+		},
+	)
+	return run, err
+}
+
+func (p *CommentEventWorkerProxy) generateSteps(steps []valid.Step) []workflows.Step {
+	// NOTE: for deployment workflows, we won't support command level user requests for log level output verbosity
+	var workflowSteps []workflows.Step
+	for _, step := range steps {
+		workflowSteps = append(workflowSteps, workflows.Step{
+			StepName:    step.StepName,
+			ExtraArgs:   step.ExtraArgs,
+			RunCommand:  step.RunCommand,
+			EnvVarName:  step.EnvVarName,
+			EnvVarValue: step.EnvVarValue,
+		})
+	}
+	return workflowSteps
 }

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -3,7 +3,6 @@ package event
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
@@ -16,6 +15,8 @@ import (
 	"github.com/runatlantis/atlantis/server/http"
 	"github.com/runatlantis/atlantis/server/logging"
 )
+
+const warningMessage = "⚠️ WARNING ⚠️\n\n You have bypassed all apply requirements for this PR 🚀 . This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘 .\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
 
 // Comment is our internal representation of a vcs based comment event.
 type Comment struct {
@@ -30,8 +31,24 @@ type Comment struct {
 	InstallationToken int64
 }
 
-func NewCommentEventWorkerProxy(logger logging.Logger, snsWriter Writer, allocator feature.Allocator, rootConfigBuilder rootConfigBuilder, scheduler scheduler, deploySignaler deploySignaler, vcsClient vcs.Client) *CommentEventWorkerProxy {
-	return &CommentEventWorkerProxy{logger: logger, snsWriter: snsWriter, allocator: allocator, rootConfigBuilder: rootConfigBuilder, scheduler: scheduler, deploySignaler: deploySignaler, vcsClient: vcsClient}
+func NewCommentEventWorkerProxy(
+	logger logging.Logger,
+	snsWriter Writer,
+	allocator feature.Allocator,
+	rootConfigBuilder rootConfigBuilder,
+	scheduler scheduler,
+	deploySignaler deploySignaler,
+	vcsClient vcs.Client) *CommentEventWorkerProxy {
+	return &CommentEventWorkerProxy{
+		logger: logger,
+		snsWriter: snsWriter,
+		allocator: allocator,
+		rootConfigBuilder:
+			rootConfigBuilder,
+			scheduler: scheduler,
+			deploySignaler: deploySignaler,
+			vcsClient: vcsClient
+	}
 }
 
 type CommentEventWorkerProxy struct {
@@ -56,7 +73,6 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 
 	if shouldAllocate && command.ForceApply {
 		p.logger.InfoContext(ctx, "running force apply command")
-		warningMessage := "⚠️ WARNING ⚠️\n\n You have bypassed all apply requirements for this PR 🚀 . This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘 .\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
 		if commentErr := p.vcsClient.CreateComment(event.BaseRepo, event.PullNum, warningMessage, ""); commentErr != nil {
 			p.logger.ErrorContext(ctx, commentErr.Error())
 		}
@@ -66,6 +82,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 	}
 	return p.forwardToSns(ctx, request)
 }
+
 func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *http.BufferedRequest) error {
 	buffer := bytes.NewBuffer([]byte{})
 
@@ -88,7 +105,6 @@ func (p *CommentEventWorkerProxy) forceApply(ctx context.Context, event Comment)
 		return errors.Wrap(err, "generating roots")
 	}
 	for _, rootCfg := range rootCfgs {
-		p.logger.WarnContext(ctx, fmt.Sprintf("starting workflow"))
 		ctx = context.WithValue(ctx, contextInternal.ProjectKey, rootCfg.Name)
 		run, err := p.deploySignaler.SignalWithStartWorkflow(
 			ctx,

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -40,14 +40,13 @@ func NewCommentEventWorkerProxy(
 	deploySignaler deploySignaler,
 	vcsClient vcs.Client) *CommentEventWorkerProxy {
 	return &CommentEventWorkerProxy{
-		logger: logger,
-		snsWriter: snsWriter,
-		allocator: allocator,
-		rootConfigBuilder:
-			rootConfigBuilder,
-			scheduler: scheduler,
-			deploySignaler: deploySignaler,
-			vcsClient: vcsClient
+		logger:            logger,
+		snsWriter:         snsWriter,
+		allocator:         allocator,
+		rootConfigBuilder: rootConfigBuilder,
+		scheduler:         scheduler,
+		deploySignaler:    deploySignaler,
+		vcsClient:         vcsClient,
 	}
 }
 

--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -31,7 +31,8 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
 	repo models.Repo,
 	revision string,
 	installationToken int64,
-	ref vcs.Ref) (client.WorkflowRun, error) {
+	ref vcs.Ref,
+	trigger workflows.Trigger) (client.WorkflowRun, error) {
 
 	options := client.StartWorkflowOptions{TaskQueue: workflows.DeployTaskQueue}
 
@@ -50,7 +51,7 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
 		options,
 		workflows.Deploy,
 		workflows.DeployRequest{
-			Trigger: workflows.MergeTrigger,
+			Trigger: trigger,
 			Repository: workflows.Repo{
 				URL:      repo.CloneURL,
 				FullName: repo.FullName,

--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -51,7 +51,6 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
 		options,
 		workflows.Deploy,
 		workflows.DeployRequest{
-			Trigger: trigger,
 			Repository: workflows.Repo{
 				URL:      repo.CloneURL,
 				FullName: repo.FullName,
@@ -78,6 +77,7 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
 				RepoRelPath: rootCfg.RepoRelDir,
 				TfVersion:   tfVersion,
 				PlanMode:    d.generatePlanMode(rootCfg),
+				Trigger:     trigger,
 			},
 		},
 	)

--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -1,0 +1,93 @@
+package event
+
+import (
+	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/runatlantis/atlantis/server/vcs"
+	"go.temporal.io/sdk/client"
+)
+
+type signaler interface {
+	SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
+		options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (client.WorkflowRun, error)
+	SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
+}
+
+type DeployWorkflowSignaler struct {
+	TemporalClient signaler
+}
+
+func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
+	ctx context.Context,
+	rootCfg *valid.MergedProjectCfg,
+	repo models.Repo,
+	revision string,
+	installationToken int64,
+	ref vcs.Ref) (client.WorkflowRun, error) {
+
+	options := client.StartWorkflowOptions{TaskQueue: workflows.DeployTaskQueue}
+
+	var tfVersion string
+	if rootCfg.TerraformVersion != nil {
+		tfVersion = rootCfg.TerraformVersion.String()
+	}
+
+	run, err := d.TemporalClient.SignalWithStartWorkflow(
+		ctx,
+		fmt.Sprintf("%s||%s", repo.FullName, rootCfg.Name),
+		workflows.DeployNewRevisionSignalID,
+		workflows.DeployNewRevisionSignalRequest{
+			Revision: revision,
+		},
+		options,
+		workflows.Deploy,
+		workflows.DeployRequest{
+			Trigger: workflows.MergeTrigger,
+			Repository: workflows.Repo{
+				URL:      repo.CloneURL,
+				FullName: repo.FullName,
+				Name:     repo.Name,
+				Owner:    repo.Owner,
+				Credentials: workflows.AppCredentials{
+					InstallationToken: installationToken,
+				},
+				HeadCommit: workflows.HeadCommit{
+					Ref: workflows.Ref{
+						Name: ref.Name,
+						Type: string(ref.Type),
+					},
+				},
+			},
+			Root: workflows.Root{
+				Name: rootCfg.Name,
+				Plan: workflows.Job{
+					Steps: d.generateSteps(rootCfg.DeploymentWorkflow.Plan.Steps),
+				},
+				Apply: workflows.Job{
+					Steps: d.generateSteps(rootCfg.DeploymentWorkflow.Apply.Steps),
+				},
+				RepoRelPath: rootCfg.RepoRelDir,
+				TfVersion:   tfVersion,
+			},
+		},
+	)
+	return run, err
+}
+
+func (d *DeployWorkflowSignaler) generateSteps(steps []valid.Step) []workflows.Step {
+	// NOTE: for deployment workflows, we won't support command level user requests for log level output verbosity
+	var workflowSteps []workflows.Step
+	for _, step := range steps {
+		workflowSteps = append(workflowSteps, workflows.Step{
+			StepName:    step.StepName,
+			ExtraArgs:   step.ExtraArgs,
+			RunCommand:  step.RunCommand,
+			EnvVarName:  step.EnvVarName,
+			EnvVarValue: step.EnvVarValue,
+		})
+	}
+	return workflowSteps
+}

--- a/server/neptune/gateway/event/deploy_workflow_signaler_test.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler_test.go
@@ -1,0 +1,221 @@
+package event_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/runatlantis/atlantis/server/vcs"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/client"
+	"testing"
+)
+
+type testRun struct{}
+
+func (r testRun) GetID() string {
+	return "123"
+}
+
+func (r testRun) GetRunID() string {
+	return "456"
+}
+
+func (r testRun) Get(ctx context.Context, valuePtr interface{}) error {
+	return nil
+}
+
+func (r testRun) GetWithOptions(ctx context.Context, valuePtr interface{}, options client.WorkflowRunGetOptions) error {
+	return nil
+}
+
+type testSignaler struct {
+	t                    *testing.T
+	expectedWorkflowID   string
+	expectedRunID        string
+	expectedSignalName   string
+	expectedSignalArg    interface{}
+	expectedOptions      client.StartWorkflowOptions
+	expectedWorkflow     interface{}
+	expectedWorkflowArgs interface{}
+	expectedErr          error
+
+	called bool
+}
+
+func (s *testSignaler) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	s.called = true
+	assert.Equal(s.t, s.expectedWorkflowID, workflowID)
+	assert.Equal(s.t, s.expectedRunID, runID)
+	assert.Equal(s.t, s.expectedSignalName, signalName)
+	assert.Equal(s.t, s.expectedSignalArg, arg)
+
+	return s.expectedErr
+}
+
+func (s *testSignaler) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
+	options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (client.WorkflowRun, error) {
+
+	s.called = true
+
+	assert.Equal(s.t, s.expectedWorkflowID, workflowID)
+	assert.Equal(s.t, s.expectedSignalName, signalName)
+	assert.Equal(s.t, s.expectedSignalArg, signalArg)
+	assert.Equal(s.t, s.expectedOptions, options)
+	assert.IsType(s.t, s.expectedWorkflow, workflow)
+	assert.Equal(s.t, []interface{}{s.expectedWorkflowArgs}, workflowArgs)
+
+	return testRun{}, s.expectedErr
+}
+
+func TestSignalWithStartWorkflow_Success(t *testing.T) {
+	repoFullName := "nish/repo"
+	repoOwner := "nish"
+	repoName := "repo"
+	repoURL := "www.nish.com"
+	sha := "12345"
+	ref := vcs.Ref{
+		Type: vcs.BranchRef,
+		Name: "main",
+	}
+
+	repo := models.Repo{
+		FullName: repoFullName,
+		Owner:    repoOwner,
+		Name:     repoName,
+		CloneURL: repoURL,
+	}
+
+	version, err := version.NewVersion("1.0.3")
+	assert.NoError(t, err)
+	rootCfg := valid.MergedProjectCfg{
+		Name: testRoot,
+		DeploymentWorkflow: valid.Workflow{
+			Plan:  valid.DefaultPlanStage,
+			Apply: valid.DefaultApplyStage,
+		},
+		TerraformVersion: version,
+	}
+
+	testSignaler := &testSignaler{
+		t:                  t,
+		expectedWorkflowID: fmt.Sprintf("%s||%s", repoFullName, testRoot),
+		expectedSignalName: workflows.DeployNewRevisionSignalID,
+		expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
+			Revision: sha,
+		},
+		expectedWorkflow: workflows.Deploy,
+		expectedOptions: client.StartWorkflowOptions{
+			TaskQueue: workflows.DeployTaskQueue,
+		},
+		expectedWorkflowArgs: workflows.DeployRequest{
+			Trigger: "merge",
+			Repository: workflows.Repo{
+				FullName: repoFullName,
+				Name:     repoName,
+				Owner:    repoOwner,
+				URL:      repoURL,
+				HeadCommit: workflows.HeadCommit{
+					Ref: workflows.Ref{
+						Name: ref.Name,
+						Type: string(ref.Type),
+					},
+				},
+			},
+			Root: workflows.Root{
+				Name: testRoot,
+				Plan: workflows.Job{
+					Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
+				},
+				Apply: workflows.Job{
+					Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
+				},
+				TfVersion: version.String(),
+			},
+		},
+	}
+	deploySignaler := event.DeployWorkflowSignaler{
+		TemporalClient: testSignaler,
+	}
+	run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref)
+	assert.NoError(t, err)
+	assert.Equal(t, testRun{}, run)
+}
+
+func TestSignalWithStartWorkflow_Failure(t *testing.T) {
+	repoFullName := "nish/repo"
+	repoOwner := "nish"
+	repoName := "repo"
+	repoURL := "www.nish.com"
+	sha := "12345"
+	ref := vcs.Ref{
+		Type: vcs.BranchRef,
+		Name: "main",
+	}
+
+	repo := models.Repo{
+		FullName: repoFullName,
+		Owner:    repoOwner,
+		Name:     repoName,
+		CloneURL: repoURL,
+	}
+
+	version, err := version.NewVersion("1.0.3")
+	assert.NoError(t, err)
+	rootCfg := valid.MergedProjectCfg{
+		Name: testRoot,
+		DeploymentWorkflow: valid.Workflow{
+			Plan:  valid.DefaultPlanStage,
+			Apply: valid.DefaultApplyStage,
+		},
+		TerraformVersion: version,
+	}
+
+	testSignaler := &testSignaler{
+		t:                  t,
+		expectedWorkflowID: fmt.Sprintf("%s||%s", repoFullName, testRoot),
+		expectedSignalName: workflows.DeployNewRevisionSignalID,
+		expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
+			Revision: sha,
+		},
+		expectedWorkflow: workflows.Deploy,
+		expectedOptions: client.StartWorkflowOptions{
+			TaskQueue: workflows.DeployTaskQueue,
+		},
+		expectedWorkflowArgs: workflows.DeployRequest{
+			Trigger: "merge",
+			Repository: workflows.Repo{
+				FullName: repoFullName,
+				Name:     repoName,
+				Owner:    repoOwner,
+				URL:      repoURL,
+				HeadCommit: workflows.HeadCommit{
+					Ref: workflows.Ref{
+						Name: ref.Name,
+						Type: string(ref.Type),
+					},
+				},
+			},
+			Root: workflows.Root{
+				Name: testRoot,
+				Plan: workflows.Job{
+					Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
+				},
+				Apply: workflows.Job{
+					Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
+				},
+				TfVersion: version.String(),
+			},
+		},
+		expectedErr: expectedErr,
+	}
+	deploySignaler := event.DeployWorkflowSignaler{
+		TemporalClient: testSignaler,
+	}
+	run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref)
+	assert.Error(t, err)
+	assert.Equal(t, testRun{}, run)
+}

--- a/server/neptune/gateway/event/deploy_workflow_signaler_test.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler_test.go
@@ -114,7 +114,6 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: workflows.MergeTrigger,
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,
@@ -137,6 +136,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					},
 					TfVersion: version.String(),
 					PlanMode:  workflows.NormalPlanMode,
+					Trigger:   workflows.MergeTrigger,
 				},
 			},
 		}
@@ -173,7 +173,6 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: workflows.MergeTrigger,
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,
@@ -196,6 +195,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					},
 					TfVersion: version.String(),
 					PlanMode:  workflows.DestroyPlanMode,
+					Trigger:   workflows.MergeTrigger,
 				},
 			},
 		}
@@ -249,7 +249,6 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 			TaskQueue: workflows.DeployTaskQueue,
 		},
 		expectedWorkflowArgs: workflows.DeployRequest{
-			Trigger: "merge",
 			Repository: workflows.Repo{
 				FullName: repoFullName,
 				Name:     repoName,
@@ -272,6 +271,7 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 				},
 				TfVersion: version.String(),
 				PlanMode:  workflows.NormalPlanMode,
+				Trigger:   workflows.MergeTrigger,
 			},
 		},
 		expectedErr: expectedErr,

--- a/server/neptune/gateway/event/deploy_workflow_signaler_test.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler_test.go
@@ -114,7 +114,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: "merge",
+				Trigger: workflows.MergeTrigger,
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,
@@ -143,7 +143,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 		deploySignaler := event.DeployWorkflowSignaler{
 			TemporalClient: testSignaler,
 		}
-		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref)
+		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref, workflows.MergeTrigger)
 		assert.NoError(t, err)
 		assert.Equal(t, testRun{}, run)
 	})
@@ -173,7 +173,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: "merge",
+				Trigger: workflows.MergeTrigger,
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,
@@ -202,7 +202,7 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 		deploySignaler := event.DeployWorkflowSignaler{
 			TemporalClient: testSignaler,
 		}
-		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref)
+		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref, workflows.MergeTrigger)
 		assert.NoError(t, err)
 		assert.Equal(t, testRun{}, run)
 	})
@@ -279,7 +279,7 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 	deploySignaler := event.DeployWorkflowSignaler{
 		TemporalClient: testSignaler,
 	}
-	run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref)
+	run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, repo, sha, 0, ref, workflows.MergeTrigger)
 	assert.Error(t, err)
 	assert.Equal(t, testRun{}, run)
 }

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -86,7 +86,7 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 }
 
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
-	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Repo.DefaultBranch, event.Sha, event.InstallationToken)
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Ref.Name, event.Sha, event.InstallationToken)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}
@@ -104,6 +104,7 @@ func (p *PushHandler) handle(ctx context.Context, event Push) error {
 	return nil
 }
 
+// TODO: extract out into a separate startWorkflow interface both the push event and comment handler can share
 func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *valid.MergedProjectCfg) (client.WorkflowRun, error) {
 	options := client.StartWorkflowOptions{TaskQueue: workflows.DeployTaskQueue}
 

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -122,7 +122,7 @@ func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *va
 		options,
 		workflows.Deploy,
 		workflows.DeployRequest{
-			Trigger: "merge",
+			Trigger: workflows.MergeTrigger,
 			Repository: workflows.Repo{
 				URL:      event.Repo.CloneURL,
 				FullName: event.Repo.FullName,

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -44,7 +44,7 @@ type scheduler interface {
 }
 
 type rootConfigBuilder interface {
-	Build(ctx context.Context, event Push) ([]*valid.MergedProjectCfg, error)
+	Build(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error)
 }
 
 type PushHandler struct {
@@ -86,7 +86,7 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 }
 
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
-	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event)
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Sha, event.InstallationToken)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -44,7 +44,7 @@ type scheduler interface {
 }
 
 type rootConfigBuilder interface {
-	Build(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error)
+	Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error)
 }
 
 type PushHandler struct {
@@ -86,7 +86,7 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 }
 
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
-	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Sha, event.InstallationToken)
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Repo.DefaultBranch, event.Sha, event.InstallationToken)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -121,8 +121,8 @@ func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *va
 		},
 		options,
 		workflows.Deploy,
-		// TODO: add other request params as we support them
 		workflows.DeployRequest{
+			Trigger: "merge",
 			Repository: workflows.Repo{
 				URL:      event.Repo.CloneURL,
 				FullName: event.Repo.FullName,

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -2,7 +2,6 @@ package event_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -18,64 +17,7 @@ import (
 	"go.temporal.io/sdk/client"
 )
 
-type testRun struct{}
-
-func (r testRun) GetID() string {
-	return "123"
-}
-
-func (r testRun) GetRunID() string {
-	return "456"
-}
-
-func (r testRun) Get(ctx context.Context, valuePtr interface{}) error {
-	return nil
-}
-
-func (r testRun) GetWithOptions(ctx context.Context, valuePtr interface{}, options client.WorkflowRunGetOptions) error {
-	return nil
-}
-
 const testRoot = "testroot"
-
-type testSignaler struct {
-	t                    *testing.T
-	expectedWorkflowID   string
-	expectedRunID        string
-	expectedSignalName   string
-	expectedSignalArg    interface{}
-	expectedOptions      client.StartWorkflowOptions
-	expectedWorkflow     interface{}
-	expectedWorkflowArgs interface{}
-	expectedErr          error
-
-	called bool
-}
-
-func (s *testSignaler) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
-	s.called = true
-	assert.Equal(s.t, s.expectedWorkflowID, workflowID)
-	assert.Equal(s.t, s.expectedRunID, runID)
-	assert.Equal(s.t, s.expectedSignalName, signalName)
-	assert.Equal(s.t, s.expectedSignalArg, arg)
-
-	return s.expectedErr
-}
-
-func (s *testSignaler) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
-	options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (client.WorkflowRun, error) {
-
-	s.called = true
-
-	assert.Equal(s.t, s.expectedWorkflowID, workflowID)
-	assert.Equal(s.t, s.expectedSignalName, signalName)
-	assert.Equal(s.t, s.expectedSignalArg, signalArg)
-	assert.Equal(s.t, s.expectedOptions, options)
-	assert.IsType(s.t, s.expectedWorkflow, workflow)
-	assert.Equal(s.t, []interface{}{s.expectedWorkflowArgs}, workflowArgs)
-
-	return testRun{}, s.expectedErr
-}
 
 type testAllocator struct {
 	t                  *testing.T
@@ -114,7 +56,6 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 				Name: "blah",
 			},
 		}
-		testSignaler := &testSignaler{t: t}
 		allocator := &testAllocator{
 			expectedAllocation: true,
 			expectedFeatureID:  feature.PlatformMode,
@@ -127,15 +68,13 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: &mockRootConfigBuilder{},
 		}
 
 		err := handler.Handle(context.Background(), e)
 		assert.NoError(t, err)
-
-		assert.False(t, testSignaler.called)
 	})
 
 	t.Run("filters non-default branch types", func(t *testing.T) {
@@ -153,7 +92,7 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 				Name: "random",
 			},
 		}
-		testSignaler := &testSignaler{t: t}
+
 		allocator := &testAllocator{
 			expectedAllocation: true,
 			expectedFeatureID:  feature.PlatformMode,
@@ -166,15 +105,13 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: &mockRootConfigBuilder{},
 		}
 
 		err := handler.Handle(context.Background(), e)
 		assert.NoError(t, err)
-
-		assert.False(t, testSignaler.called)
 	})
 
 	t.Run("filters deleted branches", func(t *testing.T) {
@@ -193,7 +130,6 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 				Name: "main",
 			},
 		}
-		testSignaler := &testSignaler{t: t}
 		allocator := &testAllocator{
 			expectedAllocation: true,
 			expectedFeatureID:  feature.PlatformMode,
@@ -206,15 +142,13 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: &mockRootConfigBuilder{},
 		}
 
 		err := handler.Handle(context.Background(), e)
 		assert.NoError(t, err)
-
-		assert.False(t, testSignaler.called)
 	})
 
 }
@@ -229,8 +163,6 @@ func TestHandlePushEvent(t *testing.T) {
 	repoOwner := "nish"
 	repoName := "repo"
 	repoURL := "www.nish.com"
-	repoRefName := "main"
-	repoRefType := "branch"
 	sha := "12345"
 	repo := models.Repo{
 		FullName:      repoFullName,
@@ -250,7 +182,6 @@ func TestHandlePushEvent(t *testing.T) {
 	}
 
 	t.Run("allocation result false", func(t *testing.T) {
-		testSignaler := &testSignaler{t: t}
 		allocator := &testAllocator{
 			expectedAllocation: false,
 			expectedFeatureID:  feature.PlatformMode,
@@ -263,19 +194,16 @@ func TestHandlePushEvent(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: &mockRootConfigBuilder{},
 		}
 
 		err := handler.Handle(context.Background(), e)
 		assert.NoError(t, err)
-
-		assert.False(t, testSignaler.called)
 	})
 
 	t.Run("allocation error", func(t *testing.T) {
-		testSignaler := &testSignaler{t: t}
 		allocator := &testAllocator{
 			expectedError:     assert.AnError,
 			expectedFeatureID: feature.PlatformMode,
@@ -288,55 +216,16 @@ func TestHandlePushEvent(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: &mockRootConfigBuilder{},
 		}
 
 		err := handler.Handle(context.Background(), e)
 		assert.NoError(t, err)
-
-		assert.False(t, testSignaler.called)
 	})
 
 	t.Run("signal success", func(t *testing.T) {
-		testSignaler := &testSignaler{
-			t:                  t,
-			expectedWorkflowID: fmt.Sprintf("%s||%s", repoFullName, testRoot),
-			expectedSignalName: workflows.DeployNewRevisionSignalID,
-			expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
-				Revision: sha,
-			},
-			expectedWorkflow: workflows.Deploy,
-			expectedOptions: client.StartWorkflowOptions{
-				TaskQueue: workflows.DeployTaskQueue,
-			},
-			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: "merge",
-				Repository: workflows.Repo{
-					FullName: repoFullName,
-					Name:     repoName,
-					Owner:    repoOwner,
-					URL:      repoURL,
-					HeadCommit: workflows.HeadCommit{
-						Ref: workflows.Ref{
-							Name: repoRefName,
-							Type: repoRefType,
-						},
-					},
-				},
-				Root: workflows.Root{
-					Name: testRoot,
-					Plan: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
-					},
-					Apply: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
-					},
-					TfVersion: version.String(),
-				},
-			},
-		}
 		allocator := &testAllocator{
 			expectedAllocation: true,
 			expectedFeatureID:  feature.PlatformMode,
@@ -363,56 +252,16 @@ func TestHandlePushEvent(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{},
 			Logger:            logger,
 			RootConfigBuilder: rootConfigBuilder,
 		}
 
 		err := handler.Handle(ctx, e)
 		assert.NoError(t, err)
-
-		assert.True(t, testSignaler.called)
 	})
 
 	t.Run("signal error", func(t *testing.T) {
-		testSignaler := &testSignaler{
-			t:                  t,
-			expectedWorkflowID: fmt.Sprintf("%s||%s", repoFullName, testRoot),
-			expectedSignalName: workflows.DeployNewRevisionSignalID,
-			expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
-				Revision: sha,
-			},
-			expectedWorkflow: workflows.Deploy,
-			expectedOptions: client.StartWorkflowOptions{
-				TaskQueue: workflows.DeployTaskQueue,
-			},
-			expectedWorkflowArgs: workflows.DeployRequest{
-				Trigger: "merge",
-				Repository: workflows.Repo{
-					FullName: repoFullName,
-					Name:     repoName,
-					Owner:    repoOwner,
-					URL:      repoURL,
-					HeadCommit: workflows.HeadCommit{
-						Ref: workflows.Ref{
-							Name: repoRefName,
-							Type: repoRefType,
-						},
-					},
-				},
-				Root: workflows.Root{
-					Name: testRoot,
-					Plan: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
-					},
-					Apply: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
-					},
-					TfVersion: version.String(),
-				},
-			},
-			expectedErr: assert.AnError,
-		}
 		allocator := &testAllocator{
 			expectedAllocation: true,
 			expectedFeatureID:  feature.PlatformMode,
@@ -440,15 +289,13 @@ func TestHandlePushEvent(t *testing.T) {
 		handler := event.PushHandler{
 			Allocator:         allocator,
 			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			TemporalClient:    testSignaler,
+			DeploySignaler:    &mockDeploySignaler{error: assert.AnError},
 			Logger:            logger,
 			RootConfigBuilder: rootConfigBuilder,
 		}
 
 		err := handler.Handle(ctx, e)
 		assert.Error(t, err)
-
-		assert.True(t, testSignaler.called)
 	})
 }
 
@@ -464,6 +311,15 @@ func convertTestSteps(steps []valid.Step) []workflows.Step {
 		})
 	}
 	return convertedSteps
+}
+
+type mockDeploySignaler struct {
+	run   client.WorkflowRun
+	error error
+}
+
+func (d *mockDeploySignaler) SignalWithStartWorkflow(_ context.Context, _ *valid.MergedProjectCfg, _ models.Repo, _ string, _ int64, _ vcs.Ref) (client.WorkflowRun, error) {
+	return d.run, d.error
 }
 
 type mockRootConfigBuilder struct {

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -469,6 +469,6 @@ type mockRootConfigBuilder struct {
 	error       error
 }
 
-func (r *mockRootConfigBuilder) Build(_ context.Context, _ event.Push) ([]*valid.MergedProjectCfg, error) {
+func (r *mockRootConfigBuilder) Build(_ context.Context, _ models.Repo, _ string, _ int64) ([]*valid.MergedProjectCfg, error) {
 	return r.rootConfigs, r.error
 }

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -469,6 +469,6 @@ type mockRootConfigBuilder struct {
 	error       error
 }
 
-func (r *mockRootConfigBuilder) Build(_ context.Context, _ models.Repo, _ string, _ int64) ([]*valid.MergedProjectCfg, error) {
+func (r *mockRootConfigBuilder) Build(_ context.Context, _ models.Repo, _ string, _ string, _ int64) ([]*valid.MergedProjectCfg, error) {
 	return r.rootConfigs, r.error
 }

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -312,6 +312,7 @@ func TestHandlePushEvent(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
+				Trigger: "merge",
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,
@@ -386,6 +387,7 @@ func TestHandlePushEvent(t *testing.T) {
 				TaskQueue: workflows.DeployTaskQueue,
 			},
 			expectedWorkflowArgs: workflows.DeployRequest{
+				Trigger: "merge",
 				Repository: workflows.Repo{
 					FullName: repoFullName,
 					Name:     repoName,

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -318,7 +318,7 @@ type mockDeploySignaler struct {
 	error error
 }
 
-func (d *mockDeploySignaler) SignalWithStartWorkflow(_ context.Context, _ *valid.MergedProjectCfg, _ models.Repo, _ string, _ int64, _ vcs.Ref) (client.WorkflowRun, error) {
+func (d *mockDeploySignaler) SignalWithStartWorkflow(_ context.Context, _ *valid.MergedProjectCfg, _ models.Repo, _ string, _ int64, _ vcs.Ref, _ workflows.Trigger) (client.WorkflowRun, error) {
 	return d.run, d.error
 }
 

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -12,7 +12,7 @@ import (
 
 // repoFetcher manages a cloned repo's workspace on disk for running commands.
 type repoFetcher interface {
-	Fetch(ctx context.Context, baseRepo models.Repo, sha string) (string, func(ctx context.Context, filePath string), error)
+	Fetch(ctx context.Context, baseRepo models.Repo, branch string, sha string) (string, func(ctx context.Context, filePath string), error)
 }
 
 // hooksRunner runs preworkflow hooks for a given repository/commit
@@ -47,9 +47,9 @@ type RootConfigBuilder struct {
 	Logger          logging.Logger
 }
 
-func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
+func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	// Generate a new filepath location and clone repo into it
-	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, sha)
+	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, branch, sha)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("creating temporary clone at path: %s", repoDir))
 	}

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -47,22 +47,22 @@ type RootConfigBuilder struct {
 	Logger          logging.Logger
 }
 
-func (b *RootConfigBuilder) Build(ctx context.Context, event Push) ([]*valid.MergedProjectCfg, error) {
+func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	// Generate a new filepath location and clone repo into it
-	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, event.Repo, event.Sha)
+	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, sha)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("creating temporary clone at path: %s", repoDir))
 	}
 	defer cleanup(ctx, repoDir)
 
 	// Run pre-workflow hooks
-	err = b.HooksRunner.Run(event.Repo, repoDir)
+	err = b.HooksRunner.Run(repo, repoDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "running pre-workflow hooks")
 	}
 
 	// Fetch files modified in commit
-	modifiedFiles, err := b.FileFetcher.GetModifiedFilesFromCommit(ctx, event.Repo, event.Sha, event.InstallationToken)
+	modifiedFiles, err := b.FileFetcher.GetModifiedFilesFromCommit(ctx, repo, sha, installationToken)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding modified files: %s", modifiedFiles)
 	}
@@ -70,7 +70,7 @@ func (b *RootConfigBuilder) Build(ctx context.Context, event Push) ([]*valid.Mer
 	// Parse repo configs into specific root configs (i.e. roots)
 	// TODO: rename project to roots
 	var mergedRootCfgs []*valid.MergedProjectCfg
-	repoCfg, err := b.ParserValidator.ParseRepoCfg(repoDir, event.Repo.ID())
+	repoCfg, err := b.ParserValidator.ParseRepoCfg(repoDir, repo.ID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", config.AtlantisYAMLFilename)
 	}
@@ -79,7 +79,7 @@ func (b *RootConfigBuilder) Build(ctx context.Context, event Push) ([]*valid.Mer
 		return nil, errors.Wrap(err, "determining roots")
 	}
 	for _, mr := range matchingRoots {
-		mergedRootCfg := b.GlobalCfg.MergeProjectCfg(event.Repo.ID(), mr, repoCfg)
+		mergedRootCfg := b.GlobalCfg.MergeProjectCfg(repo.ID(), mr, repoCfg)
 		mergedRootCfgs = append(mergedRootCfgs, &mergedRootCfg)
 	}
 	return mergedRootCfgs, nil

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -52,7 +52,7 @@ func TestRootConfigBuilder_Success(t *testing.T) {
 	expProjectConfigs := []*valid.MergedProjectCfg{
 		&projCfg,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.NoError(t, err)
 	assert.Equal(t, expProjectConfigs, projectConfigs)
 }
@@ -63,7 +63,7 @@ func TestRootConfigBuilder_DetermineRootsError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.RootFinder = mockRootFinder
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -75,7 +75,7 @@ func TestRootConfigBuilder_ParserValidatorParseError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.ParserValidator = mockParserValidator
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -86,7 +86,7 @@ func TestRootConfigBuilder_GetModifiedFilesError(t *testing.T) {
 	rcb.FileFetcher = &mockFileFetcher{
 		error: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 }
@@ -96,7 +96,7 @@ func TestRootConfigBuilder_CloneError(t *testing.T) {
 	rcb.RepoFetcher = &mockRepoFetcher{
 		cloneError: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -108,7 +108,7 @@ func TestRootConfigBuilder_HooksRunnerError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.HooksRunner = mockHooksRunner
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -121,7 +121,7 @@ type mockRepoFetcher struct {
 	cloneError error
 }
 
-func (r *mockRepoFetcher) Fetch(_ context.Context, _ models.Repo, _ string) (string, func(ctx context.Context, filePath string), error) {
+func (r *mockRepoFetcher) Fetch(_ context.Context, _ models.Repo, _ string, _ string) (string, func(ctx context.Context, filePath string), error) {
 	return "", func(ctx context.Context, filePath string) {}, r.cloneError
 }
 

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -52,7 +52,7 @@ func TestRootConfigBuilder_Success(t *testing.T) {
 	expProjectConfigs := []*valid.MergedProjectCfg{
 		&projCfg,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.NoError(t, err)
 	assert.Equal(t, expProjectConfigs, projectConfigs)
 }
@@ -63,7 +63,7 @@ func TestRootConfigBuilder_DetermineRootsError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.RootFinder = mockRootFinder
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -75,7 +75,7 @@ func TestRootConfigBuilder_ParserValidatorParseError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.ParserValidator = mockParserValidator
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -86,7 +86,7 @@ func TestRootConfigBuilder_GetModifiedFilesError(t *testing.T) {
 	rcb.FileFetcher = &mockFileFetcher{
 		error: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 }
@@ -96,7 +96,7 @@ func TestRootConfigBuilder_CloneError(t *testing.T) {
 	rcb.RepoFetcher = &mockRepoFetcher{
 		cloneError: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -108,7 +108,7 @@ func TestRootConfigBuilder_HooksRunnerError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.HooksRunner = mockHooksRunner
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent)
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Sha, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 

--- a/server/neptune/gateway/server_test.go
+++ b/server/neptune/gateway/server_test.go
@@ -23,4 +23,3 @@ func TestHealthz(t *testing.T) {
   "status": "ok"
 }`, string(body))
 }
-

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -19,6 +19,10 @@ type Step = deploy.Step
 type AppCredentials = deploy.AppCredentials
 type HeadCommit = deploy.Commit
 type Ref = deploy.Ref
+type Trigger = deploy.Trigger
+
+const ManualTrigger = deploy.ManualTrigger
+const MergeTrigger = deploy.MergeTrigger
 
 type DeployNewRevisionSignalRequest = revision.NewRevisionRequest
 

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -12,7 +12,6 @@ type Request struct {
 	GHRequestID string
 	Repository  Repo
 	Root        Root
-	Trigger     Trigger
 }
 
 type Repo struct {
@@ -58,6 +57,7 @@ type Root struct {
 	RepoRelPath string
 	TfVersion   string
 	PlanMode    PlanMode
+	Trigger     Trigger
 }
 
 type Job struct {

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -1,12 +1,18 @@
 package deploy
 
 // Types defined here should not be used internally, as our goal should be to eventually swap these out for something less brittle than json translation
+type Trigger string
+
+const (
+	MergeTrigger  Trigger = "merge"
+	ManualTrigger Trigger = "manual"
+)
 
 type Request struct {
 	GHRequestID string
 	Repository  Repo
 	Root        Root
-	Trigger     string
+	Trigger     Trigger
 }
 
 type Repo struct {

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -1,18 +1,12 @@
 package deploy
 
 // Types defined here should not be used internally, as our goal should be to eventually swap these out for something less brittle than json translation
-type RefType string
-
-const (
-	Unknown   RefType = "unknown"
-	BranchRef RefType = "branch"
-	TagRef    RefType = "tag"
-)
 
 type Request struct {
 	GHRequestID string
 	Repository  Repo
 	Root        Root
+	Trigger     string
 }
 
 type Repo struct {

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -19,6 +19,7 @@ func Root(external request.Root) root.Root {
 		},
 		Path:      external.RepoRelPath,
 		TfVersion: external.TfVersion,
+		Trigger:   root.Trigger(external.Trigger),
 	}
 
 }

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -82,10 +82,6 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 		},
 	}
 
-	// TODO: We should actually probably pass this with the revision because a revision
-	// can potentially change a root configuration
-	
-
 	// inject dependencies
 
 	// temporal effectively "injects" this, it just cares about the method names,

--- a/server/neptune/workflows/internal/root/root.go
+++ b/server/neptune/workflows/internal/root/root.go
@@ -14,7 +14,10 @@ type Root struct {
 	TfVersion string
 	Apply     job.Terraform
 	Plan      job.Plan
+	Trigger   Trigger
 }
+
+type Trigger string
 
 // LocalRoot is a root that exists locally on disk
 type LocalRoot struct {

--- a/server/vcs/provider/github/converter/comment_event.go
+++ b/server/vcs/provider/github/converter/comment_event.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"github.com/palantir/go-githubapp/githubapp"
 	"time"
 
 	"github.com/google/go-github/v45/github"
@@ -54,14 +55,17 @@ func (e CommentEventConverter) Convert(comment *github.IssueCommentEvent) (event
 		return event.Comment{}, errors.Wrap(err, "converting pull request type")
 	}
 
+	installationToken := githubapp.GetInstallationIDFromEvent(comment)
+
 	return event.Comment{
-		BaseRepo:  pull.BaseRepo,
-		HeadRepo:  pull.HeadRepo,
-		Pull:      pull,
-		User:      user,
-		PullNum:   pullNum,
-		VCSHost:   models.Github,
-		Timestamp: eventTimestamp,
-		Comment:   comment.GetComment().GetBody(),
+		BaseRepo:          pull.BaseRepo,
+		HeadRepo:          pull.HeadRepo,
+		Pull:              pull,
+		User:              user,
+		PullNum:           pullNum,
+		VCSHost:           models.Github,
+		Timestamp:         eventTimestamp,
+		InstallationToken: installationToken,
+		//Comment:           comment.GetComment().GetBody(),
 	}, nil
 }

--- a/server/vcs/provider/github/converter/comment_event.go
+++ b/server/vcs/provider/github/converter/comment_event.go
@@ -66,6 +66,6 @@ func (e CommentEventConverter) Convert(comment *github.IssueCommentEvent) (event
 		VCSHost:           models.Github,
 		Timestamp:         eventTimestamp,
 		InstallationToken: installationToken,
-		//Comment:           comment.GetComment().GetBody(),
+		Comment:           comment.GetComment().GetBody(),
 	}, nil
 }

--- a/server/vcs/provider/github/converter/comment_event_test.go
+++ b/server/vcs/provider/github/converter/comment_event_test.go
@@ -1,6 +1,7 @@
 package converter_test
 
 import (
+	"github.com/runatlantis/atlantis/server/vcs"
 	"testing"
 
 	"github.com/google/go-github/v45/github"
@@ -70,6 +71,10 @@ func setup(t *testing.T) (github.IssueCommentEvent, models.Repo, models.PullRequ
 		BaseRepo:   modelRepo,
 		HeadRepo:   modelRepo,
 		UpdatedAt:  *Pull.UpdatedAt,
+		HeadRef: vcs.Ref{
+			Type: "branch",
+			Name: "ref",
+		},
 	}
 
 	return comment, modelRepo, modelPull, pullConverter

--- a/server/vcs/provider/github/converter/pull.go
+++ b/server/vcs/provider/github/converter/pull.go
@@ -2,10 +2,10 @@ package converter
 
 import (
 	"fmt"
-
 	"github.com/google/go-github/v45/github"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/vcs"
 )
 
 // PullConverter converts a github pull request to our internal model
@@ -56,6 +56,10 @@ func (p *PullConverter) Convert(pull *github.PullRequest) (models.PullRequest, e
 	if pull.GetState() == "open" {
 		pullState = models.OpenPullState
 	}
+	ref := vcs.Ref{
+		Type: vcs.BranchRef,
+		Name: pull.Head.GetRef(),
+	}
 
 	return models.PullRequest{
 		Author:     authorUsername,
@@ -70,5 +74,6 @@ func (p *PullConverter) Convert(pull *github.PullRequest) (models.PullRequest, e
 		ClosedAt:   closedAt,
 		UpdatedAt:  updatedAt,
 		CreatedAt:  createdAt,
+		HeadRef:    ref,
 	}, nil
 }

--- a/server/vcs/provider/github/converter/pull_event_test.go
+++ b/server/vcs/provider/github/converter/pull_event_test.go
@@ -1,6 +1,7 @@
 package converter_test
 
 import (
+	"github.com/runatlantis/atlantis/server/vcs"
 	"testing"
 
 	"github.com/google/go-github/v45/github"
@@ -70,6 +71,10 @@ func TestConvert_PullRequestEvent(t *testing.T) {
 		BaseRepo:   expBaseRepo,
 		HeadRepo:   expBaseRepo,
 		UpdatedAt:  timestamp,
+		HeadRef: vcs.Ref{
+			Type: "branch",
+			Name: "ref",
+		},
 	}, actPull.Pull)
 	Equals(t, models.OpenedPullEvent, actPull.EventType)
 	Equals(t, models.User{Username: "user"}, actPull.User)

--- a/server/vcs/provider/github/converter/pull_test.go
+++ b/server/vcs/provider/github/converter/pull_test.go
@@ -1,6 +1,7 @@
 package converter_test
 
 import (
+	"github.com/runatlantis/atlantis/server/vcs"
 	"testing"
 	"time"
 
@@ -95,5 +96,9 @@ func TestParseGithubPull(t *testing.T) {
 		BaseRepo:   expBaseRepo,
 		HeadRepo:   expBaseRepo,
 		UpdatedAt:  timestamp,
+		HeadRef: vcs.Ref{
+			Type: "branch",
+			Name: "ref",
+		},
 	}, pullRes)
 }


### PR DESCRIPTION
First change here has gateway support listening for force apply comments from GH and re-routing those into temporal workflows. Now the comment handler receives a force apply comment from a repo with PlatformMode enabled, it will run the RootConfigBuilder to create the affected project roots and signal deploy workflows for each of them. To be able to build the correct roots, we needed to modify the RepoFetcher to support cloning a requested branch, instead of the default one. 

Next PRs:

- Support locking roots of temporalworker
- Listen for Unlock GH action on gateway