### PR TITLE
Fix nil DeploymentInfo bug in Deploy workflow worker

### DIFF
--- a/server/neptune/workflows/internal/activities/db.go
+++ b/server/neptune/workflows/internal/activities/db.go
@@ -9,7 +9,7 @@ import (
 
 type store interface {
 	GetDeploymentInfo(ctx context.Context, repoName string, rootName string) (*root.DeploymentInfo, error)
-	SetDeploymentInfo(ctx context.Context, deploymentInfo root.DeploymentInfo) error
+	SetDeploymentInfo(ctx context.Context, deploymentInfo *root.DeploymentInfo) error
 }
 
 type dbActivities struct {
@@ -37,7 +37,7 @@ func (a *dbActivities) FetchLatestDeployment(ctx context.Context, request FetchL
 }
 
 type StoreLatestDeploymentRequest struct {
-	DeploymentInfo root.DeploymentInfo
+	DeploymentInfo *root.DeploymentInfo
 }
 
 func (a *dbActivities) StoreLatestDeployment(ctx context.Context, request StoreLatestDeploymentRequest) error {

--- a/server/neptune/workflows/internal/activities/deployment/store.go
+++ b/server/neptune/workflows/internal/activities/deployment/store.go
@@ -59,7 +59,7 @@ func (s *Store) GetDeploymentInfo(ctx context.Context, repoName string, rootName
 	return &deploymentInfo, nil
 }
 
-func (s *Store) SetDeploymentInfo(ctx context.Context, deploymentInfo root.DeploymentInfo) error {
+func (s *Store) SetDeploymentInfo(ctx context.Context, deploymentInfo *root.DeploymentInfo) error {
 	key := BuildKey(deploymentInfo.Repo.GetFullName(), deploymentInfo.Root.Name)
 	object, err := json.Marshal(deploymentInfo)
 	if err != nil {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -108,7 +108,6 @@ func (w *Worker) Work(ctx workflow.Context) {
 			}
 		}
 
-		// LatestDeployment is nil if this a first deploy for the root
 		shouldDeployRevision, err := w.proecessRevision(ctx, msg, latestDeployment)
 		if err != nil {
 			logger.Error(ctx, "failed to process revision, moving to next one: %s", err.Error())

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -334,7 +334,10 @@ func TestWorker_CompareCommit_Deploy(t *testing.T) {
 }
 
 func TestWorker_FirstDeploy(t *testing.T) {
-	deploymentInfo, _, _, fetchDeploymentRequest, fetchDeploymentResponse, _, storeLatestDeploymentReq := getTestArtifacts()
+	deploymentInfo, _, _, fetchDeploymentRequest, _, _, storeLatestDeploymentReq := getTestArtifacts()
+	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
+		DeploymentInfo: nil,
+	}
 
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -149,7 +149,7 @@ func TestWorker_FetchLatestDeploymentOnStartupOnly(t *testing.T) {
 	env.OnActivity(da.CompareCommit, mock.Anything, activities.CompareCommitRequest{
 		Repo:                   repo,
 		DeployRequestRevision:  deploymentInfoList[1].Revision,
-		LatestDeployedRevision: latestDeployment.Revision,
+		LatestDeployedRevision: deploymentInfoList[0].Revision,
 	}).Return(activities.CompareCommitResponse{
 		CommitComparison: activities.DirectionAhead,
 	}, nil)
@@ -183,6 +183,8 @@ func TestWorker_FetchLatestDeploymentOnStartupOnly(t *testing.T) {
 	env.ExecuteWorkflow(testWorkflow, request{
 		Queue: deploymentInfoList,
 	})
+
+	env.AssertExpectations(t)
 
 	var resp response
 	err := env.GetWorkflowResult(&resp)
@@ -254,6 +256,8 @@ func TestWorker_CompareCommit_SkipDeploy(t *testing.T) {
 				Queue: deploymentInfoList,
 			})
 
+			env.AssertExpectations(t)
+
 			var resp response
 			err := env.GetWorkflowResult(&resp)
 			assert.NoError(t, err)
@@ -322,6 +326,8 @@ func TestWorker_CompareCommit_Deploy(t *testing.T) {
 				Queue: deploymentInfoList,
 			})
 
+			env.AssertExpectations(t)
+
 			var resp response
 			err := env.GetWorkflowResult(&resp)
 			assert.NoError(t, err)
@@ -373,6 +379,8 @@ func TestWorker_FirstDeploy(t *testing.T) {
 	env.ExecuteWorkflow(testWorkflow, request{
 		Queue: deploymentInfoList,
 	})
+
+	env.AssertExpectations(t)
 
 	var resp response
 	err := env.GetWorkflowResult(&resp)


### PR DESCRIPTION
When a root is being deployed for a first time, we get an nil `DeploymentInfo` object which is referenced when comparing commits. So, we add a nil check before comparing commits.  