### PR TITLE
Add workflows e2e test

### DIFF
--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -41,7 +41,8 @@ const (
 type BackendType string
 
 const (
-	S3Backend BackendType = "s3"
+	S3Backend    BackendType = "s3"
+	LocalBackend BackendType = "local"
 )
 
 // GlobalCfg is the final parsed version of server-side repo config.

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -214,7 +214,7 @@ func (sc *testStreamCloser) CloseJob(ctx context.Context, jobID string) error {
 var fileContents = ` resource "null_resource" "null" {}
 `
 
-func GetLocalTestRoot(dst, src string, ctx context.Context) error {
+func GetLocalTestRoot(ctx context.Context, dst, src string) error {
 	err := os.MkdirAll(dst, os.ModePerm)
 
 	if err != nil {

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -1,0 +1,231 @@
+package workflows_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/graymeta/stow"
+	"github.com/graymeta/stow/local"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/runtime/cache"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
+	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	internalGithub "github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type a struct {
+	*workflows.GithubActivities
+	*workflows.TerraformActivities
+	*workflows.DeployActivities
+}
+
+func TestDeployWorkflow(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	dataDir := t.TempDir()
+
+	err := os.Mkdir(filepath.Join(dataDir, "container"), os.ModePerm)
+	assert.NoError(t, err)
+
+	u, err := url.Parse("www.server.com")
+	assert.NoError(t, err)
+
+	cfg := config.Config{
+		DeploymentConfig: valid.StoreConfig{
+			BackendType: valid.LocalBackend,
+			Config: stow.ConfigMap{
+				local.ConfigKeyPath: dataDir,
+			},
+			ContainerName: "container",
+			Prefix:        "prefix",
+		},
+		TerraformCfg: config.TerraformConfig{
+			DefaultVersionStr: "1.0.2",
+		},
+		DataDir: dataDir,
+		ServerCfg: config.ServerConfig{
+			URL: u,
+		},
+		App: githubapp.Config{},
+	}
+
+	s := initAndRegisterActivities(t, env, cfg)
+
+	env.RegisterWorkflow(workflows.Deploy)
+	env.RegisterWorkflow(workflows.Terraform)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(workflows.DeployNewRevisionSignalID, workflows.DeployNewRevisionSignalRequest{
+			Revision: "12345",
+			Root: workflows.Root{
+				Name: "my test root",
+				Plan: workflows.Job{
+					Steps: []workflows.Step{
+						{
+							StepName: "init",
+						},
+						{
+							StepName: "plan",
+						},
+					},
+				},
+				Apply: workflows.Job{
+					Steps: []workflows.Step{
+						{
+							StepName: "apply",
+						},
+					},
+				},
+				RepoRelPath: "terraform/mytestroot",
+				PlanMode:    workflows.NormalPlanMode,
+				Trigger:     workflows.MergeTrigger,
+			},
+		})
+	}, 5*time.Second)
+
+	env.RegisterDelayedCallback(func() {
+		err := env.SignalWorkflowByID(s.githubClient.DeploymentID, workflows.TerraformPlanReviewSignalName, workflows.TerraformPlanReviewSignalRequest{
+			Status: workflows.ApprovedPlanReviewStatus,
+		})
+
+		if err != nil {
+			panic(err)
+		}
+	}, 30*time.Second)
+	env.ExecuteWorkflow(workflows.Deploy, workflows.DeployRequest{})
+	assert.NoError(t, env.GetWorkflowError())
+
+	t.Log(s.githubClient.Updates)
+
+	t.Fail()
+}
+
+type testSingletons struct {
+	a            *a
+	githubClient *testGithubClient
+}
+
+func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironment, cfg config.Config) *testSingletons {
+	deployActivities, err := workflows.NewDeployActivities(cfg.DeploymentConfig)
+
+	assert.NoError(t, err)
+
+	terraformActivities, err := activities.NewTerraform(
+		cfg.TerraformCfg,
+		cfg.DataDir,
+		cfg.ServerCfg.URL,
+		&testStreamCloser{},
+		activities.TerraformOptions{
+			VersionCache: cache.NewLocalBinaryCache("terraform"),
+		},
+	)
+
+	assert.NoError(t, err)
+
+	githubClient := &testGithubClient{}
+
+	githubActivities, err := activities.NewGithub(
+		githubClient,
+		cfg.DataDir,
+		GetLocalTestRoot,
+	)
+
+	assert.NoError(t, err)
+
+	env.RegisterActivity(terraformActivities)
+	env.RegisterActivity(deployActivities)
+	env.RegisterActivity(githubActivities)
+
+	return &testSingletons{
+		a: &a{
+			GithubActivities: &workflows.GithubActivities{
+				Github: githubActivities,
+			},
+			TerraformActivities: &workflows.TerraformActivities{
+				Terraform: terraformActivities,
+			},
+			DeployActivities: deployActivities,
+		},
+		githubClient: githubClient,
+	}
+
+}
+
+type testStreamCloser struct {
+	*job.StreamHandler
+}
+
+func (sc *testStreamCloser) Stream(jobID string, msg string) {}
+
+func (sc *testStreamCloser) CloseJob(ctx context.Context, jobID string) error {
+	return nil
+}
+
+var fileContents = ` resource "null_resource" "null" {}
+}`
+
+func GetLocalTestRoot(dst, src string, ctx context.Context) error {
+	err := os.Mkdir(dst, os.ModePerm)
+
+	if err != nil {
+		return errors.Wrapf(err, "creating directory at %s", dst)
+	}
+
+	if err := os.WriteFile(filepath.Join(dst, "main.tf"), []byte(fileContents), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "writing file")
+	}
+
+	return nil
+}
+
+type CheckRunUpdate struct {
+	Summary    string
+	Status     string
+	Conclusion string
+}
+
+type testGithubClient struct {
+	Updates      []CheckRunUpdate
+	DeploymentID string
+}
+
+func (c *testGithubClient) CreateCheckRun(ctx internalGithub.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	c.DeploymentID = opts.GetExternalID()
+	return &github.CheckRun{
+		ID: github.Int64(123),
+	}, &github.Response{}, nil
+}
+func (c *testGithubClient) UpdateCheckRun(ctx internalGithub.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	c.DeploymentID = opts.GetExternalID()
+	update := CheckRunUpdate{
+		Summary:    opts.GetOutput().GetSummary(),
+		Status:     opts.GetStatus(),
+		Conclusion: opts.GetConclusion(),
+	}
+
+	c.Updates = append(c.Updates, update)
+
+	return &github.CheckRun{}, &github.Response{}, nil
+}
+func (c *testGithubClient) GetArchiveLink(ctx internalGithub.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+	url, _ := url.Parse("www.testurl.com")
+
+	return url, &github.Response{}, nil
+}
+func (c *testGithubClient) CompareCommits(ctx internalGithub.Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
+	return &github.CommitsComparison{
+		Status: github.String("ahead"),
+	}, &github.Response{}, nil
+}

--- a/server/neptune/workflows/github.go
+++ b/server/neptune/workflows/github.go
@@ -3,21 +3,37 @@ package workflows
 import (
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
+	internal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/uber-go/tally/v4"
 )
 
 type GithubActivities struct {
-	activities.Github
+	*activities.Github
 }
 
 func NewGithubActivities(appConfig githubapp.Config, scope tally.Scope, dataDir string) (*GithubActivities, error) {
-	githubActivities, err := activities.NewGithub(appConfig, scope, dataDir)
+	clientCreator, err := githubapp.NewDefaultCachingClientCreator(
+		appConfig,
+		githubapp.WithClientMiddleware(
+			github.ClientMetrics(scope.SubScope("app")),
+		))
+
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing client creator")
+	}
+
+	client := &internal.Client{
+		ClientCreator: clientCreator,
+	}
+
+	githubActivities, err := activities.NewGithub(client, dataDir, activities.HashiGetter)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing github activities")
 	}
 
 	return &GithubActivities{
-		Github: *githubActivities,
+		Github: githubActivities,
 	}, nil
 }

--- a/server/neptune/workflows/internal/activities/github.go
+++ b/server/neptune/workflows/internal/activities/github.go
@@ -4,17 +4,36 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"time"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/hashicorp/go-getter"
-	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	internal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/root"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
 )
+
+type ClientContext struct {
+	InstallationToken int64
+	context.Context
+}
+
+var HashiGetter = func(dst, src string, ctx context.Context) error {
+	return getter.Get(dst, src, getter.WithContext(ctx))
+}
+
+// wraps hashicorp's go getter to allow for testing
+type gogetter func(dst, src string, ctx context.Context) error
+
+type githubClient interface {
+	CreateCheckRun(ctx internal.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error)
+	UpdateCheckRun(ctx internal.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error)
+	GetArchiveLink(ctx internal.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error)
+	CompareCommits(ctx internal.Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error)
+}
 
 type DiffDirection string
 
@@ -28,9 +47,10 @@ const (
 const deploymentsDirName = "deployments"
 
 type githubActivities struct {
-	ClientCreator githubapp.ClientCreator
-	DataDir       string
-	LinkBuilder   LinkBuilder
+	Client      githubClient
+	DataDir     string
+	LinkBuilder LinkBuilder
+	Getter      gogetter
 }
 
 type CreateCheckRunRequest struct {
@@ -88,13 +108,10 @@ func (a *githubActivities) UpdateCheckRun(ctx context.Context, request UpdateChe
 		opts.Conclusion = github.String(conclusion)
 	}
 
-	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
-
-	if err != nil {
-		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating installation client")
-	}
-
-	run, _, err := client.Checks.UpdateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, request.ID, opts)
+	run, _, err := a.Client.UpdateCheckRun(
+		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
+		request.Repo.Owner, request.Repo.Name, request.ID, opts,
+	)
 
 	if err != nil {
 		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating check run")
@@ -126,13 +143,10 @@ func (a *githubActivities) CreateCheckRun(ctx context.Context, request CreateChe
 		opts.Conclusion = &conclusion
 	}
 
-	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
-
-	if err != nil {
-		return CreateCheckRunResponse{}, errors.Wrap(err, "creating installation client")
-	}
-
-	run, _, err := client.Checks.CreateCheckRun(ctx, request.Repo.Owner, request.Repo.Name, opts)
+	run, _, err := a.Client.CreateCheckRun(
+		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
+		request.Repo.Owner, request.Repo.Name, opts,
+	)
 
 	if err != nil {
 		return CreateCheckRunResponse{}, errors.Wrap(err, "creating check run")
@@ -191,12 +205,8 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 	opts := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}
-	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
-	if err != nil {
-		return FetchRootResponse{}, errors.Wrap(err, "creating installation client")
-	}
 	// note: this link exists for 5 minutes when fetching a private repository archive
-	archiveLink, resp, err := client.Repositories.GetArchiveLink(ctx, request.Repo.Owner, request.Repo.Name, github.Zipball, opts, true)
+	archiveLink, resp, err := a.Client.GetArchiveLink(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, github.Zipball, opts, true)
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "getting repo archive link")
 	}
@@ -205,7 +215,7 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 		return FetchRootResponse{}, errors.Errorf("getting repo archive link returns non-302 status %d", resp.StatusCode)
 	}
 	downloadLink := a.LinkBuilder.BuildDownloadLinkFromArchive(archiveLink, request.Root, request.Repo, request.Revision)
-	err = getter.Get(destinationPath, downloadLink, getter.WithContext(ctx))
+	err = a.Getter(destinationPath, downloadLink, ctx)
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "fetching and extracting zip")
 	}
@@ -226,12 +236,8 @@ type CompareCommitResponse struct {
 }
 
 func (a *githubActivities) CompareCommit(ctx context.Context, request CompareCommitRequest) (CompareCommitResponse, error) {
-	client, err := a.ClientCreator.NewInstallationClient(request.Repo.Credentials.InstallationToken)
-	if err != nil {
-		return CompareCommitResponse{}, errors.Wrap(err, "creating installation client")
-	}
+	comparison, resp, err := a.Client.CompareCommits(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, request.LatestDeployedRevision, request.DeployRequestRevision, &github.ListOptions{})
 
-	comparison, resp, err := client.Repositories.CompareCommits(ctx, request.Repo.Owner, request.Repo.Name, request.LatestDeployedRevision, request.DeployRequestRevision, &github.ListOptions{})
 	if err != nil {
 		return CompareCommitResponse{}, errors.Wrap(err, "comparing commits")
 	}

--- a/server/neptune/workflows/internal/activities/github.go
+++ b/server/neptune/workflows/internal/activities/github.go
@@ -21,12 +21,12 @@ type ClientContext struct {
 	context.Context
 }
 
-var HashiGetter = func(dst, src string, ctx context.Context) error {
+var HashiGetter = func(ctx context.Context, dst, src string) error {
 	return getter.Get(dst, src, getter.WithContext(ctx))
 }
 
 // wraps hashicorp's go getter to allow for testing
-type gogetter func(dst, src string, ctx context.Context) error
+type gogetter func(ctx context.Context, dst, src string) error
 
 type githubClient interface {
 	CreateCheckRun(ctx internal.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error)
@@ -215,7 +215,7 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 		return FetchRootResponse{}, errors.Errorf("getting repo archive link returns non-302 status %d", resp.StatusCode)
 	}
 	downloadLink := a.LinkBuilder.BuildDownloadLinkFromArchive(archiveLink, request.Root, request.Repo, request.Revision)
-	err = a.Getter(destinationPath, downloadLink, ctx)
+	err = a.Getter(ctx, destinationPath, downloadLink)
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "fetching and extracting zip")
 	}

--- a/server/neptune/workflows/internal/activities/job.go
+++ b/server/neptune/workflows/internal/activities/job.go
@@ -7,12 +7,12 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/logger"
 )
 
-type streamCloser interface {
+type closer interface {
 	CloseJob(ctx context.Context, jobID string) error
 }
 
 type jobActivities struct {
-	StreamCloser streamCloser
+	StreamCloser closer
 }
 
 type CloseJobRequest struct {

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -37,17 +37,17 @@ type TerraformClient interface {
 	RunCommand(ctx context.Context, request *terraform.RunCommandRequest, options ...terraform.RunOptions) error
 }
 
-type streamHandler interface {
+type streamer interface {
 	Stream(jobID string, msg string)
 }
 
 type terraformActivities struct {
 	TerraformClient  TerraformClient
 	DefaultTFVersion *version.Version
-	StreamHandler    streamHandler
+	StreamHandler    streamer
 }
 
-func NewTerraformActivities(client TerraformClient, defaultTfVersion *version.Version, streamHandler streamHandler) *terraformActivities { //nolint:golint // avoiding refactor while adding linter action
+func NewTerraformActivities(client TerraformClient, defaultTfVersion *version.Version, streamHandler streamer) *terraformActivities { //nolint:golint // avoiding refactor while adding linter action
 	return &terraformActivities{
 		TerraformClient:  client,
 		DefaultTFVersion: defaultTfVersion,

--- a/server/neptune/workflows/internal/activities/terraform/async_client.go
+++ b/server/neptune/workflows/internal/activities/terraform/async_client.go
@@ -28,19 +28,12 @@ func NewAsyncClient(
 	cfg ClientConfig,
 	defaultVersion string,
 	tfDownloader terraform.Downloader,
+	versionCache cache.ExecutionVersionCache,
 ) (*AsyncClient, error) {
 	version, err := getDefaultVersion(defaultVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting default version")
 	}
-
-	loader := terraform.NewVersionLoader(tfDownloader, cfg.TfDownloadURL)
-
-	versionCache := cache.NewExecutionVersionLayeredLoadingCache(
-		"terraform",
-		cfg.BinDir,
-		loader.LoadVersion,
-	)
 
 	// warm the cache with this version
 	_, err = versionCache.Get(version)

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -15,7 +15,8 @@ func Root(external request.Root) root.Root {
 		Plan: job.Plan{
 			Terraform: job.Terraform{
 				Steps: steps(external.Plan.Steps)},
-			Mode: mode(external.PlanMode),
+			Mode:     mode(external.PlanMode),
+			Approval: job.PlanApprovalType(external.PlanApprovalType),
 		},
 		Path:      external.RepoRelPath,
 		TfVersion: external.TfVersion,

--- a/server/neptune/workflows/internal/deploy/request/root.go
+++ b/server/neptune/workflows/internal/deploy/request/root.go
@@ -14,14 +14,17 @@ const (
 	ManualTrigger Trigger = "manual"
 )
 
+type PlanApprovalType string
+
 type Root struct {
-	Name        string
-	Apply       Job
-	Plan        Job
-	RepoRelPath string
-	TfVersion   string
-	PlanMode    PlanMode
-	Trigger     Trigger
+	Name             string
+	Apply            Job
+	Plan             Job
+	RepoRelPath      string
+	TfVersion        string
+	PlanMode         PlanMode
+	PlanApprovalType string
+	Trigger          Trigger
 }
 
 type Job struct {

--- a/server/neptune/workflows/internal/github/client.go
+++ b/server/neptune/workflows/internal/github/client.go
@@ -1,0 +1,75 @@
+package github
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+)
+
+type Client struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+type Context interface {
+	GetInstallationToken() int64
+	context.Context
+}
+
+type contextWithToken struct {
+	InstallationToken int64
+	context.Context
+}
+
+func (c *contextWithToken) GetInstallationToken() int64 {
+	return c.InstallationToken
+}
+
+func ContextWithInstallationToken(ctx context.Context, installationToken int64) Context {
+	return &contextWithToken{
+		InstallationToken: installationToken,
+		Context:           ctx,
+	}
+}
+
+func (c *Client) CreateCheckRun(ctx Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	return client.Checks.CreateCheckRun(ctx, owner, repo, opts)
+}
+func (c *Client) UpdateCheckRun(ctx Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	return client.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, opts)
+}
+func (c *Client) GetArchiveLink(ctx Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	return client.Repositories.GetArchiveLink(ctx, owner, repo, archiveformat, opts, followRedirects)
+
+}
+
+
+func (c *Client) CompareCommits(ctx Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	return client.Repositories.CompareCommits(ctx, owner, repo, base, head, opts)
+}

--- a/server/neptune/workflows/internal/github/client.go
+++ b/server/neptune/workflows/internal/github/client.go
@@ -63,7 +63,6 @@ func (c *Client) GetArchiveLink(ctx Context, owner, repo string, archiveformat g
 
 }
 
-
 func (c *Client) CompareCommits(ctx Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
 	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
 

--- a/server/neptune/workflows/internal/job/context.go
+++ b/server/neptune/workflows/internal/job/context.go
@@ -14,6 +14,13 @@ type ExecutionContext struct {
 	JobID string
 }
 
+type PlanApprovalType string
+
+const (
+	ManualApproval PlanApprovalType = "manual"
+	AutoApproval   PlanApprovalType = "auto"
+)
+
 type PlanMode string
 
 func NewDestroyPlanMode() *PlanMode {
@@ -22,7 +29,8 @@ func NewDestroyPlanMode() *PlanMode {
 }
 
 type Plan struct {
-	Mode *PlanMode
+	Mode     *PlanMode
+	Approval PlanApprovalType
 	Terraform
 }
 

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
-	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
@@ -25,16 +24,16 @@ const RejectedPlanReviewStatus = terraform.Rejected
 const TerraformPlanReviewSignalName = terraform.PlanReviewSignalName
 
 type TerraformActivities struct {
-	activities.Terraform
+	*activities.Terraform
 }
 
-func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler *job.StreamHandler) (*TerraformActivities, error) {
+func NewTerraformActivities(config config.TerraformConfig, dataDir string, serverURL *url.URL, streamHandler activities.StreamCloser) (*TerraformActivities, error) {
 	terraformActivities, err := activities.NewTerraform(config, dataDir, serverURL, streamHandler)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing terraform activities")
 	}
 	return &TerraformActivities{
-		Terraform: *terraformActivities,
+		Terraform: terraformActivities,
 	}, nil
 }
 


### PR DESCRIPTION
First stab at an e2e test that currently just checks to make sure that `UpdateCheckRuns` has been called enough times and that our stream handler has some output associated with 2 job ids.

This PR includes a lot of additional changes to make this work:
* Interfacing our github client
* Support config to auto apply
* Refactoring DI to allow us to inject a few custom things for testing (local cache, custom go-getter, gh client)