### PR TITLE
Fix nil Clenaup function when fetch root fails

### DIFF
--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -24,7 +24,7 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*root.LocalRoot, func() error
 	}).Get(ctx, &fetchRootResponse)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, func() error { return nil }, err
 	}
 
 	return fetchRootResponse.LocalRoot, func() error {


### PR DESCRIPTION
When `FetchRoot` activity fails, it returns a nil cleanup function which gets called when the calling method is exiting. So, let's return a no-op function instead. 