### PR TITLE
Add TemporalClientError.

### DIFF
--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -254,7 +254,7 @@ func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jo
 
 	wg.Wait()
 
-	return TerraformClientError{error: err}
+	return &TerraformClientError{error: err}
 }
 
 func (t *terraformActivities) resolveVersion(v string) (*version.Version, error) {

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -254,7 +254,11 @@ func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jo
 
 	wg.Wait()
 
-	return &TerraformClientError{error: err}
+	if err != nil {
+		return TerraformClientError{error: err}
+	}
+
+	return nil
 }
 
 func (t *terraformActivities) resolveVersion(v string) (*version.Version, error) {

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -14,6 +14,12 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 )
 
+// TerraformClientError can be used to assert a non-retryable error type for
+// callers of this activity
+type TerraformClientError struct {
+	error
+}
+
 var DisableInputArg = terraform.Argument{
 	Key:   "input",
 	Value: "false",
@@ -248,7 +254,7 @@ func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jo
 
 	wg.Wait()
 
-	return err
+	return TerraformClientError{error: err}
 }
 
 func (t *terraformActivities) resolveVersion(v string) (*version.Version, error) {

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -67,7 +67,6 @@ func (r *JobRunner) Plan(ctx workflow.Context, localRoot *terraform.LocalRoot, j
 		case "plan":
 			resp, err = r.plan(jobCtx, localRoot.Root.Plan.Mode, step.ExtraArgs)
 		}
-
 		if err != nil {
 			return resp, errors.Wrapf(err, "running step %s", step.StepName)
 		}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	runner "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -51,6 +52,9 @@ func Workflow(ctx workflow.Context, request Request) error {
 	options := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 30 * time.Minute,
 		HeartbeatTimeout:       1 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			NonRetryableErrorTypes: []string{"TemporalClientError"},
+		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, options)
 


### PR DESCRIPTION
We shouldn't retry continuously if there's an issue from the terraform binary so let's track those errors accordingly.