### PR TITLE
Move root config to signal request.

### DIFF
--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -123,6 +123,18 @@ func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *va
 		workflows.DeployNewRevisionSignalID,
 		workflows.DeployNewRevisionSignalRequest{
 			Revision: event.Sha,
+			Root: workflows.Root{
+				Name: rootCfg.Name,
+				Plan: workflows.Job{
+					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Plan.Steps),
+				},
+				Apply: workflows.Job{
+					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Apply.Steps),
+				},
+				RepoRelPath: rootCfg.RepoRelDir,
+				TfVersion:   tfVersion,
+				PlanMode:    p.generatePlanMode(rootCfg),
+			},
 		},
 		options,
 		workflows.Deploy,
@@ -142,18 +154,6 @@ func (p *PushHandler) startWorkflow(ctx context.Context, event Push, rootCfg *va
 						Type: string(event.Ref.Type),
 					},
 				},
-			},
-			Root: workflows.Root{
-				Name: rootCfg.Name,
-				Plan: workflows.Job{
-					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Plan.Steps),
-				},
-				Apply: workflows.Job{
-					Steps: p.generateSteps(rootCfg.DeploymentWorkflow.Apply.Steps),
-				},
-				RepoRelPath: rootCfg.RepoRelDir,
-				TfVersion:   tfVersion,
-				PlanMode:    p.generatePlanMode(rootCfg),
 			},
 		},
 	)

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -306,6 +306,17 @@ func TestHandlePushEvent(t *testing.T) {
 			expectedSignalName: workflows.DeployNewRevisionSignalID,
 			expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
 				Revision: sha,
+				Root: workflows.Root{
+					Name: testRoot,
+					Plan: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
+					},
+					Apply: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
+					},
+					PlanMode:  workflows.NormalPlanMode,
+					TfVersion: version.String(),
+				},
 			},
 			expectedWorkflow: workflows.Deploy,
 			expectedOptions: client.StartWorkflowOptions{
@@ -323,17 +334,6 @@ func TestHandlePushEvent(t *testing.T) {
 							Type: repoRefType,
 						},
 					},
-				},
-				Root: workflows.Root{
-					Name: testRoot,
-					Plan: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
-					},
-					Apply: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
-					},
-					PlanMode:  workflows.NormalPlanMode,
-					TfVersion: version.String(),
 				},
 			},
 		}
@@ -381,6 +381,17 @@ func TestHandlePushEvent(t *testing.T) {
 			expectedSignalName: workflows.DeployNewRevisionSignalID,
 			expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
 				Revision: sha,
+				Root: workflows.Root{
+					Name: testRoot,
+					Plan: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
+					},
+					Apply: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
+					},
+					PlanMode:  workflows.DestroyPlanMode,
+					TfVersion: version.String(),
+				},
 			},
 			expectedWorkflow: workflows.Deploy,
 			expectedOptions: client.StartWorkflowOptions{
@@ -398,17 +409,6 @@ func TestHandlePushEvent(t *testing.T) {
 							Type: repoRefType,
 						},
 					},
-				},
-				Root: workflows.Root{
-					Name: testRoot,
-					Plan: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
-					},
-					Apply: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
-					},
-					PlanMode:  workflows.DestroyPlanMode,
-					TfVersion: version.String(),
 				},
 			},
 		}
@@ -459,6 +459,17 @@ func TestHandlePushEvent(t *testing.T) {
 			expectedSignalName: workflows.DeployNewRevisionSignalID,
 			expectedSignalArg: workflows.DeployNewRevisionSignalRequest{
 				Revision: sha,
+				Root: workflows.Root{
+					Name: testRoot,
+					Plan: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
+					},
+					Apply: workflows.Job{
+						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
+					},
+					PlanMode:  workflows.NormalPlanMode,
+					TfVersion: version.String(),
+				},
 			},
 			expectedWorkflow: workflows.Deploy,
 			expectedOptions: client.StartWorkflowOptions{
@@ -476,17 +487,6 @@ func TestHandlePushEvent(t *testing.T) {
 							Type: repoRefType,
 						},
 					},
-				},
-				Root: workflows.Root{
-					Name: testRoot,
-					Plan: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultPlanStage.Steps),
-					},
-					Apply: workflows.Job{
-						Steps: convertTestSteps(valid.DefaultApplyStage.Steps),
-					},
-					PlanMode:  workflows.NormalPlanMode,
-					TfVersion: version.String(),
 				},
 			},
 			expectedErr: assert.AnError,

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -6,24 +6,25 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/uber-go/tally/v4"
 	"go.temporal.io/sdk/workflow"
 )
 
 // Export anything that callers need such as requests, signals, etc.
 type DeployRequest = deploy.Request
-type Repo = deploy.Repo
-type Root = deploy.Root
-type Job = deploy.Job
-type Step = deploy.Step
-type AppCredentials = deploy.AppCredentials
-type HeadCommit = deploy.Commit
-type Ref = deploy.Ref
+type Repo = request.Repo
+type Root = request.Root
+type Job = request.Job
+type Step = request.Step
+type AppCredentials = request.AppCredentials
+type HeadCommit = request.Commit
+type Ref = request.Ref
 
-type PlanMode = deploy.PlanMode
+type PlanMode = request.PlanMode
 
-const DestroyPlanMode = deploy.DestroyPlanMode
-const NormalPlanMode = deploy.NormalPlanMode
+const DestroyPlanMode = request.DestroyPlanMode
+const NormalPlanMode = request.NormalPlanMode
 
 type DeployNewRevisionSignalRequest = revision.NewRevisionRequest
 

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -1,79 +1,8 @@
 package deploy
 
-// Types defined here should not be used internally, as our goal should be to eventually swap these out for something less brittle than json translation
-type RefType string
-
-const (
-	Unknown   RefType = "unknown"
-	BranchRef RefType = "branch"
-	TagRef    RefType = "tag"
-)
+import "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 
 type Request struct {
 	GHRequestID string
-	Repository  Repo
-	Root        Root
-}
-
-type Repo struct {
-	// FullName is the owner and repo name separated
-	// by a "/"
-	FullName string
-	// Owner is just the repo owner
-	Owner string
-	// Name is just the repo name, this will never have
-	// /'s in it.
-	Name string
-	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
-	URL string
-
-	Credentials AppCredentials
-	HeadCommit  Commit
-}
-
-type Commit struct {
-	Ref Ref
-}
-
-type Ref struct {
-	Name string
-	Type string
-}
-
-type AppCredentials struct {
-	InstallationToken int64
-}
-
-type PlanMode string
-
-const (
-	DestroyPlanMode PlanMode = "destroy"
-	NormalPlanMode  PlanMode = "normal"
-)
-
-type Root struct {
-	Name        string
-	Apply       Job
-	Plan        Job
-	RepoRelPath string
-	TfVersion   string
-	PlanMode    PlanMode
-}
-
-type Job struct {
-	Steps []Step
-}
-
-// Step was taken from the Atlantis OG config, we might be able to clean this up/remove it
-type Step struct {
-	StepName  string
-	ExtraArgs []string
-	// RunCommand is either a custom run step or the command to run
-	// during an env step to populate the environment variable dynamically.
-	RunCommand string
-	// EnvVarName is the name of the
-	// environment variable that should be set by this step.
-	EnvVarName string
-	// EnvVarValue is the value to set EnvVarName to.
-	EnvVarValue string
+	Repository  request.Repo
 }

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -1,0 +1,47 @@
+package converter
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+)
+
+func Root(external request.Root) root.Root {
+	return root.Root{
+		Name: external.Name,
+		Apply: job.Terraform{
+			Steps: steps(external.Apply.Steps),
+		},
+		Plan: job.Plan{
+			Terraform: job.Terraform{
+				Steps: steps(external.Plan.Steps)},
+			Mode: mode(external.PlanMode),
+		},
+		Path:      external.RepoRelPath,
+		TfVersion: external.TfVersion,
+	}
+
+}
+
+func mode(mode request.PlanMode) *job.PlanMode {
+	switch mode {
+	case request.DestroyPlanMode:
+		return job.NewDestroyPlanMode()
+	}
+
+	return nil
+}
+
+func steps(requestSteps []request.Step) []job.Step {
+	var terraformSteps []job.Step
+	for _, step := range requestSteps {
+		terraformSteps = append(terraformSteps, job.Step{
+			StepName:    step.StepName,
+			ExtraArgs:   step.ExtraArgs,
+			RunCommand:  step.RunCommand,
+			EnvVarName:  step.EnvVarName,
+			EnvVarValue: step.EnvVarValue,
+		})
+	}
+	return terraformSteps
+}

--- a/server/neptune/workflows/internal/deploy/request/repo.go
+++ b/server/neptune/workflows/internal/deploy/request/repo.go
@@ -1,0 +1,39 @@
+package request
+
+// Types defined here should not be used internally, as our goal should be to eventually swap these out for something less brittle than json translation
+type RefType string
+
+const (
+	Unknown   RefType = "unknown"
+	BranchRef RefType = "branch"
+	TagRef    RefType = "tag"
+)
+
+type Repo struct {
+	// FullName is the owner and repo name separated
+	// by a "/"
+	FullName string
+	// Owner is just the repo owner
+	Owner string
+	// Name is just the repo name, this will never have
+	// /'s in it.
+	Name string
+	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
+	URL string
+
+	Credentials AppCredentials
+	HeadCommit  Commit
+}
+
+type Commit struct {
+	Ref Ref
+}
+
+type Ref struct {
+	Name string
+	Type string
+}
+
+type AppCredentials struct {
+	InstallationToken int64
+}

--- a/server/neptune/workflows/internal/deploy/request/root.go
+++ b/server/neptune/workflows/internal/deploy/request/root.go
@@ -1,0 +1,35 @@
+package request
+
+type PlanMode string
+
+const (
+	DestroyPlanMode PlanMode = "destroy"
+	NormalPlanMode  PlanMode = "normal"
+)
+
+type Root struct {
+	Name        string
+	Apply       Job
+	Plan        Job
+	RepoRelPath string
+	TfVersion   string
+	PlanMode    PlanMode
+}
+
+type Job struct {
+	Steps []Step
+}
+
+// Step was taken from the Atlantis OG config, we might be able to clean this up/remove it
+type Step struct {
+	StepName  string
+	ExtraArgs []string
+	// RunCommand is either a custom run step or the command to run
+	// during an env step to populate the environment variable dynamically.
+	RunCommand string
+	// EnvVarName is the name of the
+	// environment variable that should be set by this step.
+	EnvVarName string
+	// EnvVarValue is the value to set EnvVarName to.
+	EnvVarValue string
+}


### PR DESCRIPTION
Since root definitions can change with revisions, this should be passed in through the signal.