### PR TITLE
Handle SIGTERM in temporal worker

### DIFF
--- a/server/logging/logger.go
+++ b/server/logging/logger.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	context "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	logurzap "logur.dev/adapter/zap"
 	"logur.dev/logur"
-	context "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 )
 
 // Logger is the logging interface used throughout the code.
@@ -45,6 +45,12 @@ type logger struct {
 	Closer
 }
 
+type closer struct{}
+
+func (c *closer) Close() error {
+	return nil
+}
+
 func NewLoggerFromLevel(lvl LogLevel) (*logger, error) {
 	structuredLogger, err := NewStructuredLoggerFromLevel(lvl)
 	if err != nil {
@@ -59,6 +65,7 @@ func NewLoggerFromLevel(lvl LogLevel) (*logger, error) {
 
 	return &logger{
 		LoggerFacade: ctxLogger,
+		Closer:       &closer{},
 	}, nil
 
 }

--- a/server/neptune/temporalworker/controllers/job_controller.go
+++ b/server/neptune/temporalworker/controllers/job_controller.go
@@ -19,6 +19,14 @@ type multiplexor interface {
 	Handle(w http.ResponseWriter, r *http.Request) error
 }
 
+type receiverRegistry interface {
+	AddReceiver(jobID string, ch chan string)
+}
+
+type store interface {
+	Get(jobID string) (*job.Job, error)
+}
+
 type JobsController struct {
 	AtlantisVersion string
 	AtlantisURL     *url.URL
@@ -29,14 +37,6 @@ type JobsController struct {
 
 	StatsScope tally.Scope
 	Logger     logging.Logger
-}
-
-type receiverRegistry interface {
-	AddReceiver(jobID string, ch chan string)
-}
-
-type store interface {
-	Get(jobID string) (*job.Job, error)
 }
 
 func NewJobsController(

--- a/server/neptune/temporalworker/controllers/job_controller.go
+++ b/server/neptune/temporalworker/controllers/job_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -20,19 +19,6 @@ type multiplexor interface {
 	Handle(w http.ResponseWriter, r *http.Request) error
 }
 
-type receiverRegistry interface {
-	AddReceiver(jobID string, ch chan string)
-	Broadcast(msg job.OutputLine)
-	Close(ctx context.Context, jobID string)
-}
-
-type store interface {
-	Get(jobID string) (*job.Job, error)
-	Write(jobID string, output string) error
-	Remove(jobID string)
-	Close(ctx context.Context, jobID string, status job.JobStatus) error
-}
-
 type JobsController struct {
 	AtlantisVersion string
 	AtlantisURL     *url.URL
@@ -46,8 +32,8 @@ type JobsController struct {
 }
 
 func NewJobsController(
-	store store,
-	receiverRegistry receiverRegistry,
+	store job.Store,
+	receiverRegistry job.ReceiverRegistry,
 	serverCfg neptune.ServerConfig,
 	scope tally.Scope,
 	logger logging.Logger,

--- a/server/neptune/temporalworker/controllers/job_controller.go
+++ b/server/neptune/temporalworker/controllers/job_controller.go
@@ -31,9 +31,17 @@ type JobsController struct {
 	Logger     logging.Logger
 }
 
+type receiverRegistry interface {
+	AddReceiver(jobID string, ch chan string)
+}
+
+type store interface {
+	Get(jobID string) (*job.Job, error)
+}
+
 func NewJobsController(
-	store job.Store,
-	receiverRegistry job.ReceiverRegistry,
+	store store,
+	receiverRegistry receiverRegistry,
 	serverCfg neptune.ServerConfig,
 	scope tally.Scope,
 	logger logging.Logger,

--- a/server/neptune/temporalworker/job/partition_registry.go
+++ b/server/neptune/temporalworker/job/partition_registry.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PartitionRegistry struct {
-	ReceiverRegistry receiverRegistry
+	ReceiverRegistry ReceiverRegistry
 	Store            Store
 	Logger           logging.Logger
 }

--- a/server/neptune/temporalworker/job/partition_registry.go
+++ b/server/neptune/temporalworker/job/partition_registry.go
@@ -6,9 +6,17 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
+type receiverAdder interface {
+	AddReceiver(jobID string, ch chan string)
+}
+
+type storeGetter interface {
+	Get(jobID string) (*Job, error)
+}
+
 type PartitionRegistry struct {
-	ReceiverRegistry ReceiverRegistry
-	Store            Store
+	ReceiverRegistry receiverAdder
+	Store            storeGetter
 	Logger           logging.Logger
 }
 

--- a/server/neptune/temporalworker/job/partition_registry_test.go
+++ b/server/neptune/temporalworker/job/partition_registry_test.go
@@ -40,6 +40,10 @@ func (t *testStore) Close(ctx context.Context, jobID string, status job.JobStatu
 	return t.Err
 }
 
+func (t *testStore) Cleanup(ctx context.Context) error {
+	return t.Err
+}
+
 type strictTestStore struct {
 	t   *testing.T
 	get struct {
@@ -55,6 +59,10 @@ type strictTestStore struct {
 		count   int
 	}
 	close struct {
+		runners []*testStore
+		count   int
+	}
+	cleanup struct {
 		runners []*testStore
 		count   int
 	}
@@ -93,6 +101,15 @@ func (t strictTestStore) Close(ctx context.Context, jobID string, status job.Job
 	}
 	err := t.close.runners[t.close.count].Close(ctx, jobID, status)
 	t.close.count += 1
+	return err
+}
+
+func (t strictTestStore) Cleanup(ctx context.Context) error {
+	if t.cleanup.count > len(t.cleanup.runners)-1 {
+		t.t.FailNow()
+	}
+	err := t.cleanup.runners[t.cleanup.count].Cleanup(ctx)
+	t.cleanup.count += 1
 	return err
 }
 

--- a/server/neptune/temporalworker/job/receiver_registry_test.go
+++ b/server/neptune/temporalworker/job/receiver_registry_test.go
@@ -27,6 +27,9 @@ func (t *testReceiverRegistry) Broadcast(msg job.OutputLine) {
 func (t *testReceiverRegistry) Close(ctx context.Context, jobID string) {
 }
 
+func (t *testReceiverRegistry) CleanUp() {
+}
+
 type strictTestReceiverRegistry struct {
 	t           *testing.T
 	addReceiver struct {
@@ -38,6 +41,10 @@ type strictTestReceiverRegistry struct {
 		count   int
 	}
 	close struct {
+		runners []*testReceiverRegistry
+		count   int
+	}
+	cleanup struct {
 		runners []*testReceiverRegistry
 		count   int
 	}
@@ -67,6 +74,15 @@ func (t strictTestReceiverRegistry) Close(ctx context.Context, jobID string) {
 	}
 	t.close.runners[t.close.count].Close(ctx, jobID)
 	t.close.count += 1
+	return
+}
+
+func (t *strictTestReceiverRegistry) CleanUp() {
+	if t.cleanup.count > len(t.cleanup.runners)-1 {
+		t.t.FailNow()
+	}
+	t.cleanup.runners[t.cleanup.count].CleanUp()
+	t.cleanup.count += 1
 	return
 }
 

--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -202,7 +202,6 @@ func (s *StorageBackendJobStore) Cleanup(ctx context.Context) error {
 		if err != nil {
 			s.logger.ErrorContext(ctx, fmt.Sprintf("failed to persist job %s on cleanup: %s", jobID, err))
 			failedJobs = append(failedJobs, jobID)
-			continue
 		}
 	}
 

--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ type Store interface {
 	Write(jobID string, output string) error
 	Remove(jobID string)
 	Close(ctx context.Context, jobID string, status JobStatus) error
+	Cleanup(ctx context.Context) error
 }
 
 func NewStorageBackedStore(config valid.Jobs, logger logging.Logger, scope tally.Scope) (*StorageBackendJobStore, error) {
@@ -37,26 +39,28 @@ func NewStorageBackedStore(config valid.Jobs, logger logging.Logger, scope tally
 	}
 
 	return &StorageBackendJobStore{
-		Store: &InMemoryStore{
+		InMemoryStore: &InMemoryStore{
 			jobs: map[string]*Job{},
 		},
 		storageBackend: storageBackend,
+		logger:         logger,
 	}, nil
 }
 
 func NewTestStorageBackedStore(logger logging.Logger, storageBackend StorageBackend, jobs map[string]*Job) *StorageBackendJobStore {
 	return &StorageBackendJobStore{
-		Store: &InMemoryStore{
+		InMemoryStore: &InMemoryStore{
 			jobs: jobs,
 		},
 		storageBackend: storageBackend,
+		logger:         logger,
 	}
 }
 
 // Setup job store for testing
 func NewTestJobStore(storageBackend StorageBackend, jobs map[string]*Job) *StorageBackendJobStore {
 	return &StorageBackendJobStore{
-		Store: &InMemoryStore{
+		InMemoryStore: &InMemoryStore{
 			jobs: jobs,
 		},
 		storageBackend: storageBackend,
@@ -124,15 +128,23 @@ func (m *InMemoryStore) Remove(jobID string) {
 	delete(m.jobs, jobID)
 }
 
+func (m *InMemoryStore) GetJobs() map[string]*Job {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.jobs
+}
+
 // Storage backend job store deals with handling jobs in backend storage
 type StorageBackendJobStore struct {
-	Store
+	*InMemoryStore
 	storageBackend StorageBackend
+	logger         logging.Logger
 }
 
 func (s *StorageBackendJobStore) Get(jobID string) (*Job, error) {
 	// Get job from memory
-	if jobInMem, _ := s.Store.Get(jobID); jobInMem != nil {
+	if jobInMem, _ := s.InMemoryStore.Get(jobID); jobInMem != nil {
 		return jobInMem, nil
 	}
 
@@ -149,18 +161,19 @@ func (s *StorageBackendJobStore) Get(jobID string) (*Job, error) {
 }
 
 func (s StorageBackendJobStore) Write(jobID string, output string) error {
-	return s.Store.Write(jobID, output)
+	return s.InMemoryStore.Write(jobID, output)
 }
 
 // Activity context since it's called from within an activity
 func (s *StorageBackendJobStore) Close(ctx context.Context, jobID string, status JobStatus) error {
-	if err := s.Store.Close(ctx, jobID, status); err != nil {
+	if err := s.InMemoryStore.Close(ctx, jobID, status); err != nil {
 		return err
 	}
 
-	job, err := s.Store.Get(jobID)
+	job, err := s.InMemoryStore.Get(jobID)
 	if err != nil || job == nil {
 		return errors.Wrapf(err, "retrieving job: %s from memory store", jobID)
+
 	}
 
 	ok, err := s.storageBackend.Write(ctx, jobID, job.Output)
@@ -170,11 +183,31 @@ func (s *StorageBackendJobStore) Close(ctx context.Context, jobID string, status
 
 	// Remove from memory if successfully persisted
 	if ok {
-		s.Store.Remove(jobID)
+		s.InMemoryStore.Remove(jobID)
 	}
 	return nil
 }
 
 func (s *StorageBackendJobStore) Remove(jobID string) {
-	s.Store.Remove(jobID)
+	s.InMemoryStore.Remove(jobID)
+}
+
+// Persist all jobs in memory
+func (s *StorageBackendJobStore) Cleanup(ctx context.Context) error {
+	failedJobs := []string{}
+	for jobID, job := range s.InMemoryStore.GetJobs() {
+		_, err := s.storageBackend.Write(ctx, jobID, job.Output)
+
+		// Track failed jobs, log errors and continue with other jobs
+		if err != nil {
+			s.logger.ErrorContext(ctx, fmt.Sprintf("failed to persist job %s on cleanup: %s", jobID, err))
+			failedJobs = append(failedJobs, jobID)
+			continue
+		}
+	}
+
+	if len(failedJobs) > 0 {
+		return errors.Errorf("failed to persist jobs: %s\n", strings.Join(failedJobs, ","))
+	}
+	return nil
 }

--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -21,7 +21,6 @@ type StreamHandler interface {
 	CleanUp(ctx context.Context) error
 }
 
-// TODO: Return streaming channel
 func NewStreamHandler(
 	jobStore Store,
 	receiverRegistry ReceiverRegistry,

--- a/server/neptune/temporalworker/job/stream_handler_test.go
+++ b/server/neptune/temporalworker/job/stream_handler_test.go
@@ -63,7 +63,7 @@ func TestStreamHandler_Handle(t *testing.T) {
 			},
 		}
 
-		streamHandler := job.NewStreamHandler(
+		streamHandler := job.NewTestStreamHandler(
 			testJobStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters(logFilter),
@@ -92,7 +92,7 @@ func TestStreamHandler_Stream(t *testing.T) {
 
 		// Buffered channel to simplify testing since it's not blocking
 		mainTfCh := make(chan *job.OutputLine, len(logs))
-		streamHandler := job.NewStreamHandler(
+		streamHandler := job.NewTestStreamHandler(
 			&testStore{},
 			&testReceiverRegistry{},
 			valid.TerraformLogFilters{},
@@ -157,7 +157,7 @@ func TestStreamHandler_Close(t *testing.T) {
 				},
 			},
 		}
-		streamHandler := job.NewStreamHandler(
+		streamHandler := job.NewTestStreamHandler(
 			testStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters{},
@@ -198,7 +198,7 @@ func TestStreamHandler_Cleanup(t *testing.T) {
 				},
 			},
 		}
-		streamHandler := job.NewStreamHandler(
+		streamHandler := job.NewTestStreamHandler(
 			testStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters{},

--- a/server/neptune/temporalworker/job/stream_handler_test.go
+++ b/server/neptune/temporalworker/job/stream_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
@@ -62,13 +63,13 @@ func TestStreamHandler_Handle(t *testing.T) {
 			},
 		}
 
-		streamHandler := job.StreamHandler{
-			JobOutput:        outputCh,
-			Store:            testJobStore,
-			ReceiverRegistry: testReceiverRegistry,
-			LogFilter:        logFilter,
-			Logger:           logging.NewNoopCtxLogger(t),
-		}
+		streamHandler := job.NewStreamHandler(
+			testJobStore,
+			testReceiverRegistry,
+			valid.TerraformLogFilters(logFilter),
+			outputCh,
+			logging.NewNoopCtxLogger(t),
+		)
 
 		go streamHandler.Handle()
 
@@ -91,13 +92,13 @@ func TestStreamHandler_Stream(t *testing.T) {
 
 		// Buffered channel to simplify testing since it's not blocking
 		mainTfCh := make(chan *job.OutputLine, len(logs))
-		streamHandler := &job.StreamHandler{
-			JobOutput:        mainTfCh,
-			Store:            &testStore{},
-			ReceiverRegistry: &testReceiverRegistry{},
-			Logger:           logging.NewNoopCtxLogger(t),
-		}
-
+		streamHandler := job.NewStreamHandler(
+			&testStore{},
+			&testReceiverRegistry{},
+			valid.TerraformLogFilters{},
+			mainTfCh,
+			logging.NewNoopCtxLogger(t),
+		)
 		go func() {
 			for _, line := range logs {
 				streamHandler.Stream(jobID, line)
@@ -126,7 +127,7 @@ func TestStreamHandler_Close(t *testing.T) {
 	jobID := "1234"
 
 	t.Run("closes receiver registry", func(t *testing.T) {
-		testReceiverRegistry := strictTestReceiverRegistry{
+		testReceiverRegistry := &strictTestReceiverRegistry{
 			t: t,
 			close: struct {
 				runners []*testReceiverRegistry
@@ -141,7 +142,7 @@ func TestStreamHandler_Close(t *testing.T) {
 			},
 		}
 
-		testStore := strictTestStore{
+		testStore := &strictTestStore{
 			t: t,
 			close: struct {
 				runners []*testStore
@@ -156,11 +157,54 @@ func TestStreamHandler_Close(t *testing.T) {
 				},
 			},
 		}
-		streamHandler := job.StreamHandler{
-			Store:            testStore,
-			ReceiverRegistry: testReceiverRegistry,
-			Logger:           logging.NewNoopCtxLogger(t),
+		streamHandler := job.NewStreamHandler(
+			testStore,
+			testReceiverRegistry,
+			valid.TerraformLogFilters{},
+			nil,
+			logging.NewNoopCtxLogger(t),
+		)
+		streamHandler.CloseJob(context.Background(), jobID)
+	})
+}
+
+// Should clean up josb store and receiver registry
+func TestStreamHandler_Cleanup(t *testing.T) {
+	t.Run("cleans up store and receiver registry", func(t *testing.T) {
+		testReceiverRegistry := &strictTestReceiverRegistry{
+			t: t,
+			cleanup: struct {
+				runners []*testReceiverRegistry
+				count   int
+			}{
+				runners: []*testReceiverRegistry{
+					&testReceiverRegistry{
+						t: t,
+					},
+				},
+			},
 		}
-		streamHandler.Close(context.Background(), jobID)
+
+		testStore := &strictTestStore{
+			t: t,
+			cleanup: struct {
+				runners []*testStore
+				count   int
+			}{
+				runners: []*testStore{
+					&testStore{
+						t: t,
+					},
+				},
+			},
+		}
+		streamHandler := job.NewStreamHandler(
+			testStore,
+			testReceiverRegistry,
+			valid.TerraformLogFilters{},
+			nil,
+			logging.NewNoopCtxLogger(t),
+		)
+		streamHandler.CleanUp(context.Background())
 	})
 }

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -37,10 +37,10 @@ const (
 	ProjectJobsViewRouteName = "project-jobs-detail"
 
 	// Equal to default terraform timeout
-	TemporalWorkerTimeout = 60 * 60 * time.Second
+	TemporalWorkerTimeout = time.Hour
 
 	// 5 minutes to allow cleaning up the job store
-	StreamHandlerTimeout = 5 * 60 * time.Second
+	StreamHandlerTimeout = 5 * time.Minute
 )
 
 type Server struct {

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -206,6 +206,7 @@ func (s Server) Start() error {
 	wg.Wait()
 
 	// Close job stream when temporalworker exits to allow gracefully shutting down the stream handler
+	s.Logger.Info("Closing job output channel")
 	close(s.JobStream)
 
 	// On cleanup, stream handler closes all active receivers and persists jobs in memory

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -50,7 +50,7 @@ type Server struct {
 	StatsScope       tally.Scope
 	StatsCloser      io.Closer
 	TemporalClient   *temporal.ClientWrapper
-	JobStreamHandler job.StreamHandler
+	JobStreamHandler *job.StreamHandler
 	JobStream        chan *job.OutputLine
 
 	DeployActivities    *workflows.DeployActivities

--- a/server/neptune/workflows/internal/activities/job.go
+++ b/server/neptune/workflows/internal/activities/job.go
@@ -8,7 +8,7 @@ import (
 )
 
 type streamCloser interface {
-	Close(ctx context.Context, jobID string) error
+	CloseJob(ctx context.Context, jobID string) error
 }
 
 type jobActivities struct {
@@ -20,7 +20,7 @@ type CloseJobRequest struct {
 }
 
 func (t *jobActivities) CloseJob(ctx context.Context, request CloseJobRequest) error {
-	err := t.StreamCloser.Close(ctx, request.JobID)
+	err := t.StreamCloser.CloseJob(ctx, request.JobID)
 	if err != nil {
 		logger.Error(ctx, errors.Wrapf(err, "closing job").Error())
 	}

--- a/server/neptune/workflows/internal/activities/main.go
+++ b/server/neptune/workflows/internal/activities/main.go
@@ -11,6 +11,7 @@ import (
 	legacy_tf "github.com/runatlantis/atlantis/server/core/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/github"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities/terraform"
 	repo "github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github/link"
@@ -53,7 +54,7 @@ type Terraform struct {
 	*jobActivities
 }
 
-func NewTerraform(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler streamHandler) (*Terraform, error) {
+func NewTerraform(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler *job.StreamHandler) (*Terraform, error) {
 	binDir, err := mkSubDir(dataDir, BinDirName)
 	if err != nil {
 		return nil, err

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -39,7 +39,8 @@ type TerraformClient interface {
 
 type streamHandler interface {
 	Stream(jobID string, msg string)
-	Close(ctx context.Context, jobID string) error
+	CloseJob(ctx context.Context, jobID string) error
+	CleanUp(ctx context.Context) error
 }
 
 type terraformActivities struct {
@@ -111,6 +112,9 @@ type TerraformPlanResponse struct {
 }
 
 func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) (TerraformPlanResponse, error) {
+	//TODO: move this to a separate activity that should be invoked at a higher level
+	defer t.StreamHandler.CloseJob(ctx, request.JobID)
+
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
 		return TerraformPlanResponse{}, err

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -39,8 +39,6 @@ type TerraformClient interface {
 
 type streamHandler interface {
 	Stream(jobID string, msg string)
-	CloseJob(ctx context.Context, jobID string) error
-	CleanUp(ctx context.Context) error
 }
 
 type terraformActivities struct {

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -28,7 +28,11 @@ func (t *testStreamHandler) Stream(jobID string, msg string) {
 
 }
 
-func (t *testStreamHandler) Close(ctx context.Context, jobID string) error {
+func (t *testStreamHandler) CloseJob(ctx context.Context, jobID string) error {
+	return nil
+}
+
+func (t *testStreamHandler) CleanUp(ctx context.Context) error {
 	return nil
 }
 

--- a/server/neptune/workflows/internal/activities/terraform_test.go
+++ b/server/neptune/workflows/internal/activities/terraform_test.go
@@ -28,14 +28,6 @@ func (t *testStreamHandler) Stream(jobID string, msg string) {
 
 }
 
-func (t *testStreamHandler) CloseJob(ctx context.Context, jobID string) error {
-	return nil
-}
-
-func (t *testStreamHandler) CleanUp(ctx context.Context) error {
-	return nil
-}
-
 type multiCallTfClient struct {
 	clients []*testTfClient
 

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -28,7 +28,7 @@ type TerraformActivities struct {
 	activities.Terraform
 }
 
-func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler *job.StreamHandler) (*TerraformActivities, error) {
+func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler job.StreamHandler) (*TerraformActivities, error) {
 	terraformActivities, err := activities.NewTerraform(config, dataDir, serverURL, streamHandler)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing terraform activities")

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -28,7 +28,7 @@ type TerraformActivities struct {
 	activities.Terraform
 }
 
-func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler job.StreamHandler) (*TerraformActivities, error) {
+func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler *job.StreamHandler) (*TerraformActivities, error) {
 	terraformActivities, err := activities.NewTerraform(config, dataDir, serverURL, streamHandler)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing terraform activities")


### PR DESCRIPTION
In this PR, we configure the `WorkerStopTimeout` to 60 minutes which is equal to the termination grace period configured for our legacy worker. 

The go routine that runs the temporal worker closes the job output channel when exiting which exits the for loop in `streamHandler.Handle()` and triggers clean up to close any active receivers and persists all jobs in memory. 