### PR TITLE
Lock workflow when force applies occur on root

### DIFF
--- a/server/neptune/workflows/internal/config/logger/logger.go
+++ b/server/neptune/workflows/internal/config/logger/logger.go
@@ -5,11 +5,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-func Info(ctx workflow.Context, msg string) {
+func Info(ctx workflow.Context, msg string, additionalKVs ...interface{}) {
 	logger := workflow.GetLogger(ctx)
 	kvs := context.ExtractFieldsAsList(ctx)
 
-	logger.Info(msg, kvs...)
+	logger.Info(msg, append(kvs, additionalKVs)...)
 }
 
 func Warn(ctx workflow.Context, msg string, additionalKVs ...interface{}) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
@@ -41,7 +41,7 @@ func (p *RevisionProcessor) Process(ctx workflow.Context, requestedDeployment te
 		if err = p.updateCheckRun(ctx, requestedDeployment, github.CheckRunFailure, DirectionBehindSummary, nil); err != nil {
 			logger.Error(ctx, "unable to update check run", err.Error())
 		}
-		return fmt.Errorf("requested revision %s is behind current one %s", requestedDeployment.Revision, latestDeployment.GetRevision())
+		return fmt.Errorf("requested revision %s is behind current one %s", requestedDeployment.Revision, latestDeployment.Revision)
 	case activities.DirectionDiverged:
 		return p.waitForUserUnlock(ctx, requestedDeployment)
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
@@ -1,0 +1,113 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+type githubActivities interface {
+	CompareCommit(ctx context.Context, request activities.CompareCommitRequest) (activities.CompareCommitResponse, error)
+	UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
+}
+
+type RevisionProcessor struct {
+	Activities githubActivities
+}
+
+const (
+	DirectionBehindSummary   = "This revision is behind the current revision and will not be deployed.  If this is intentional, revert the default branch to this revision to trigger a new deployment."
+	UpdateCheckRunRetryCount = 5
+
+	ForceApplySummary = "The current deployment has diverged from the default branch, so we have locked the root. This is most likely the result of this PR performing a deployment. To override that lock and allow the main branch to perform new deployments, select the Unlock button."
+)
+
+func (p *RevisionProcessor) Process(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) error {
+	commitDirection, err := p.getDeployRequestCommitDirection(ctx, requestedDeployment, latestDeployment)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(ctx, fmt.Sprintf("relationship of deployed to requested revision: %s", commitDirection),
+		"deployed-revision", latestDeployment.GetRevision(),
+		"requested-revision", requestedDeployment.Revision)
+
+	switch commitDirection {
+	case activities.DirectionBehind:
+		p.updateCheckRun(ctx, requestedDeployment, github.CheckRunFailure, DirectionBehindSummary)
+		return errors.New("requested revision is behind current one")
+	case activities.DirectionDiverged:
+		return p.lock(ctx, requestedDeployment)
+	}
+	return nil
+}
+
+func (p *RevisionProcessor) getDeployRequestCommitDirection(ctx workflow.Context, deployRequest terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) (activities.DiffDirection, error) {
+	// root being deployed for the first time
+	if latestDeployment == nil {
+		return activities.DirectionAhead, nil
+	}
+
+	var compareCommitResp activities.CompareCommitResponse
+	err := workflow.ExecuteActivity(ctx, p.Activities.CompareCommit, activities.CompareCommitRequest{
+		DeployRequestRevision:  deployRequest.Revision,
+		LatestDeployedRevision: latestDeployment.Revision,
+		Repo:                   deployRequest.Repo,
+	}).Get(ctx, &compareCommitResp)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to determine deploy request commit direction")
+	}
+	return compareCommitResp.CommitComparison, nil
+}
+
+// worker should not block on updating check runs for invalid deploy requests so let's retry for UpdateCheckrunRetryCount only
+func (p *RevisionProcessor) updateCheckRun(ctx workflow.Context, deployRequest terraform.DeploymentInfo, state github.CheckRunState, summary string) {
+	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
+		MaximumAttempts: UpdateCheckRunRetryCount,
+	})
+
+	err := workflow.ExecuteActivity(ctx, p.Activities.UpdateCheckRun, activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(deployRequest.Root.Name),
+		State:   state,
+		Repo:    deployRequest.Repo,
+		ID:      deployRequest.CheckRunID,
+		Summary: summary,
+	}).Get(ctx, nil)
+	if err != nil {
+		logger.Error(ctx, "unable to update checkrun", err.Error())
+	}
+}
+
+// For merged deployments, notify user of a force apply lock status and lock future deployments until signal is received
+func (p *RevisionProcessor) lock(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo) error {
+	// We won't lock any manually triggered
+	if deploymentInfo.Root.Trigger == root.ManualTrigger {
+		return nil
+	}
+	request := activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+		State:   github.CheckRunPending,
+		Repo:    deploymentInfo.Repo,
+		ID:      deploymentInfo.CheckRunID,
+		Summary: ForceApplySummary,
+		Actions: []github.CheckRunAction{github.CreateUnlockAction()},
+	}
+	var resp activities.UpdateCheckRunResponse
+	err := workflow.ExecuteActivity(ctx, p.Activities.UpdateCheckRun, request).Get(ctx, &resp)
+	if err != nil {
+		return errors.Wrap(err, "updating check run")
+	}
+	// Wait for unlock signal
+	signalChan := workflow.GetSignalChannel(ctx, UnlockSignalName)
+	var unlockRequest UnlockSignalRequest
+	_ = signalChan.Receive(ctx, &unlockRequest)
+	// TODO: store info on user that unlocked revision, maybe within the check run or just log it?
+	return nil
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -9,17 +9,12 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
-const (
-	UpdateCheckRunRetryCount = 5
-	DeploymentInfoVersion    = "1.0.0"
-	DirectionBehindSummary   = "This revision is behind the current revision and will not be deployed.  If this is intentional, revert the default branch to this revision to trigger a new deployment."
-)
+const DeploymentInfoVersion = "1.0.0"
 
 type terraformWorkflowRunner interface {
 	Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo) error
@@ -30,14 +25,12 @@ type dbActivities interface {
 	StoreLatestDeployment(ctx context.Context, request activities.StoreLatestDeploymentRequest) error
 }
 
-type githubActivities interface {
-	CompareCommit(ctx context.Context, request activities.CompareCommitRequest) (activities.CompareCommitResponse, error)
-	UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
+type revisionProcessor interface {
+	Process(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) error
 }
 
 type workerActivities interface {
 	dbActivities
-	githubActivities
 }
 
 type WorkerState string
@@ -58,6 +51,7 @@ type Worker struct {
 	Queue                   *Queue
 	TerraformWorkflowRunner terraformWorkflowRunner
 	Activities              workerActivities
+	RevisionProcessor       revisionProcessor
 
 	// mutable
 	state WorkerState
@@ -103,21 +97,9 @@ func (w *Worker) Work(ctx workflow.Context) {
 			logger.Error(ctx, "unable to fetch latest deployment for root: %s, skipping deploy: %s", msg.Root.Name, err.Error())
 			continue
 		}
-
-		commitDirection, err := w.getDeployRequestCommitDirection(ctx, msg, latestDeployment)
+		err = w.RevisionProcessor.Process(ctx, msg, latestDeployment)
 		if err != nil {
-			logger.Error(ctx, "unable to determine depoy request commit direction: %s", err.Error())
-			continue
-		}
-
-		if !w.isValidRevision(msg, commitDirection) {
-			logger.Info(ctx, fmt.Sprintf("Deploy Request Revision: %s is not valid, moving to next one", msg.Revision))
-			w.updateCheckRun(ctx, msg, github.CheckRunFailure, DirectionBehindSummary)
-			continue
-		}
-
-		if err = w.processRevision(ctx, msg, latestDeployment, commitDirection); err != nil {
-			logger.Error(ctx, "failed to process revision, moving to next one: %s", err.Error())
+			logger.Error(ctx, "failed to process revision, moving to next one")
 			continue
 		}
 
@@ -135,30 +117,6 @@ func (w *Worker) Work(ctx workflow.Context) {
 	}
 }
 
-// TODO: Check if triger type is Manual for Diverged commits for FA
-func (w *Worker) isValidRevision(deployRequest terraform.DeploymentInfo, commitDirection activities.DiffDirection) bool {
-	return commitDirection != activities.DirectionBehind
-}
-
-func (w *Worker) getDeployRequestCommitDirection(ctx workflow.Context, deployRequest terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) (activities.DiffDirection, error) {
-	// root being deployed for the first time
-	if latestDeployment == nil {
-		return activities.DirectionAhead, nil
-	}
-
-	var compareCommitResp activities.CompareCommitResponse
-	err := workflow.ExecuteActivity(ctx, w.Activities.CompareCommit, activities.CompareCommitRequest{
-		DeployRequestRevision:  deployRequest.Revision,
-		LatestDeployedRevision: latestDeployment.Revision,
-		Repo:                   deployRequest.Repo,
-	}).Get(ctx, &compareCommitResp)
-	if err != nil {
-		return activities.DiffDirection(""), errors.Wrap(err, "comparing committ")
-	}
-
-	return compareCommitResp.CommitComparison, nil
-}
-
 func (w *Worker) buildLatestDeployment(deployRequest terraform.DeploymentInfo) *root.DeploymentInfo {
 	return &root.DeploymentInfo{
 		Version:    DeploymentInfoVersion,
@@ -167,33 +125,6 @@ func (w *Worker) buildLatestDeployment(deployRequest terraform.DeploymentInfo) *
 		Revision:   deployRequest.Revision,
 		Root:       deployRequest.Root,
 		Repo:       deployRequest.Repo,
-	}
-}
-
-func (w *Worker) processRevision(ctx workflow.Context, deployRequest terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo, commitComparison activities.DiffDirection) error {
-
-	switch commitComparison {
-	case activities.DirectionIdentical:
-		logger.Info(ctx, fmt.Sprintf("Deployed Revision: %s is identical to the Deploy Request Revision: %s", latestDeployment.Revision, deployRequest.Revision))
-		return nil
-
-	// TODO: Handle Force Applies
-	case activities.DirectionDiverged:
-		logger.Info(ctx, fmt.Sprintf("Deployed Revision: %s is divergent from the Deploy Request Revision: %s.", latestDeployment.Revision, deployRequest.Revision))
-		return nil
-
-	case activities.DirectionAhead:
-		var logMsg string
-		if latestDeployment == nil {
-			logMsg = fmt.Sprintf("Deploying root: %s at revision: %s for the first time", deployRequest.Root.Name, deployRequest.Revision)
-		} else {
-			logMsg = fmt.Sprintf("Deployed Revision: %s is ahead of the Deploy Request Revision: %s", latestDeployment.Revision, deployRequest.Revision)
-		}
-		logger.Info(ctx, logMsg)
-		return nil
-
-	default:
-		return fmt.Errorf("Invalid commit comparison response: %s", commitComparison)
 	}
 }
 
@@ -225,22 +156,4 @@ func (w *Worker) persistLatestDeployment(ctx workflow.Context, deploymentInfo *r
 
 func (w *Worker) GetState() WorkerState {
 	return w.state
-}
-
-// worker should not block on updating checkruns for invalid deploy requests so let's retry for UpdateCheckrunRetryCount only
-func (w *Worker) updateCheckRun(ctx workflow.Context, deployRequest terraform.DeploymentInfo, state github.CheckRunState, summary string) {
-	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
-		MaximumAttempts: UpdateCheckRunRetryCount,
-	})
-
-	err := workflow.ExecuteActivity(ctx, w.Activities.UpdateCheckRun, activities.UpdateCheckRunRequest{
-		Title:   terraform.BuildCheckRunTitle(deployRequest.Root.Name),
-		State:   state,
-		Repo:    deployRequest.Repo,
-		ID:      deployRequest.CheckRunID,
-		Summary: summary,
-	}).Get(ctx, nil)
-	if err != nil {
-		logger.Error(ctx, "unable to update checkrun", err.Error())
-	}
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -1,12 +1,9 @@
 package queue
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
@@ -16,21 +13,8 @@ import (
 
 const DeploymentInfoVersion = "1.0.0"
 
-type terraformWorkflowRunner interface {
-	Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo) error
-}
-
-type dbActivities interface {
-	FetchLatestDeployment(ctx context.Context, request activities.FetchLatestDeploymentRequest) (activities.FetchLatestDeploymentResponse, error)
-	StoreLatestDeployment(ctx context.Context, request activities.StoreLatestDeploymentRequest) error
-}
-
 type revisionProcessor interface {
-	Process(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) error
-}
-
-type workerActivities interface {
-	dbActivities
+	Process(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) (*root.DeploymentInfo, error)
 }
 
 type WorkerState string
@@ -48,10 +32,8 @@ type UnlockSignalRequest struct {
 }
 
 type Worker struct {
-	Queue                   *Queue
-	TerraformWorkflowRunner terraformWorkflowRunner
-	Activities              workerActivities
-	RevisionProcessor       revisionProcessor
+	Queue             *Queue
+	RevisionProcessor revisionProcessor
 
 	// mutable
 	state WorkerState
@@ -91,67 +73,11 @@ func (w *Worker) Work(ctx workflow.Context) {
 
 		ctx := workflow.WithValue(ctx, internalContext.SHAKey, msg.Revision)
 		ctx = workflow.WithValue(ctx, internalContext.DeploymentIDKey, msg.ID)
-
-		latestDeployment, err = w.fetchLatestDeployment(ctx, msg, latestDeployment)
+		latestDeployment, err = w.RevisionProcessor.Process(ctx, msg, latestDeployment)
 		if err != nil {
-			logger.Error(ctx, "unable to fetch latest deployment for root: %s, skipping deploy: %s", msg.Root.Name, err.Error())
-			continue
-		}
-		err = w.RevisionProcessor.Process(ctx, msg, latestDeployment)
-		if err != nil {
-			logger.Error(ctx, "failed to process revision, moving to next one")
-			continue
-		}
-
-		err = w.TerraformWorkflowRunner.Run(ctx, msg)
-		if err != nil {
-			logger.Error(ctx, "failed to deploy revision, moving to next one")
-			continue
-		}
-		latestDeployment = w.buildLatestDeployment(msg)
-
-		// TODO: Persist deployment on shutdown if it fails instead of blocking
-		if err = w.persistLatestDeployment(ctx, latestDeployment); err != nil {
-			logger.Error(ctx, "failed to persist latest deploy job")
+			logger.Error(ctx, "failed to process revision, moving to next one", "err", err)
 		}
 	}
-}
-
-func (w *Worker) buildLatestDeployment(deployRequest terraform.DeploymentInfo) *root.DeploymentInfo {
-	return &root.DeploymentInfo{
-		Version:    DeploymentInfoVersion,
-		ID:         deployRequest.ID.String(),
-		CheckRunID: deployRequest.CheckRunID,
-		Revision:   deployRequest.Revision,
-		Root:       deployRequest.Root,
-		Repo:       deployRequest.Repo,
-	}
-}
-
-func (w *Worker) fetchLatestDeployment(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, latestDeployment *root.DeploymentInfo) (*root.DeploymentInfo, error) {
-	// Skip fetching latest deployment it it's already in memory
-	if latestDeployment != nil {
-		return latestDeployment, nil
-	}
-	var resp activities.FetchLatestDeploymentResponse
-	err := workflow.ExecuteActivity(ctx, w.Activities.FetchLatestDeployment, activities.FetchLatestDeploymentRequest{
-		FullRepositoryName: deploymentInfo.Repo.GetFullName(),
-		RootName:           deploymentInfo.Root.Name,
-	}).Get(ctx, &resp)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching latest deployment")
-	}
-	return resp.DeploymentInfo, nil
-}
-
-func (w *Worker) persistLatestDeployment(ctx workflow.Context, deploymentInfo *root.DeploymentInfo) error {
-	err := workflow.ExecuteActivity(ctx, w.Activities.StoreLatestDeployment, activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: deploymentInfo,
-	}).Get(ctx, nil)
-	if err != nil {
-		return errors.Wrap(err, "persisting deployment info")
-	}
-	return nil
 }
 
 func (w *Worker) GetState() WorkerState {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -62,10 +62,11 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 
 	var wa *testDeployActivity
 	worker := queue.Worker{
-		Queue:                   q,
-		TerraformWorkflowRunner: &testTerraformWorkflowRunner{},
-		Activities:              wa,
-		RevisionProcessor:       &queue.RevisionProcessor{Activities: wa},
+		Queue: q,
+		RevisionProcessor: &queue.RevisionProcessor{
+			Activities:              wa,
+			TerraformWorkflowRunner: &testTerraformWorkflowRunner{},
+		},
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -42,6 +42,17 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
 	})
+	info := workflow.GetInfo(ctx)
+	execution := info.WorkflowExecution
+
+	payload := queue.UnlockSignalRequest{User: "username"}
+	if err := workflow.SignalExternalWorkflow(ctx, execution.ID, execution.RunID, queue.UnlockSignalName, payload).Get(ctx, nil); err != nil {
+		return response{}, err
+	}
+
+	if err := workflow.Sleep(ctx, 1*time.Second); err != nil {
+		return response{}, err
+	}
 
 	q := queue.NewQueue()
 
@@ -54,6 +65,7 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		Queue:                   q,
 		TerraformWorkflowRunner: &testTerraformWorkflowRunner{},
 		Activities:              wa,
+		RevisionProcessor:       &queue.RevisionProcessor{Activities: wa},
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {
@@ -269,73 +281,120 @@ func TestWorker_CompareCommit_SkipDeploy(t *testing.T) {
 
 }
 
-func TestWorker_CompareCommit_Deploy(t *testing.T) {
+func TestWorker_CompareCommit_DeployAhead(t *testing.T) {
 	deploymentInfo, _, _, fetchDeploymentRequest, fetchDeploymentResponse, compareCommitRequest, storeLatestDeploymentReq := getTestArtifacts()
-	cases := []struct {
-		description           string
-		compareCommitResponse activities.CompareCommitResponse
-	}{
-		{
-			description: "ahead",
-			compareCommitResponse: activities.CompareCommitResponse{
-				CommitComparison: activities.DirectionAhead,
-			},
-		},
-		{
-			description: "diverged",
-			compareCommitResponse: activities.CompareCommitResponse{
-				CommitComparison: activities.DirectionDiverged,
-			},
-		},
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	compareCommitResponse := activities.CompareCommitResponse{
+		CommitComparison: activities.DirectionAhead,
 	}
-	for _, c := range cases {
-		t.Run(c.description, func(t *testing.T) {
-			ts := testsuite.WorkflowTestSuite{}
-			env := ts.NewTestWorkflowEnvironment()
 
-			da := testDeployActivity{}
-			// we set this callback so we can query the state of the queue
-			// after all processing has complete to determine whether we should
-			// shutdown the worker
-			env.RegisterDelayedCallback(func() {
-				encoded, err := env.QueryWorkflow("queue")
+	da := testDeployActivity{}
+	// we set this callback so we can query the state of the queue
+	// after all processing has complete to determine whether we should
+	// shutdown the worker
+	env.RegisterDelayedCallback(func() {
+		encoded, err := env.QueryWorkflow("queue")
 
-				assert.NoError(t, err)
+		assert.NoError(t, err)
 
-				var q queueAndState
-				err = encoded.Get(&q)
+		var q queueAndState
+		err = encoded.Get(&q)
 
-				assert.NoError(t, err)
+		assert.NoError(t, err)
 
-				assert.True(t, q.QueueIsEmpty)
-				assert.Equal(t, queue.WaitingWorkerState, q.State)
+		assert.True(t, q.QueueIsEmpty)
+		assert.Equal(t, queue.WaitingWorkerState, q.State)
 
-				env.CancelWorkflow()
+		env.CancelWorkflow()
 
-			}, 10*time.Second)
+	}, 10*time.Second)
 
-			deploymentInfoList := []terraform.DeploymentInfo{
-				deploymentInfo,
-			}
-
-			env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
-			env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(c.compareCommitResponse, nil)
-			env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
-
-			env.ExecuteWorkflow(testWorkflow, request{
-				Queue: deploymentInfoList,
-			})
-
-			env.AssertExpectations(t)
-
-			var resp response
-			err := env.GetWorkflowResult(&resp)
-			assert.NoError(t, err)
-
-			assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
-			assert.True(t, resp.QueueIsEmpty)
-		})
+	deploymentInfoList := []terraform.DeploymentInfo{
+		deploymentInfo,
 	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Queue: deploymentInfoList,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
+	assert.True(t, resp.QueueIsEmpty)
+
+}
+
+func TestWorker_CompareCommit_DeployDiverged(t *testing.T) {
+	deploymentInfo, _, _, fetchDeploymentRequest, fetchDeploymentResponse, compareCommitRequest, storeLatestDeploymentReq := getTestArtifacts()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	compareCommitResponse := activities.CompareCommitResponse{
+		CommitComparison: activities.DirectionDiverged,
+	}
+
+	da := testDeployActivity{}
+	// we set this callback so we can query the state of the queue
+	// after all processing has complete to determine whether we should
+	// shutdown the worker
+	env.RegisterDelayedCallback(func() {
+		encoded, err := env.QueryWorkflow("queue")
+
+		assert.NoError(t, err)
+
+		var q queueAndState
+		err = encoded.Get(&q)
+
+		assert.NoError(t, err)
+
+		assert.True(t, q.QueueIsEmpty)
+		assert.Equal(t, queue.WaitingWorkerState, q.State)
+
+		env.CancelWorkflow()
+
+	}, 10*time.Second)
+
+	deploymentInfoList := []terraform.DeploymentInfo{
+		deploymentInfo,
+	}
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+		State:   github.CheckRunPending,
+		Repo:    deploymentInfo.Repo,
+		ID:      deploymentInfo.CheckRunID,
+		Summary: queue.ForceApplySummary,
+		Actions: []github.CheckRunAction{github.CreateUnlockAction()},
+	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
+	env.OnActivity(da.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(activities.UpdateCheckRunResponse{
+		ID: int64(1),
+	}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Queue: deploymentInfoList,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
+	assert.True(t, resp.QueueIsEmpty)
 
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -372,7 +372,7 @@ func TestWorker_CompareCommit_DeployDiverged(t *testing.T) {
 		State:   github.CheckRunPending,
 		Repo:    deploymentInfo.Repo,
 		ID:      deploymentInfo.CheckRunID,
-		Summary: queue.ForceApplySummary,
+		Summary: queue.DivergedCommitsSummary,
 		Actions: []github.CheckRunAction{github.CreateUnlockAction()},
 	}
 

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -74,11 +74,13 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	revisionQueue := queue.NewQueue()
 	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, a, sideeffect.GenerateUUID)
 	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow)
+	revisionProcessor := &queue.RevisionProcessor{Activities: a}
 
 	worker := &queue.Worker{
 		Queue:                   revisionQueue,
 		TerraformWorkflowRunner: tfWorkflowRunner,
 		Activities:              a,
+		RevisionProcessor:       revisionProcessor,
 	}
 
 	return &Runner{

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -74,13 +74,14 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	revisionQueue := queue.NewQueue()
 	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, a, sideeffect.GenerateUUID)
 	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow)
-	revisionProcessor := &queue.RevisionProcessor{Activities: a}
+	revisionProcessor := &queue.RevisionProcessor{
+		Activities:              a,
+		TerraformWorkflowRunner: tfWorkflowRunner,
+	}
 
 	worker := &queue.Worker{
-		Queue:                   revisionQueue,
-		TerraformWorkflowRunner: tfWorkflowRunner,
-		Activities:              a,
-		RevisionProcessor:       revisionProcessor,
+		Queue:             revisionQueue,
+		RevisionProcessor: revisionProcessor,
 	}
 
 	return &Runner{

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -6,6 +6,11 @@ import (
 	"github.com/google/go-github/v45/github"
 )
 
+const (
+	UnlockLabel       = "Unlock"
+	UnlockDescription = "Unlock this plan to proceed"
+)
+
 type CheckRunState string
 
 type CheckRunAction struct {
@@ -26,10 +31,9 @@ func (a CheckRunAction) ToGithubAction() *github.CheckRunAction {
 
 func CreateUnlockAction() CheckRunAction {
 	return CheckRunAction{
-		Description: "Unlock this plan to proceed",
-		Label:       "Unlock",
+		Description: UnlockDescription,
+		Label:       UnlockLabel,
 	}
-
 }
 
 func CreatePlanReviewAction(t PlanReviewActionType) CheckRunAction {

--- a/server/neptune/workflows/internal/github/checks.go
+++ b/server/neptune/workflows/internal/github/checks.go
@@ -24,6 +24,14 @@ func (a CheckRunAction) ToGithubAction() *github.CheckRunAction {
 	}
 }
 
+func CreateUnlockAction() CheckRunAction {
+	return CheckRunAction{
+		Description: "Unlock this plan to proceed",
+		Label:       "Unlock",
+	}
+
+}
+
 func CreatePlanReviewAction(t PlanReviewActionType) CheckRunAction {
 	return CheckRunAction{
 		Description: fmt.Sprintf("%s this plan to proceed", string(t)),

--- a/server/neptune/workflows/internal/root/deployment.go
+++ b/server/neptune/workflows/internal/root/deployment.go
@@ -12,10 +12,3 @@ type DeploymentInfo struct {
 	Repo       github.Repo
 	Root       Root
 }
-
-func (i *DeploymentInfo) GetRevision() string {
-	if i == nil {
-		return ""
-	}
-	return i.Revision
-}

--- a/server/neptune/workflows/internal/root/deployment.go
+++ b/server/neptune/workflows/internal/root/deployment.go
@@ -12,3 +12,10 @@ type DeploymentInfo struct {
 	Repo       github.Repo
 	Root       Root
 }
+
+func (i *DeploymentInfo) GetRevision() string {
+	if i == nil {
+		return ""
+	}
+	return i.Revision
+}

--- a/server/neptune/workflows/internal/root/root.go
+++ b/server/neptune/workflows/internal/root/root.go
@@ -19,6 +19,11 @@ type Root struct {
 
 type Trigger string
 
+const (
+	MergeTrigger  Trigger = "merge"
+	ManualTrigger Trigger = "manual"
+)
+
 // LocalRoot is a root that exists locally on disk
 type LocalRoot struct {
 	Root Root


### PR DESCRIPTION
For the first iteration of force applies, in the event one has already occurred (i.e. requested revision diverges from latest), we will lock the root against future merged revisions. The lock can be undone through the user selecting the created Unlock GH action.

Note that this won't let subsequent force applies occur once a revision is merged and triggers the initial unlock. A future implementation of FA will need to allow us to always allow FAs to bypass the lock.