### PR TITLE
Pass background context to AsyncAutoplannerWorkerProxy to avoid context cancellations

### DIFF
--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -63,7 +63,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 
 	projectCmds, err := r.PrjCmdBuilder.BuildAutoplanCommands(cmdCtx)
 	if err != nil {
-		if _, statusErr := r.CommitStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.FailedCommitStatus, command.Plan, "", ""); statusErr != nil {
+		if _, statusErr := r.CommitStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.FailedCommitStatus, command.Plan, "", err.Error()); statusErr != nil {
 			cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %v", statusErr))
 		}
 		// If error happened after clone was made, we should clean it up here too

--- a/server/neptune/gateway/event/pull_request_handler.go
+++ b/server/neptune/gateway/event/pull_request_handler.go
@@ -49,10 +49,11 @@ type AsyncAutoplannerWorkerProxy struct {
 
 func (p *AsyncAutoplannerWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
 	go func() {
-		err := p.proxy.Handle(ctx, request, event)
+		// Passing background context to avoid context cancellation since the parent goroutine does not wait for this goroutine to finish execution.
+		err := p.proxy.Handle(context.Background(), request, event)
 
 		if err != nil {
-			p.logger.ErrorContext(ctx, err.Error())
+			p.logger.ErrorContext(context.Background(), err.Error())
 		}
 	}()
 	return nil


### PR DESCRIPTION
Since the parent goroutine does not wait for `AsyncAutoplannerWorkerProxy.Handle()`, we need to pass background context to the `AsyncAutoplannerWorkerProxy.Handle()` to avoid context cancellation.