### PR TITLE
Don't case context values to string.

### DIFF
--- a/server/neptune/context/key.go
+++ b/server/neptune/context/key.go
@@ -30,9 +30,7 @@ func ExtractFields(ctx KVStore) map[string]interface{} {
 	args := make(map[string]interface{})
 
 	for _, k := range Keys {
-		if v, ok := ctx.Value(k).(string); ok {
-			args[k.String()] = v
-		}
+		args[k.String()] = ctx.Value(k)
 	}
 
 	return args
@@ -42,10 +40,8 @@ func ExtractFieldsAsList(ctx KVStore) []interface{} {
 	var args []interface{}
 
 	for _, k := range Keys {
-		if v, ok := ctx.Value(k).(string); ok {
-			args = append(args, k)
-			args = append(args, v)
-		}
+		args = append(args, k)
+		args = append(args, ctx.Value(k))
 	}
 
 	return args

--- a/server/neptune/gateway/context/key.go
+++ b/server/neptune/gateway/context/key.go
@@ -25,9 +25,7 @@ func ExtractFields(ctx context.Context) map[string]interface{} {
 	args := make(map[string]interface{})
 
 	for _, k := range Keys {
-		if v, ok := ctx.Value(k).(string); ok {
-			args[k.String()] = v
-		}
+		args[k.String()] = ctx.Value(k)
 	}
 
 	return args


### PR DESCRIPTION
I believe this is why we have no `atlantis.err` keys in our logs.