### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,17 @@
 linters:
   enable:
-  - deadcode
   - errcheck
   - gochecknoinits
 # We don't use goconst because it gives false positives in the tests.
 #  - goconst
   - gofmt
-  - golint
+  - revive
   - gosec
   - gosimple
   - ineffassign
-  - interfacer
   - staticcheck
-  - structcheck
   - typecheck
   - unconvert
   - unused
-  - varcheck
   - vet
   - vetshadow

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -29,7 +29,7 @@ const DefaultWorkflowName = "default"
 // TODO: Make this more customizable, not everyone wants this rigid workflow
 // maybe something along the lines of defining overridable/non-overrideable apply
 // requirements in the config and removing the flag to enable policy checking.
-var NonOverrideableApplyReqs []string = []string{PoliciesPassedApplyReq}
+var NonOverrideableApplyReqs = []string{PoliciesPassedApplyReq}
 
 type WorkflowModeType int
 

--- a/server/core/locking/locking_test.go
+++ b/server/core/locking/locking_test.go
@@ -179,7 +179,7 @@ func TestGetLock_NoOpLocker(t *testing.T) {
 	l := locking.NewNoOpLocker()
 	lock, err := l.GetLock("owner/repo/path/workspace")
 	Ok(t, err)
-	var expected *models.ProjectLock = nil
+	var expected *models.ProjectLock
 	Equals(t, expected, lock)
 }
 

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -95,7 +95,7 @@ func (p *SourceResolverProxy) Resolve(policySet valid.PolicySet) (string, error)
 	case valid.LocalPolicySet:
 		return p.localSourceResolver.Resolve(policySet)
 	default:
-		return "", errors.New(fmt.Sprintf("unable to resolve policy set source %s", source))
+		return "", fmt.Errorf("unable to resolve policy set source %s", source)
 	}
 }
 
@@ -237,7 +237,7 @@ func getDefaultVersion() (*version.Version, error) {
 	defaultVersion, exists := os.LookupEnv(DefaultConftestVersionEnvKey)
 
 	if !exists {
-		return nil, errors.New(fmt.Sprintf("%s not set.", DefaultConftestVersionEnvKey))
+		return nil, fmt.Errorf("%s not set", DefaultConftestVersionEnvKey)
 	}
 
 	wrappedVersion, err := version.NewVersion(defaultVersion)

--- a/server/core/runtime/steps_runner.go
+++ b/server/core/runtime/steps_runner.go
@@ -23,7 +23,7 @@ func NewStepsRunner(
 	versionStepRunner Runner,
 	runStepRunner CustomRunner,
 	envStepRunner EnvRunner,
-) *stepsRunner { //nolint:golint // avoiding refactor while adding linter action
+) *stepsRunner { //nolint:revive // avoiding refactor while adding linter action
 	stepsRunner := &stepsRunner{}
 
 	stepsRunner.InitRunner = initStepRunner

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CommandTrigger represents the how the command was triggered
-type CommandTrigger int //nolint:golint // avoiding refactor while adding linter action
+type CommandTrigger int //nolint:revive // avoiding refactor while adding linter action
 
 const (
 	// Commands that are automatically triggered (ie. automatic plans)

--- a/server/events/size_limited_project_command_builder.go
+++ b/server/events/size_limited_project_command_builder.go
@@ -3,7 +3,6 @@ package events
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
@@ -44,14 +43,12 @@ func (b *SizeLimitedProjectCommandBuilder) CheckAgainstLimit(projects []command.
 	}
 
 	if b.Limit != InfiniteProjectsPerPR && len(planCommands) > b.Limit {
-		return errors.New(
-			fmt.Sprintf(
-				"Number of projects cannot exceed %d.  This can either be caused by:\n"+
-					"1) GH failure in recognizing the diff\n"+
-					"2) Pull Request batch is too large for the given Atlantis instance\n\n"+
-					"Please break this pull request into smaller batches and try again.",
-				b.Limit,
-			),
+		return fmt.Errorf(
+			"Number of projects cannot exceed %d.  This can either be caused by:\n"+
+				"1) GH failure in recognizing the diff\n"+
+				"2) Pull Request batch is too large for the given Atlantis instance\n\n"+
+				"Please break this pull request into smaller batches and try again.",
+			b.Limit,
 		)
 	}
 	return nil

--- a/server/logging/logger.go
+++ b/server/logging/logger.go
@@ -45,7 +45,7 @@ type logger struct {
 	Closer
 }
 
-func NewLoggerFromLevel(lvl LogLevel) (*logger, error) { //nolint:golint // avoiding refactor while adding linter action
+func NewLoggerFromLevel(lvl LogLevel) (*logger, error) { //nolint:revive // avoiding refactor while adding linter action
 	structuredLogger, err := NewStructuredLoggerFromLevel(lvl)
 	if err != nil {
 		return &logger{}, err

--- a/server/lyft/checks/github_client.go
+++ b/server/lyft/checks/github_client.go
@@ -45,7 +45,7 @@ const (
 )
 
 // github checks conclusion
-type ChecksConclusion int //nolint:golint // avoiding refactor while adding linter action
+type ChecksConclusion int //nolint:revive // avoiding refactor while adding linter action
 
 const (
 	Neutral ChecksConclusion = iota
@@ -96,7 +96,7 @@ func (e CheckStatus) String() string {
 }
 
 // [WENGINES-4643] TODO: Remove this wrapper and add checks implementation to UpdateStatus() directly after github checks is stable
-type ChecksClientWrapper struct { //nolint:golint // avoiding refactor while adding linter action
+type ChecksClientWrapper struct { //nolint:revive // avoiding refactor while adding linter action
 	*vcs.GithubClient
 	FeatureAllocator feature.Allocator
 	Logger           logging.Logger

--- a/server/lyft/feature/allocator.go
+++ b/server/lyft/feature/allocator.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Add more attributes as needed to determine eligibility of a feature
-type FeatureContext struct { //nolint:golint // avoiding refactor while adding linter action
+type FeatureContext struct { //nolint:revive // avoiding refactor while adding linter action
 	RepoName         string
 	PullCreationTime time.Time
 }

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -15,7 +15,7 @@ import (
 var pushEvent event.Push
 var rcb event.RootConfigBuilder
 var globalCfg valid.GlobalCfg
-var expectedErr = errors.New("some error") //nolint:golint // error name is fine for testing purposes
+var expectedErr = errors.New("some error") //nolint:revive // error name is fine for testing purposes
 
 func setupTesting(t *testing.T) {
 	globalCfg = valid.NewGlobalCfg()

--- a/server/neptune/temporalworker/controllers/websocket/mux.go
+++ b/server/neptune/temporalworker/controllers/websocket/mux.go
@@ -30,7 +30,7 @@ type multiplexor struct {
 	registry     partitionRegistry
 }
 
-func NewMultiplexor(log logging.Logger, keyGenerator partitionKeyGenerator, registry partitionRegistry) *multiplexor { //nolint:golint // avoiding refactor while adding linter action
+func NewMultiplexor(log logging.Logger, keyGenerator partitionKeyGenerator, registry partitionRegistry) *multiplexor { //nolint:revive // avoiding refactor while adding linter action
 	return &multiplexor{
 		writer:       NewWriter(log),
 		keyGenerator: keyGenerator,

--- a/server/neptune/temporalworker/job/receiver_registry.go
+++ b/server/neptune/temporalworker/job/receiver_registry.go
@@ -19,7 +19,7 @@ type receiverRegistry struct {
 	lock      sync.RWMutex
 }
 
-func NewReceiverRegistry() *receiverRegistry { //nolint:golint // avoiding refactor while adding linter action
+func NewReceiverRegistry() *receiverRegistry { //nolint:revive // avoiding refactor while adding linter action
 	return &receiverRegistry{
 		receivers: map[string]map[chan string]bool{},
 	}

--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/storage"
 )
 
-type JobStatus int //nolint:golint // avoiding refactor while adding linter action
+type JobStatus int //nolint:revive // avoiding refactor while adding linter action
 
 const (
 	Processing JobStatus = iota
@@ -211,7 +211,7 @@ func (s *StorageBackendJobStore) Cleanup(ctx context.Context) error {
 	}
 
 	if len(failedJobs) > 0 {
-		return errors.Errorf("failed to persist jobs: %s\n", strings.Join(failedJobs, ","))
+		return errors.Errorf("failed to persist jobs: %s", strings.Join(failedJobs, ","))
 	}
 	return nil
 }

--- a/server/neptune/workflows/internal/activities/terraform.go
+++ b/server/neptune/workflows/internal/activities/terraform.go
@@ -47,7 +47,7 @@ type terraformActivities struct {
 	StreamHandler    streamHandler
 }
 
-func NewTerraformActivities(client TerraformClient, defaultTfVersion *version.Version, streamHandler streamHandler) *terraformActivities { //nolint:golint // avoiding refactor while adding linter action
+func NewTerraformActivities(client TerraformClient, defaultTfVersion *version.Version, streamHandler streamHandler) *terraformActivities { //nolint:revive // avoiding refactor while adding linter action
 	return &terraformActivities{
 		TerraformClient:  client,
 		DefaultTFVersion: defaultTfVersion,

--- a/server/neptune/workflows/internal/activities/terraform/subcommand.go
+++ b/server/neptune/workflows/internal/activities/terraform/subcommand.go
@@ -57,7 +57,7 @@ func newArgument(arg string) (Argument, error) {
 	coll := strings.Split(arg, "=")
 
 	if len(coll) != 2 {
-		return Argument{}, errors.New(fmt.Sprintf("cannot parse argument: %s. argument can only have one =", arg))
+		return Argument{}, fmt.Errorf("cannot parse argument: %s. argument can only have one =", arg)
 	}
 
 	return Argument{

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/activities/terraform"
@@ -23,7 +24,7 @@ type stepRunner interface {
 	Run(executionContext *job.ExecutionContext, localRoot *root.LocalRoot, step job.Step) (string, error)
 }
 
-type JobRunner struct { ///nolint:golint // avoiding refactor while adding linter action
+type JobRunner struct { ///nolint:revive // avoiding refactor while adding linter action
 	Activity      terraformActivities
 	EnvStepRunner stepRunner
 	CmdStepRunner stepRunner

--- a/server/wrappers/project_context.go
+++ b/server/wrappers/project_context.go
@@ -11,7 +11,7 @@ type projectContext struct {
 
 func WrapProjectContext(
 	projectCtxBuilder events.ProjectCommandContextBuilder,
-) *projectContext { //nolint:golint // avoiding refactor while adding linter action
+) *projectContext { //nolint:revive // avoiding refactor while adding linter action
 	return &projectContext{
 		projectCtxBuilder,
 	}

--- a/server/wrappers/project_runners.go
+++ b/server/wrappers/project_runners.go
@@ -12,7 +12,7 @@ type projectCommand struct {
 	events.ProjectCommandRunner
 }
 
-func WrapProjectRunner(projectRunner events.ProjectCommandRunner) *projectCommand { //nolint:golint // avoiding refactor while adding linter action
+func WrapProjectRunner(projectRunner events.ProjectCommandRunner) *projectCommand { //nolint:revive // avoiding refactor while adding linter action
 	return &projectCommand{
 		projectRunner,
 	}

--- a/testdrive/utils.go
+++ b/testdrive/utils.go
@@ -214,7 +214,7 @@ func execAndWaitForStderr(wg *sync.WaitGroup, stderrMatch *regexp.Regexp, timeou
 		cancel()
 		// We still need to wait for the command to finish.
 		command.Wait()                                                  // nolint: errcheck
-		return cancel, errChan, fmt.Errorf("timeout, logs:\n%s\n", log) // nolint: staticcheck, golint
+		return cancel, errChan, fmt.Errorf("timeout, logs:\n%s\n", log) // nolint: staticcheck, revive
 	}
 
 	// Increment the wait group so callers can wait for the command to finish.


### PR DESCRIPTION
Noticed some of our linters have been deprecated and were throwing stale lint failures. So, I have replaced the linters according to the suggestions: 
```
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
``` 