### PR TITLE
Mark atlantis/apply as success for Neptune

### DIFF
--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -240,6 +240,7 @@ func NewServer(config Config) (*Server, error) {
 		OutputUpdater:                 outputUpdater,
 		WorkingDir:                    workingDir,
 		WorkingDirLocker:              workingDirLocker,
+		Allocator:                     featureAllocator,
 	}
 
 	repoConverter := github_converter.RepoConverter{}


### PR DESCRIPTION
As part of Neptune rollout, we need to set the `atlantis/apply` to success in the plan stage to allow users to be able to merge their PR which will trigger the deploy workflow. 

The gateway listens for Comment Events as well as Pull Request events. However, we only need to listen for Pull Request events since it's guaranteed to emit a PR event after platform mode is enabled for a service.  

- Open PRs (after rebase) will emit `PullRequestUpdated` event when platform mode is enabled for a service . 
- New PRs for service with platform mode enabled will emit a `PullRequestCreated` event. 

So, we check if platform mode is enabled and the feature flag is turned on when handling a PR event. If both the conditions are met, we set the atlantis/apply status to success which should unblock the PR from merging. 