### PR TITLE
Audit job fixes.

### DIFF
--- a/server/neptune/workflows/activities/deployment/info.go
+++ b/server/neptune/workflows/activities/deployment/info.go
@@ -2,6 +2,9 @@ package deployment
 
 const InfoSchemaVersion = 1.0
 
+// These objects are persisted and should be kept as lightweight as possible
+// Additionally, please ensure changes to this object going forward are backwards compatible
+// Version is there to help in case of incompatible changes.
 type Info struct {
 	Version  int
 	ID       string

--- a/server/neptune/workflows/activities/deployment/info.go
+++ b/server/neptune/workflows/activities/deployment/info.go
@@ -1,19 +1,24 @@
 package deployment
 
-import (
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-)
-
-const InfoSchemaVersion = "1.0.0"
+const InfoSchemaVersion = 1.0
 
 type Info struct {
-	Version        string
-	ID             string
-	CheckRunID     int64
-	Revision       string
-	InitiatingUser github.User
-	Repo           github.Repo
-	Root           terraform.Root
-	Tags           map[string]string
+	Version  int
+	ID       string
+	Revision string
+	Repo     Repo
+	Root     Root
+}
+
+type Repo struct {
+	Owner string
+	Name  string
+}
+
+func (r Repo) GetFullName() string {
+	return r.Owner + "/" + r.Name
+}
+
+type Root struct {
+	Name string
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
@@ -145,12 +145,16 @@ func (p *RevisionProcessor) fetchLatestDeployment(ctx workflow.Context, deployme
 
 func (p *RevisionProcessor) buildLatestDeployment(deployRequest terraformWorkflow.DeploymentInfo) *deployment.Info {
 	return &deployment.Info{
-		Version:    deployment.InfoSchemaVersion,
-		ID:         deployRequest.ID.String(),
-		CheckRunID: deployRequest.CheckRunID,
-		Revision:   deployRequest.Revision,
-		Root:       deployRequest.Root,
-		Repo:       deployRequest.Repo,
+		Version:  deployment.InfoSchemaVersion,
+		ID:       deployRequest.ID.String(),
+		Revision: deployRequest.Revision,
+		Root: deployment.Root{
+			Name: deployRequest.Root.Name,
+		},
+		Repo: deployment.Repo{
+			Name:  deployRequest.Repo.Name,
+			Owner: deployRequest.Repo.Owner,
+		},
 	}
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -171,24 +171,28 @@ func TestWorker_FetchLatestDeploymentOnStartupOnly(t *testing.T) {
 	// Mock StoreLatestDeploymentRequest for both requests
 	env.OnActivity(da.StoreLatestDeployment, mock.Anything, activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         uuid.UUID{}.String(),
-			CheckRunID: deploymentInfoList[0].CheckRunID,
-			Revision:   deploymentInfoList[0].Revision,
-			Repo:       repo,
-			Root: terraform.Root{
+			Version:  deployment.InfoSchemaVersion,
+			ID:       uuid.UUID{}.String(),
+			Revision: deploymentInfoList[0].Revision,
+			Repo: deployment.Repo{
+				Owner: "owner",
+				Name:  "test",
+			},
+			Root: deployment.Root{
 				Name: deploymentInfoList[0].Root.Name,
 			},
 		},
 	}).Return(nil)
 	env.OnActivity(da.StoreLatestDeployment, mock.Anything, activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         uuid.UUID{}.String(),
-			CheckRunID: deploymentInfoList[1].CheckRunID,
-			Revision:   deploymentInfoList[1].Revision,
-			Repo:       repo,
-			Root: terraform.Root{
+			Version:  deployment.InfoSchemaVersion,
+			ID:       uuid.UUID{}.String(),
+			Revision: deploymentInfoList[1].Revision,
+			Repo: deployment.Repo{
+				Owner: "owner",
+				Name:  "test",
+			},
+			Root: deployment.Root{
 				Name: deploymentInfoList[1].Root.Name,
 			},
 		},
@@ -506,7 +510,10 @@ func getTestArtifacts() (
 	fetchDeploymentResponse = activities.FetchLatestDeploymentResponse{
 		DeploymentInfo: &deployment.Info{
 			Revision: latestDeployedRevision.Revision,
-			Repo:     repo,
+			Repo: deployment.Repo{
+				Owner: "owner",
+				Name:  "test",
+			},
 		},
 	}
 
@@ -518,12 +525,16 @@ func getTestArtifacts() (
 
 	storeDeploymentRequest = activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         deploymentInfo.ID.String(),
-			CheckRunID: deploymentInfo.CheckRunID,
-			Revision:   deploymentInfo.Revision,
-			Root:       deploymentInfo.Root,
-			Repo:       repo,
+			Version:  deployment.InfoSchemaVersion,
+			ID:       deploymentInfo.ID.String(),
+			Revision: deploymentInfo.Revision,
+			Root: deployment.Root{
+				Name: deploymentInfo.Root.Name,
+			},
+			Repo: deployment.Repo{
+				Owner: "owner",
+				Name:  "test",
+			},
 		},
 	}
 	return

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -109,20 +108,16 @@ func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Jo
 	}
 
 	auditJobReq := activities.AuditJobRequest{
-		DeploymentInfo: deployment.Info{
-			Version:        deployment.InfoSchemaVersion,
-			ID:             deploymentInfo.ID.String(),
-			CheckRunID:     deploymentInfo.CheckRunID,
-			Revision:       deploymentInfo.Revision,
-			InitiatingUser: deploymentInfo.InitiatingUser,
-			Root:           deploymentInfo.Root,
-			Repo:           deploymentInfo.Repo,
-			Tags:           deploymentInfo.Tags,
-		},
-		State:        atlantisJobState,
-		StartTime:    startTime,
-		EndTime:      endTime,
-		IsForceApply: deploymentInfo.Root.Trigger == terraform.ManualTrigger,
+		Repo:           deploymentInfo.Repo,
+		Root:           deploymentInfo.Root,
+		JobID:          jobState.ID,
+		InitiatingUser: deploymentInfo.InitiatingUser,
+		Tags:           deploymentInfo.Tags,
+		Revision:       deploymentInfo.Revision,
+		State:          atlantisJobState,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		IsForceApply:   deploymentInfo.Root.Trigger == terraform.ManualTrigger,
 	}
 
 	return workflow.ExecuteActivity(ctx, n.Activity.AuditJob, auditJobReq).Get(ctx, nil)

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -73,14 +72,6 @@ func TestStateReceive(t *testing.T) {
 		ID:         uuid.New(),
 		Root:       terraform.Root{Name: "root"},
 		Repo:       github.Repo{Name: "hello"},
-	}
-
-	deploymentInfo := deployment.Info{
-		ID:         internalDeploymentInfo.ID.String(),
-		Version:    deployment.InfoSchemaVersion,
-		CheckRunID: internalDeploymentInfo.CheckRunID,
-		Root:       internalDeploymentInfo.Root,
-		Repo:       internalDeploymentInfo.Repo,
 	}
 
 	cases := []struct {
@@ -156,10 +147,11 @@ func TestStateReceive(t *testing.T) {
 			},
 			ExpectedCheckRunState: github.CheckRunPending,
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
-				DeploymentInfo: deploymentInfo,
-				State:          activities.AtlantisJobStateRunning,
-				StartTime:      strconv.FormatInt(stTime.Unix(), 10),
-				IsForceApply:   false,
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				State:        activities.AtlantisJobStateRunning,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				IsForceApply: false,
 			},
 		},
 		{
@@ -177,11 +169,12 @@ func TestStateReceive(t *testing.T) {
 			},
 			ExpectedCheckRunState: github.CheckRunFailure,
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
-				DeploymentInfo: deploymentInfo,
-				State:          activities.AtlantisJobStateFailure,
-				StartTime:      strconv.FormatInt(stTime.Unix(), 10),
-				EndTime:        strconv.FormatInt(endTime.Unix(), 10),
-				IsForceApply:   false,
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
 			},
 		},
 		{
@@ -199,11 +192,12 @@ func TestStateReceive(t *testing.T) {
 			},
 			ExpectedCheckRunState: github.CheckRunSuccess,
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
-				DeploymentInfo: deploymentInfo,
-				State:          activities.AtlantisJobStateSuccess,
-				StartTime:      strconv.FormatInt(stTime.Unix(), 10),
-				EndTime:        strconv.FormatInt(endTime.Unix(), 10),
-				IsForceApply:   false,
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				State:        activities.AtlantisJobStateSuccess,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
 			},
 		},
 	}
@@ -229,11 +223,12 @@ func TestStateReceive(t *testing.T) {
 
 			if c.ExpectedAuditJobRequest != nil {
 				env.OnActivity(a.AuditJob, mock.Anything, activities.AuditJobRequest{
-					DeploymentInfo: c.ExpectedAuditJobRequest.DeploymentInfo,
-					State:          c.ExpectedAuditJobRequest.State,
-					StartTime:      c.ExpectedAuditJobRequest.StartTime,
-					EndTime:        c.ExpectedAuditJobRequest.EndTime,
-					IsForceApply:   c.ExpectedAuditJobRequest.IsForceApply,
+					Root:         c.ExpectedAuditJobRequest.Root,
+					Repo:         c.ExpectedAuditJobRequest.Repo,
+					State:        c.ExpectedAuditJobRequest.State,
+					StartTime:    c.ExpectedAuditJobRequest.StartTime,
+					EndTime:      c.ExpectedAuditJobRequest.EndTime,
+					IsForceApply: c.ExpectedAuditJobRequest.IsForceApply,
 				}).Return(nil)
 			}
 

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -53,6 +53,7 @@ func (s *WorkflowStore) InitPlanJob(jobID fmt.Stringer, serverURL fmt.Stringer) 
 		return errors.Wrap(err, "generating url for plan job")
 	}
 	s.state.Plan = &Job{
+		ID: jobID.String(),
 		Output: &JobOutput{
 			URL: outputURL,
 		},
@@ -69,6 +70,7 @@ func (s *WorkflowStore) InitApplyJob(jobID fmt.Stringer, serverURL fmt.Stringer)
 		return errors.Wrap(err, "generating url for apply job")
 	}
 	s.state.Apply = &Job{
+		ID: jobID.String(),
 		Output: &JobOutput{
 			URL: outputURL,
 		},

--- a/server/neptune/workflows/internal/terraform/state/store_test.go
+++ b/server/neptune/workflows/internal/terraform/state/store_test.go
@@ -28,6 +28,7 @@ func TestInitPlanJob(t *testing.T) {
 	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
 	assert.NoError(t, err)
 
+	jobID := bytes.NewBufferString("1234")
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Plan: &state.Job{
@@ -35,6 +36,7 @@ func TestInitPlanJob(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
+				ID: jobID.String(),
 			},
 		},
 		t: t,
@@ -44,7 +46,6 @@ func TestInitPlanJob(t *testing.T) {
 		notifier.notify,
 	)
 
-	jobID := bytes.NewBufferString("1234")
 	baseURL := bytes.NewBufferString("www.test.com")
 
 	err = subject.InitPlanJob(jobID, baseURL)
@@ -59,6 +60,7 @@ func TestInitApplyJob(t *testing.T) {
 	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
 	assert.NoError(t, err)
 
+	jobID := bytes.NewBufferString("1234")
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Apply: &state.Job{
@@ -66,6 +68,7 @@ func TestInitApplyJob(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
+				ID: jobID.String(),
 			},
 		},
 		t: t,
@@ -75,7 +78,6 @@ func TestInitApplyJob(t *testing.T) {
 		notifier.notify,
 	)
 
-	jobID := bytes.NewBufferString("1234")
 	baseURL := bytes.NewBufferString("www.test.com")
 
 	err = subject.InitApplyJob(jobID, baseURL)
@@ -91,6 +93,8 @@ func TestUpdateApplyJob(t *testing.T) {
 	endTime := stTime.Add(time.Second * 10)
 	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
 	assert.NoError(t, err)
+
+	jobID := bytes.NewBufferString("1234")
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Apply: &state.Job{
@@ -98,6 +102,7 @@ func TestUpdateApplyJob(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
+				ID: jobID.String(),
 			},
 		},
 		t: t,
@@ -107,7 +112,6 @@ func TestUpdateApplyJob(t *testing.T) {
 		notifier.notify,
 	)
 
-	jobID := bytes.NewBufferString("1234")
 	baseURL := bytes.NewBufferString("www.test.com")
 
 	// init and then update
@@ -139,6 +143,8 @@ func TestUpdatePlanJob(t *testing.T) {
 
 	exoectedURL, err := url.Parse("www.test.com/jobs/1234")
 	assert.NoError(t, err)
+
+	jobID := bytes.NewBufferString("1234")
 	notifier := &testNotifier{
 		expectedState: &state.Workflow{
 			Plan: &state.Job{
@@ -146,6 +152,7 @@ func TestUpdatePlanJob(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: exoectedURL,
 				},
+				ID: jobID.String(),
 			},
 		},
 		t: t,
@@ -155,7 +162,6 @@ func TestUpdatePlanJob(t *testing.T) {
 		notifier.notify,
 	)
 
-	jobID := bytes.NewBufferString("1234")
 	baseURL := bytes.NewBufferString("www.test.com")
 
 	// init and then update

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -27,6 +27,7 @@ type JobOutput struct {
 }
 
 type Job struct {
+	ID        string
 	Output    *JobOutput
 	Status    JobStatus
 	StartTime time.Time


### PR DESCRIPTION
Couple things I noticed that weren't right:
* deployment.Info is just being passed around everywhere willy nilly.  This is a data model that gets persisted. Best practice is to keep it for that and keep it light weight.  This shouldn't change often because if it does you can get parsing errors.
* deployment.Info stores SO much unnecessary items. The only thing we need storing is revision so why're we storing the world in there?
* JobID wasn't being used for the atlantis event, deploymentID was which is not correct.