### PR TITLE
Pass GithubCredentials to repo fetcher to generate new tokens on every fetch

### DIFF
--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -283,15 +283,11 @@ func NewServer(config Config) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing temporal client")
 	}
 
-	ghToken, err := githubCredentials.GetToken()
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching github token")
-	}
 	repoFetcher := &github.RepoFetcher{
-		DataDir:        config.DataDir,
-		Token:          ghToken,
-		GithubHostname: config.GithubHostname,
-		Logger:         ctxLogger,
+		DataDir:           config.DataDir,
+		GithubCredentials: githubCredentials,
+		GithubHostname:    config.GithubHostname,
+		Logger:            ctxLogger,
 	}
 	hooksRunner := &preworkflow.HooksRunner{
 		GlobalCfg:    globalCfg,


### PR DESCRIPTION
We currently generate a github token on startup and pass it to the `RepoFetcher` which is used to clone repos. Since the tokens are only valid for a set period of time, we should generate a new token on every fetch. So, we change the `RepoFetcher` to generate new github token on every fetch. 