### PR TITLE
Add heartbeat to tf activities

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -3,17 +3,15 @@ package activities
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
-	"path/filepath"
-	"time"
-
 	"github.com/google/go-github/v45/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
 	internal "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"net/http"
+	"net/url"
+	"path/filepath"
 )
 
 type ClientContext struct {
@@ -195,7 +193,7 @@ type FetchRootResponse struct {
 // FetchRoot fetches a link to the archive URL using the GH client, processes that URL into a download URL that the
 // go-getter library can use, and then go-getter to download/extract files/subdirs within the root path to the destinationPath.
 func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootRequest) (FetchRootResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	ref, err := request.Repo.Ref.String()
 	if err != nil {

--- a/server/neptune/workflows/activities/temporal/heartbeat.go
+++ b/server/neptune/workflows/activities/temporal/heartbeat.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const HeartbeatTimeout = 10 * time.Second
+
 // Adapted from dynajoe/temporal-terraform-demo:
 // https://github.com/dynajoe/temporal-terraform-demo/blob/b468ac13cd9400ec0ffeb1b96eb8135e4b36d8ee/heartbeat/heartbeat.go#L10
 func StartHeartbeat(ctx context.Context, frequency time.Duration) (context.Context, func()) {

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -4,16 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
-	"io"
-	"path/filepath"
-	"sync"
-	"time"
-
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"io"
+	"path/filepath"
+	"sync"
 )
 
 var DisableInputArg = terraform.Argument{
@@ -71,7 +69,7 @@ type TerraformInitResponse struct {
 }
 
 func (t *terraformActivities) TerraformInit(ctx context.Context, request TerraformInitRequest) (TerraformInitResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	// Resolve the tf version to be used for this operation
 	tfVersion, err := t.resolveVersion(request.TfVersion)
@@ -115,7 +113,7 @@ type TerraformPlanResponse struct {
 }
 
 func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) (TerraformPlanResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
@@ -201,7 +199,7 @@ type TerraformApplyResponse struct {
 }
 
 func (t *terraformActivities) TerraformApply(ctx context.Context, request TerraformApplyRequest) (TerraformApplyResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
 	"io"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
@@ -55,6 +57,7 @@ func NewTerraformActivities(client TerraformClient, defaultTfVersion *version.Ve
 }
 
 // Terraform Init
+
 type TerraformInitRequest struct {
 	Args      []terraform.Argument
 	Envs      map[string]string
@@ -68,6 +71,8 @@ type TerraformInitResponse struct {
 }
 
 func (t *terraformActivities) TerraformInit(ctx context.Context, request TerraformInitRequest) (TerraformInitResponse, error) {
+	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	defer cancel()
 	// Resolve the tf version to be used for this operation
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
@@ -93,6 +98,7 @@ func (t *terraformActivities) TerraformInit(ctx context.Context, request Terrafo
 }
 
 // Terraform Plan
+
 type TerraformPlanRequest struct {
 	Args      []terraform.Argument
 	Envs      map[string]string
@@ -109,6 +115,8 @@ type TerraformPlanResponse struct {
 }
 
 func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) (TerraformPlanResponse, error) {
+	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
 		return TerraformPlanResponse{}, err
@@ -193,6 +201,8 @@ type TerraformApplyResponse struct {
 }
 
 func (t *terraformActivities) TerraformApply(ctx context.Context, request TerraformApplyRequest) (TerraformApplyResponse, error) {
+	ctx, cancel := temporal.StartHeartbeat(ctx, 10*time.Second)
+	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
 		return TerraformApplyResponse{}, err


### PR DESCRIPTION
These activities have the potential of being long-running so we add a 10sec. heartbeat for the worker to keep track of their progression.