### PR TITLE
support workflow mode type in repo config.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -62,7 +62,6 @@ const (
 	DisableApplyFlag           = "disable-apply"
 	DisableAutoplanFlag        = "disable-autoplan"
 	DisableMarkdownFoldingFlag = "disable-markdown-folding"
-	EnablePlatformModeFlag     = "enable-platform-mode"
 	EnableRegExpCmdFlag        = "enable-regexp-cmd"
 	EnableDiffMarkdownFormat   = "enable-diff-markdown-format"
 	FFOwnerFlag                = "ff-owner"

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -329,10 +329,6 @@ var boolFlags = map[string]boolFlag{
 		description:  "Disable atlantis auto planning feature",
 		defaultValue: false,
 	},
-	EnablePlatformModeFlag: {
-		description:  "Enable Atlantis to run in platform mode, where it will run plan and policy checks inside the PR and run plan and apply after PR is merged.",
-		defaultValue: false,
-	},
 	EnableRegExpCmdFlag: {
 		description:  "Enable Atlantis to use regular expressions on plan/apply commands when \"-p\" flag is passed with it.",
 		defaultValue: false,
@@ -456,7 +452,6 @@ func (c *GatewayCreator) NewServer(userConfig server.UserConfig, config server.C
 		AppCfg:                    appConfig,
 		RepoAllowList:             userConfig.RepoAllowlist,
 		MaxProjectsPerPR:          userConfig.MaxProjectsPerPR,
-		EnablePlatformMode:        userConfig.EnablePlatformMode,
 		FFOwner:                   userConfig.FFOwner,
 		FFRepo:                    userConfig.FFRepo,
 		FFBranch:                  userConfig.FFBranch,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -96,7 +96,6 @@ var testFlags = map[string]interface{}{
 	LyftModeFlag:                 "",
 	LyftWorkerQueueUrlFlag:       "",
 	DisableAutoplanFlag:          true,
-	EnablePlatformModeFlag:       false,
 	EnableRegExpCmdFlag:          false,
 	EnableDiffMarkdownFormat:     false,
 }

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1281,7 +1281,7 @@ func ensureRunningConftest(t *testing.T) {
 		t.Logf("could not parse contest version from %s", versionOutput)
 		t.FailNow()
 	}
-	localVersion, err := version.NewVersion(match[3])
+	localVersion, err := version.NewVersion(match[1])
 	Ok(t, err)
 	minVersion, err := version.NewVersion(ConftestVersion)
 	Ok(t, err)
@@ -1327,7 +1327,7 @@ func ensureRunning014(t *testing.T) {
 //	   => 0.11.10
 var versionRegex = regexp.MustCompile("Terraform v(.*?)(\\s.*)?\n")
 
-var versionConftestRegex = regexp.MustCompile("(Version)|(Conftest): (.*?)(\\s.*)?\n")
+var versionConftestRegex = regexp.MustCompile("Version: (.*?)(\\s.*)?\n")
 
 type testLockURLGenerator struct{}
 

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -77,12 +77,10 @@ func (m *NoopTFDownloader) GetAny(dst, src string, opts ...getter.ClientOption) 
 	return nil
 }
 
-type LocalConftestCache struct {
-	conftestPath string
-}
+type LocalConftestCache struct{}
 
 func (m *LocalConftestCache) Get(key *version.Version) (string, error) {
-	return m.conftestPath, nil
+	return exec.LookPath(fmt.Sprintf("conftest%s", ConftestVersion))
 }
 
 func TestGitHubWorkflow(t *testing.T) {
@@ -652,7 +650,6 @@ func TestGitHubWorkflowPullRequestsWorkflows(t *testing.T) {
 
 type e2eOptions struct {
 	featureConfig ffclient.Retriever
-	conftestPath  string
 }
 
 func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig, ghClient vcs.IGithubClient, options ...e2eOptions) (string, events_controllers.VCSEventsController, locking.ApplyLocker) {
@@ -681,6 +678,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 
 	lockURLGenerator := &testLockURLGenerator{}
 	webhookSender := &testWebhookSender{}
+
 	conftestCache := &LocalConftestCache{}
 	downloader := &NoopTFDownloader{}
 	overrideCloneURL := fmt.Sprintf("file://%s", repoDir)

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/atlantis.yaml
@@ -2,5 +2,6 @@ version: 3
 projects:
   - dir: staging
     workspace: staging
+    workflow_mode_type: platform
     autoplan:
       when_modified: ["**/*.tf*"]

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/atlantis.yaml
@@ -1,7 +1,7 @@
 version: 3
+workflow_mode_type: platform
 projects:
   - dir: staging
     workspace: staging
-    workflow_mode_type: platform
     autoplan:
       when_modified: ["**/*.tf*"]

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
@@ -1,1 +1,5 @@
+Ran Apply for dir: `.` workspace: `default`
+
+```diff
 atlantis apply is disabled for this project. Please track the deployment when the PR is merged. 
+```

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
@@ -1,1 +1,1 @@
-**Apply Failed**: Atlantis apply is being deprecated, please merge the PR to apply your changes
+atlantis apply is disabled for this project. Please track the deployment when the PR is merged. 

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/atlantis.yaml
@@ -1,5 +1,5 @@
 version: 3
+workflow_mode_type: platform
 projects:
 - dir: .
-  workflow_mode_type: platform
   workspace: default

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
 projects:
 - dir: .
+  workflow_mode_type: platform
   workspace: default

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-apply.txt
@@ -1,1 +1,5 @@
+Ran Apply for dir: `.` workspace: `default`
+
+```diff
 atlantis apply is disabled for this project. Please track the deployment when the PR is merged. 
+```

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-apply.txt
@@ -1,1 +1,1 @@
-**Apply Failed**: Atlantis apply is being deprecated, please merge the PR to apply your changes
+atlantis apply is disabled for this project. Please track the deployment when the PR is merged. 

--- a/server/core/config/parser_validator_test.go
+++ b/server/core/config/parser_validator_test.go
@@ -1233,6 +1233,12 @@ workflows:
 						PolicyCheck: valid.DefaultPolicyCheckStage,
 					},
 				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
+				},
 			},
 		},
 		"workflow stages empty": {
@@ -1252,6 +1258,12 @@ workflows:
 						Plan:        valid.DefaultPlanStage,
 						PolicyCheck: valid.DefaultPolicyCheckStage,
 					},
+				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
 				},
 			},
 		},
@@ -1273,6 +1285,12 @@ workflows:
 						PolicyCheck: valid.DefaultPolicyCheckStage,
 						Apply:       valid.DefaultApplyStage,
 					},
+				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
 				},
 			},
 		},
@@ -1351,6 +1369,12 @@ policies:
 						},
 					},
 				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
+				},
 			},
 		},
 		"id regex with trailing slash": {
@@ -1368,6 +1392,12 @@ repos:
 				},
 				Workflows: map[string]valid.Workflow{
 					"default": defaultCfg.Workflows["default"],
+				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
 				},
 			},
 		},
@@ -1388,6 +1418,12 @@ repos:
 				},
 				Workflows: map[string]valid.Workflow{
 					"default": defaultCfg.Workflows["default"],
+				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": defaultCfg.DeploymentWorkflows["default"],
 				},
 			},
 		},
@@ -1426,6 +1462,16 @@ workflows:
 								},
 							},
 						},
+						PullRequestWorkflow: &valid.Workflow{
+							Name:        "default",
+							Plan:        valid.DefaultLocklessPlanStage,
+							PolicyCheck: valid.DefaultPolicyCheckStage,
+						},
+						DeploymentWorkflow: &valid.Workflow{
+							Name:  "default",
+							Plan:  valid.DefaultPlanStage,
+							Apply: valid.DefaultApplyStage,
+						},
 						AllowedWorkflows:     []string{},
 						AllowedOverrides:     []string{},
 						AllowCustomWorkflows: Bool(false),
@@ -1446,6 +1492,20 @@ workflows:
 								},
 							},
 						},
+					},
+				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": {
+						Name:        "default",
+						Plan:        valid.DefaultLocklessPlanStage,
+						PolicyCheck: valid.DefaultPolicyCheckStage,
+					},
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": {
+						Name:  "default",
+						Plan:  valid.DefaultPlanStage,
+						Apply: valid.DefaultApplyStage,
 					},
 				},
 			},
@@ -1491,7 +1551,7 @@ workflows:
 }
 
 func TestParseGlobalCfg_PlatformMode(t *testing.T) {
-	defaultCfg := valid.NewGlobalCfg().EnablePlatformMode()
+	defaultCfg := valid.NewGlobalCfg()
 	preWorkflowHook := &valid.PreWorkflowHook{
 		StepName:   "run",
 		RunCommand: "custom workflow command",
@@ -1628,7 +1688,6 @@ policies:
       source: local
 `,
 			exp: valid.GlobalCfg{
-				WorkflowMode: valid.PlatformWorkflowMode,
 				Repos: []valid.Repo{
 					defaultCfg.Repos[0],
 					{
@@ -1688,7 +1747,6 @@ deployment_workflows:
       - run: custom
 `,
 			exp: valid.GlobalCfg{
-				WorkflowMode: valid.PlatformWorkflowMode,
 				Repos: []valid.Repo{
 					{
 						IDRegex:           regexp.MustCompile(".*"),
@@ -1773,7 +1831,7 @@ deployment_workflows:
 			path := filepath.Join(tmp, "conf.yaml")
 			Ok(t, ioutil.WriteFile(path, []byte(c.input), 0600))
 
-			act, err := r.ParseGlobalCfg(path, valid.NewGlobalCfg().EnablePlatformMode())
+			act, err := r.ParseGlobalCfg(path, valid.NewGlobalCfg())
 
 			if c.expErr != "" {
 				expErr := strings.Replace(c.expErr, "<tmp>", path, -1)
@@ -1933,6 +1991,12 @@ func TestParserValidator_ParseGlobalCfgJSON(t *testing.T) {
 					"default": valid.NewGlobalCfg().Workflows["default"],
 					"custom":  customWorkflow,
 				},
+				PullRequestWorkflows: map[string]valid.Workflow{
+					"default": valid.NewGlobalCfg().PullRequestWorkflows["default"],
+				},
+				DeploymentWorkflows: map[string]valid.Workflow{
+					"default": valid.NewGlobalCfg().DeploymentWorkflows["default"],
+				},
 				PolicySets: valid.PolicySets{
 					Version: conftestVersion,
 					PolicySets: []valid.PolicySet{
@@ -2025,7 +2089,7 @@ func TestParserValidator_ParseGlobalCfgV2JSON(t *testing.T) {
 	}
 
 	conftestVersion, _ := version.NewVersion("v1.0.0")
-	globalCfg := valid.NewGlobalCfg().EnablePlatformMode()
+	globalCfg := valid.NewGlobalCfg()
 
 	cases := map[string]struct {
 		json   string
@@ -2103,7 +2167,6 @@ func TestParserValidator_ParseGlobalCfgV2JSON(t *testing.T) {
 }
 `,
 			exp: valid.GlobalCfg{
-				WorkflowMode: valid.PlatformWorkflowMode,
 				Repos: []valid.Repo{
 					globalCfg.Repos[0],
 					{

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -122,11 +122,8 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 
 	defaultRepo := &defaultCfg.Repos[0]
 	validWorkflows := g.Workflows.ToValid(defaultCfg)
-	var validPullRequestWorkflows, validDeploymentWorkflows map[string]valid.Workflow
-	if defaultCfg.PlatformModeEnabled() {
-		validPullRequestWorkflows = g.PullRequestWorkflows.ToValid(defaultCfg)
-		validDeploymentWorkflows = g.DeploymentWorkflows.ToValid(defaultCfg)
-	}
+	validPullRequestWorkflows := g.PullRequestWorkflows.ToValid(defaultCfg)
+	validDeploymentWorkflows := g.DeploymentWorkflows.ToValid(defaultCfg)
 
 	// Handle the special case where they're redefining the default
 	// workflow. In this case, our default repo config references
@@ -155,7 +152,6 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 	repos = append(defaultCfg.Repos, repos...)
 
 	return valid.GlobalCfg{
-		WorkflowMode:         defaultCfg.WorkflowMode,
 		Repos:                repos,
 		Workflows:            validWorkflows,
 		PullRequestWorkflows: validPullRequestWorkflows,

--- a/server/core/config/raw/repo_cfg.go
+++ b/server/core/config/raw/repo_cfg.go
@@ -18,12 +18,13 @@ const DefaultParallelPolicyCheck = false
 
 // RepoCfg is the raw schema for repo-level atlantis.yaml config.
 type RepoCfg struct {
-	Version       *int                `yaml:"version,omitempty"`
-	Projects      []Project           `yaml:"projects,omitempty"`
-	Workflows     map[string]Workflow `yaml:"workflows,omitempty"`
-	PolicySets    PolicySets          `yaml:"policies,omitempty"`
-	ParallelApply *bool               `yaml:"parallel_apply,omitempty"`
-	ParallelPlan  *bool               `yaml:"parallel_plan,omitempty"`
+	Version          *int                `yaml:"version,omitempty"`
+	Projects         []Project           `yaml:"projects,omitempty"`
+	Workflows        map[string]Workflow `yaml:"workflows,omitempty"`
+	PolicySets       PolicySets          `yaml:"policies,omitempty"`
+	ParallelApply    *bool               `yaml:"parallel_apply,omitempty"`
+	ParallelPlan     *bool               `yaml:"parallel_plan,omitempty"`
+	WorkflowModeType string              `yaml:"workflow_mode_type,omitempty"`
 }
 
 func (r RepoCfg) Validate() error {
@@ -41,6 +42,7 @@ func (r RepoCfg) Validate() error {
 		validation.Field(&r.Version, validation.By(equals2)),
 		validation.Field(&r.Projects),
 		validation.Field(&r.Workflows),
+		validation.Field(&r.WorkflowModeType, validation.In("pr", "platform")),
 	)
 }
 
@@ -65,6 +67,12 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		parallelPlan = *r.ParallelPlan
 	}
 
+	workflowModeType := valid.DefaultWorkflowMode
+	switch r.WorkflowModeType {
+	case "platform":
+		workflowModeType = valid.PlatformWorkflowMode
+	}
+
 	return valid.RepoCfg{
 		Version:             *r.Version,
 		Projects:            validProjects,
@@ -72,5 +80,6 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		ParallelApply:       parallelApply,
 		ParallelPlan:        parallelPlan,
 		ParallelPolicyCheck: parallelPlan,
+		WorkflowModeType:    workflowModeType,
 	}
 }

--- a/server/core/config/valid/repo_cfg.go
+++ b/server/core/config/valid/repo_cfg.go
@@ -22,6 +22,7 @@ type RepoCfg struct {
 	ParallelApply        bool
 	ParallelPlan         bool
 	ParallelPolicyCheck  bool
+	WorkflowModeType     WorkflowModeType
 }
 
 func (r RepoCfg) FindProjectsByDirWorkspace(repoRelDir string, workspace string) []Project {

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"time"
-
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/uber-go/tally/v4"

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -77,6 +77,7 @@ func NewProjectContext(
 		PullReqStatus:        pullStatus,
 		JobID:                uuid.New().String(),
 		RequestCtx:           ctx.RequestCtx,
+		WorkflowModeType:     projCfg.WorkflowMode,
 	}
 }
 
@@ -155,6 +156,8 @@ type ProjectContext struct {
 	RequestCtx context.Context
 	// StatusId is used for consecutive status updates in the step runners
 	StatusId string
+
+	WorkflowModeType valid.WorkflowModeType
 }
 
 // ProjectCloneDir creates relative path to clone the repo to. If we are running

--- a/server/events/output_updater.go
+++ b/server/events/output_updater.go
@@ -123,6 +123,10 @@ func (c *ChecksOutputUpdater) handleCommandFailure(ctx *command.Context, cmd Pul
 
 func (c *ChecksOutputUpdater) buildJobURL(ctx *command.Context, cmd command.Name, jobID string) string {
 
+	if jobID == "" {
+		return ""
+	}
+
 	// Only support streaming logs for plan and apply operation for now
 	if cmd == command.Plan || cmd == command.Apply {
 		jobURL, err := c.JobURLGenerator.GenerateProjectJobURL(jobID)

--- a/server/events/pr_project_context_builder.go
+++ b/server/events/pr_project_context_builder.go
@@ -1,24 +1,36 @@
 package events
 
 import (
+	"fmt"
+
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 )
 
-func NewPRProjectCommandContextBuilder(
+func NewPlatformModeProjectCommandContextBuilder(
 	commentBuilder CommentBuilder,
-) ProjectCommandContextBuilder {
-	return &prProjectContextBuilder{
+	delegate ProjectCommandContextBuilder,
+	logger logging.Logger,
+	allocator feature.Allocator,
+) *PlatformModeProjectContextBuilder {
+	return &PlatformModeProjectContextBuilder{
 		CommentBuilder: commentBuilder,
+		delegate:       delegate,
+		Logger:         logger,
+		allocator:      allocator,
 	}
 }
 
-type prProjectContextBuilder struct {
-	ProjectCommandContextBuilder
+type PlatformModeProjectContextBuilder struct {
+	delegate       ProjectCommandContextBuilder
+	allocator      feature.Allocator
 	CommentBuilder CommentBuilder
+	Logger         logging.Logger
 }
 
-func (p *prProjectContextBuilder) BuildProjectContext(
+func (p *PlatformModeProjectContextBuilder) BuildProjectContext(
 	ctx *command.Context,
 	cmdName command.Name,
 	prjCfg valid.MergedProjectCfg,
@@ -26,14 +38,23 @@ func (p *prProjectContextBuilder) BuildProjectContext(
 	repoDir string,
 	contextFlags *command.ContextFlags,
 ) []command.ProjectContext {
-	return buildContext(
-		ctx,
-		cmdName,
-		getSteps(cmdName, prjCfg.PullRequestWorkflow, contextFlags.LogLevel),
-		p.CommentBuilder,
-		prjCfg,
-		commentArgs,
-		repoDir,
-		contextFlags,
-	)
+	shouldAllocate, err := p.allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{RepoName: ctx.HeadRepo.FullName})
+	if err != nil {
+		p.Logger.ErrorContext(ctx.RequestCtx, fmt.Sprintf("unable to allocate for feature: %s, error: %s", feature.PlatformMode, err))
+	}
+
+	if shouldAllocate && prjCfg.WorkflowMode == valid.PlatformWorkflowMode {
+		return buildContext(
+			ctx,
+			cmdName,
+			getSteps(cmdName, prjCfg.PullRequestWorkflow, contextFlags.LogLevel),
+			p.CommentBuilder,
+			prjCfg,
+			commentArgs,
+			repoDir,
+			contextFlags,
+		)
+	}
+
+	return p.delegate.BuildProjectContext(ctx, cmdName, prjCfg, commentArgs, repoDir, contextFlags)
 }

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -1,93 +1,438 @@
 package command_test
 
 import (
+	"context"
+	"gopkg.in/go-playground/assert.v1"
 	"testing"
 
-	. "github.com/petergtz/pegomock"
-
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
-	"github.com/runatlantis/atlantis/server/events/command/mocks"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	lyftCommand "github.com/runatlantis/atlantis/server/lyft/command"
-	featureMocks "github.com/runatlantis/atlantis/server/lyft/feature/mocks"
-	featureMatchers "github.com/runatlantis/atlantis/server/lyft/feature/mocks/matchers"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 )
 
-var dbUpdater *events.DBUpdater
-var pullUpdater *events.PullOutputUpdater
-var policyCheckCommandRunner *events.PolicyCheckCommandRunner
-var planCommandRunner *events.PlanCommandRunner
-var preWorkflowHooksCommandRunner events.PreWorkflowHooksCommandRunner
+type testAllocator struct {
+	expectedFeatureName feature.Name
+	expectedCtx         feature.FeatureContext
+	expectedT           *testing.T
 
-func TestFeatureAllocatorRunner(t *testing.T) {
-	featureAllocator := featureMocks.NewMockAllocator()
-	testLogger := logging.NewNoopCtxLogger(t)
-	// platformModeRunner := plan.NewRunner(vcsClient)
+	expectedResult bool
+	expectedErr    error
+}
+
+func (t *testAllocator) ShouldAllocate(name feature.Name, ctx feature.FeatureContext) (bool, error) {
+	assert.Equal(t.expectedT, t.expectedFeatureName, name)
+	assert.Equal(t.expectedT, t.expectedCtx, ctx)
+
+	return t.expectedResult, t.expectedErr
+}
+
+type testRunner struct {
+	expectedPlanResult            command.ProjectResult
+	expectedPolicyCheckResult     command.ProjectResult
+	expectedApplyResult           command.ProjectResult
+	expectedApprovePoliciesResult command.ProjectResult
+	expectedVersionResult         command.ProjectResult
+}
+
+// Plan runs terraform plan for the project described by ctx.
+func (r *testRunner) Plan(ctx command.ProjectContext) command.ProjectResult {
+	return r.expectedPlanResult
+}
+
+// PolicyCheck evaluates policies defined with Rego for the project described by ctx.
+func (r *testRunner) PolicyCheck(ctx command.ProjectContext) command.ProjectResult {
+	return r.expectedPolicyCheckResult
+}
+
+// Apply runs terraform apply for the project described by ctx.
+func (r *testRunner) Apply(ctx command.ProjectContext) command.ProjectResult {
+	return r.expectedApplyResult
+}
+
+func (r *testRunner) ApprovePolicies(ctx command.ProjectContext) command.ProjectResult {
+	return r.expectedApprovePoliciesResult
+}
+
+func (r *testRunner) Version(ctx command.ProjectContext) command.ProjectResult {
+	return r.expectedVersionResult
+}
+
+func TestPlatformModeProjectRunner_plan(t *testing.T) {
+	expectedResult := command.ProjectResult{
+		JobId: "1234y",
+	}
+
 	cases := []struct {
-		description         string
-		platformModeEnabled bool
-		allocated           bool
-		err                 error
+		description      string
+		shouldAllocate   bool
+		workflowModeType valid.WorkflowModeType
+		platformRunner   events.ProjectCommandRunner
+		prModeRunner     events.ProjectCommandRunner
+		subject          lyftCommand.PlatformModeProjectRunner
 	}{
 		{
-			description:         "feature allocated and platform mode enabled",
-			platformModeEnabled: true,
-			allocated:           true,
+			description:      "allocated and platform mode enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner: &testRunner{
+				expectedPlanResult: expectedResult,
+			},
+			prModeRunner: &testRunner{},
 		},
 		{
-			description:         "feature allocated and platform mode disabled",
-			platformModeEnabled: false,
-			allocated:           true,
+			description:      "allocated and platform mode not enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.DefaultWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedPlanResult: expectedResult,
+			},
 		},
 		{
-			description:         "feature not allocated and platform mode enabled",
-			platformModeEnabled: true,
-			allocated:           false,
-		},
-		{
-			description:         "feature not allocated and platform mode disabled",
-			platformModeEnabled: false,
-			allocated:           false,
+			description:      "not allocated and platform mode enabled",
+			shouldAllocate:   false,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedPlanResult: expectedResult,
+			},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			RegisterMockTestingT(t)
-
-			allocatedRunner := mocks.NewMockRunner()
-			unallocatedRunner := mocks.NewMockRunner()
-			featuredRunner := lyftCommand.NewPlatformModeFeatureRunner(
-				featureAllocator,
-				c.platformModeEnabled,
-				testLogger,
-				allocatedRunner,
-				unallocatedRunner,
-			)
-
-			When(featureAllocator.ShouldAllocate(
-				featureMatchers.AnyFeatureName(),
-				featureMatchers.AnyFeatureFeatureContext(),
-			)).ThenReturn(c.allocated, c.err)
-
-			ctx := &command.Context{
-				HeadRepo: models.Repo{
-					FullName: "test-repo",
+			subject := lyftCommand.PlatformModeProjectRunner{
+				PlatformModeRunner: c.platformRunner,
+				PrModeRunner:       c.prModeRunner,
+				Allocator: &testAllocator{
+					expectedResult:      c.shouldAllocate,
+					expectedFeatureName: feature.PlatformMode,
+					expectedCtx: feature.FeatureContext{
+						RepoName: "nish/repo",
+					},
 				},
+				Logger: logging.NewNoopCtxLogger(t),
 			}
-			cmd := &command.Comment{}
-			featuredRunner.Run(ctx, cmd)
 
-			if c.platformModeEnabled && c.allocated {
-				allocatedRunner.VerifyWasCalledOnce().Run(ctx, cmd)
-				unallocatedRunner.VerifyWasCalled(Never()).Run(ctx, cmd)
-			} else {
-				allocatedRunner.VerifyWasCalled(Never()).Run(ctx, cmd)
-				unallocatedRunner.VerifyWasCalledOnce().Run(ctx, cmd)
-			}
+			result := subject.Plan(command.ProjectContext{
+				RequestCtx: context.Background(),
+				HeadRepo: models.Repo{
+					FullName: "nish/repo",
+				},
+				WorkflowModeType: c.workflowModeType,
+			})
+
+			assert.Equal(t, expectedResult, result)
 		})
+	}
+}
 
+func TestPlatformModeProjectRunner_policyCheck(t *testing.T) {
+	expectedResult := command.ProjectResult{
+		JobId: "1234y",
+	}
+
+	cases := []struct {
+		description      string
+		shouldAllocate   bool
+		workflowModeType valid.WorkflowModeType
+		platformRunner   events.ProjectCommandRunner
+		prModeRunner     events.ProjectCommandRunner
+		subject          lyftCommand.PlatformModeProjectRunner
+	}{
+		{
+			description:      "allocated and platform mode enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner: &testRunner{
+				expectedPolicyCheckResult: expectedResult,
+			},
+			prModeRunner: &testRunner{},
+		},
+		{
+			description:      "allocated and platform mode not enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.DefaultWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedPolicyCheckResult: expectedResult,
+			},
+		},
+		{
+			description:      "not allocated and platform mode enabled",
+			shouldAllocate:   false,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedPolicyCheckResult: expectedResult,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			subject := lyftCommand.PlatformModeProjectRunner{
+				PlatformModeRunner: c.platformRunner,
+				PrModeRunner:       c.prModeRunner,
+				Allocator: &testAllocator{
+					expectedResult:      c.shouldAllocate,
+					expectedFeatureName: feature.PlatformMode,
+					expectedCtx: feature.FeatureContext{
+						RepoName: "nish/repo",
+					},
+				},
+				Logger: logging.NewNoopCtxLogger(t),
+			}
+
+			result := subject.PolicyCheck(command.ProjectContext{
+				RequestCtx: context.Background(),
+				HeadRepo: models.Repo{
+					FullName: "nish/repo",
+				},
+				WorkflowModeType: c.workflowModeType,
+			})
+
+			assert.Equal(t, expectedResult, result)
+		})
+	}
+}
+
+func TestPlatformModeProjectRunner_apply(t *testing.T) {
+	cases := []struct {
+		description      string
+		shouldAllocate   bool
+		workflowModeType valid.WorkflowModeType
+		platformRunner   events.ProjectCommandRunner
+		prModeRunner     events.ProjectCommandRunner
+		subject          lyftCommand.PlatformModeProjectRunner
+		expectedResult   command.ProjectResult
+	}{
+		{
+			description:      "allocated and platform mode enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner: &testRunner{
+				expectedApplyResult: command.ProjectResult{
+					RepoRelDir:   "reldir",
+					Workspace:    "default",
+					ProjectName:  "project",
+					StatusId:     "id",
+					Command:      command.Apply,
+					ApplySuccess: "atlantis apply is disabled for this project. Please track the deployment when the PR is merged. ",
+				},
+			},
+			expectedResult: command.ProjectResult{
+				RepoRelDir:   "reldir",
+				Workspace:    "default",
+				ProjectName:  "project",
+				StatusId:     "id",
+				Command:      command.Apply,
+				ApplySuccess: "atlantis apply is disabled for this project. Please track the deployment when the PR is merged. ",
+			},
+			prModeRunner: &testRunner{},
+		},
+		{
+			description:      "allocated and platform mode not enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.DefaultWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedApplyResult: command.ProjectResult{
+					JobId: "1234y",
+				},
+			},
+			expectedResult: command.ProjectResult{
+				JobId: "1234y",
+			},
+		},
+		{
+			description:      "not allocated and platform mode enabled",
+			shouldAllocate:   false,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedApplyResult: command.ProjectResult{
+					JobId: "1234y",
+				},
+			},
+			expectedResult: command.ProjectResult{
+				JobId: "1234y",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			subject := lyftCommand.PlatformModeProjectRunner{
+				PlatformModeRunner: c.platformRunner,
+				PrModeRunner:       c.prModeRunner,
+				Allocator: &testAllocator{
+					expectedResult:      c.shouldAllocate,
+					expectedFeatureName: feature.PlatformMode,
+					expectedCtx: feature.FeatureContext{
+						RepoName: "nish/repo",
+					},
+				},
+				Logger: logging.NewNoopCtxLogger(t),
+			}
+
+			result := subject.Apply(command.ProjectContext{
+				RequestCtx: context.Background(),
+				HeadRepo: models.Repo{
+					FullName: "nish/repo",
+				},
+				RepoRelDir:       "reldir",
+				Workspace:        "default",
+				ProjectName:      "project",
+				StatusId:         "id",
+				WorkflowModeType: c.workflowModeType,
+			})
+
+			assert.Equal(t, c.expectedResult, result)
+		})
+	}
+}
+
+func TestPlatformModeProjectRunner_approvePolicies(t *testing.T) {
+	expectedResult := command.ProjectResult{
+		JobId: "1234y",
+	}
+
+	cases := []struct {
+		description      string
+		shouldAllocate   bool
+		workflowModeType valid.WorkflowModeType
+		platformRunner   events.ProjectCommandRunner
+		prModeRunner     events.ProjectCommandRunner
+		subject          lyftCommand.PlatformModeProjectRunner
+	}{
+		{
+			description:      "allocated and platform mode enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner: &testRunner{
+				expectedApprovePoliciesResult: expectedResult,
+			},
+			prModeRunner: &testRunner{},
+		},
+		{
+			description:      "allocated and platform mode not enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.DefaultWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedApprovePoliciesResult: expectedResult,
+			},
+		},
+		{
+			description:      "not allocated and platform mode enabled",
+			shouldAllocate:   false,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedApprovePoliciesResult: expectedResult,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			subject := lyftCommand.PlatformModeProjectRunner{
+				PlatformModeRunner: c.platformRunner,
+				PrModeRunner:       c.prModeRunner,
+				Allocator: &testAllocator{
+					expectedResult:      c.shouldAllocate,
+					expectedFeatureName: feature.PlatformMode,
+					expectedCtx: feature.FeatureContext{
+						RepoName: "nish/repo",
+					},
+				},
+				Logger: logging.NewNoopCtxLogger(t),
+			}
+
+			result := subject.ApprovePolicies(command.ProjectContext{
+				RequestCtx: context.Background(),
+				HeadRepo: models.Repo{
+					FullName: "nish/repo",
+				},
+				WorkflowModeType: c.workflowModeType,
+			})
+
+			assert.Equal(t, expectedResult, result)
+		})
+	}
+}
+
+func TestPlatformModeProjectRunner_version(t *testing.T) {
+	expectedResult := command.ProjectResult{
+		JobId: "1234y",
+	}
+
+	cases := []struct {
+		description      string
+		shouldAllocate   bool
+		workflowModeType valid.WorkflowModeType
+		platformRunner   events.ProjectCommandRunner
+		prModeRunner     events.ProjectCommandRunner
+		subject          lyftCommand.PlatformModeProjectRunner
+	}{
+		{
+			description:      "allocated and platform mode enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner: &testRunner{
+				expectedVersionResult: expectedResult,
+			},
+			prModeRunner: &testRunner{},
+		},
+		{
+			description:      "allocated and platform mode not enabled",
+			shouldAllocate:   true,
+			workflowModeType: valid.DefaultWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedVersionResult: expectedResult,
+			},
+		},
+		{
+			description:      "not allocated and platform mode enabled",
+			shouldAllocate:   false,
+			workflowModeType: valid.PlatformWorkflowMode,
+			platformRunner:   &testRunner{},
+			prModeRunner: &testRunner{
+				expectedVersionResult: expectedResult,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			subject := lyftCommand.PlatformModeProjectRunner{
+				PlatformModeRunner: c.platformRunner,
+				PrModeRunner:       c.prModeRunner,
+				Allocator: &testAllocator{
+					expectedResult:      c.shouldAllocate,
+					expectedFeatureName: feature.PlatformMode,
+					expectedCtx: feature.FeatureContext{
+						RepoName: "nish/repo",
+					},
+				},
+				Logger: logging.NewNoopCtxLogger(t),
+			}
+
+			result := subject.Version(command.ProjectContext{
+				RequestCtx: context.Background(),
+				HeadRepo: models.Repo{
+					FullName: "nish/repo",
+				},
+				WorkflowModeType: c.workflowModeType,
+			})
+
+			assert.Equal(t, expectedResult, result)
+		})
 	}
 }

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -55,7 +55,6 @@ type Config struct {
 	AppCfg                    githubapp.Config
 	RepoAllowList             string
 	MaxProjectsPerPR          int
-	EnablePlatformMode        bool
 	FFOwner                   string
 	FFRepo                    string
 	FFBranch                  string

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -101,9 +101,6 @@ func NewServer(config Config) (*Server, error) {
 	}
 
 	globalCfg := valid.NewGlobalCfg()
-	if config.EnablePlatformMode {
-		globalCfg = globalCfg.EnablePlatformMode()
-	}
 	validator := &cfgParser.ParserValidator{}
 	if config.RepoConfig != "" {
 		globalCfg, err = validator.ParseGlobalCfg(config.RepoConfig, globalCfg)

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -33,7 +33,6 @@ type UserConfig struct {
 	DisableApply               bool   `mapstructure:"disable-apply"`
 	DisableAutoplan            bool   `mapstructure:"disable-autoplan"`
 	DisableMarkdownFolding     bool   `mapstructure:"disable-markdown-folding"`
-	EnablePlatformMode         bool   `mapstructure:"enable-platform-mode"`
 	EnablePolicyChecks         bool   `mapstructure:"enable-policy-checks"`
 	EnableRegExpCmd            bool   `mapstructure:"enable-regexp-cmd"`
 	EnableDiffMarkdownFormat   bool   `mapstructure:"enable-diff-markdown-format"`


### PR DESCRIPTION
This will allow us to cutover individual roots using the repo config.  Additionally, this has the additional benefit of supporting our existing atlantis apply statuses since we are confirming to the project command runner pattern.