### PR TITLE
Initial Priority Queue implementation.

### DIFF
--- a/server/neptune/context/key.go
+++ b/server/neptune/context/key.go
@@ -40,6 +40,9 @@ func ExtractFieldsAsList(ctx KVStore) []interface{} {
 	var args []interface{}
 
 	for _, k := range Keys {
+		if ctx.Value(k) == nil {
+			continue
+		}
 		args = append(args, k)
 		args = append(args, ctx.Value(k))
 	}

--- a/server/neptune/gateway/context/key.go
+++ b/server/neptune/gateway/context/key.go
@@ -25,6 +25,9 @@ func ExtractFields(ctx context.Context) map[string]interface{} {
 	args := make(map[string]interface{})
 
 	for _, k := range Keys {
+		if ctx.Value(k) == nil {
+			continue
+		}
 		args[k.String()] = ctx.Value(k)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -1,0 +1,385 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	model "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type testTerraformWorkflowRunner struct {
+}
+
+func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo) error {
+	return nil
+}
+
+type testDeployActivity struct{}
+
+func (t *testDeployActivity) FetchLatestDeployment(ctx context.Context, deployerRequest activities.FetchLatestDeploymentRequest) (activities.FetchLatestDeploymentResponse, error) {
+	return activities.FetchLatestDeploymentResponse{}, nil
+}
+
+func (t *testDeployActivity) StoreLatestDeployment(ctx context.Context, deployerRequest activities.StoreLatestDeploymentRequest) error {
+	return nil
+}
+
+func (t *testDeployActivity) CompareCommit(ctx context.Context, deployerRequest activities.CompareCommitRequest) (activities.CompareCommitResponse, error) {
+	return activities.CompareCommitResponse{}, nil
+}
+
+func (t *testDeployActivity) UpdateCheckRun(ctx context.Context, deployerRequest activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
+	return activities.UpdateCheckRunResponse{}, nil
+}
+
+type deployerRequest struct {
+	Info         terraform.DeploymentInfo
+	LatestDeploy *deployment.Info
+}
+
+func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.Info, error) {
+	options := workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, options)
+	var a *testDeployActivity
+
+	deployer := &queue.Deployer{
+		Activities:              a,
+		TerraformWorkflowRunner: &testTerraformWorkflowRunner{},
+	}
+
+	return deployer.Deploy(ctx, r.Info, r.LatestDeploy)
+}
+
+func TestDeployer_FirstDeploy(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	da := &testDeployActivity{}
+	env.RegisterActivity(da)
+
+	repo := github.Repo{
+		Owner: "owner",
+		Name:  "test",
+	}
+
+	root := model.Root{
+		Name: "root_1",
+	}
+
+	deploymentInfo := terraform.DeploymentInfo{
+		ID:         uuid.UUID{},
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	latestDeployedRevision := &deployment.Info{
+		ID:         deploymentInfo.ID.String(),
+		Version:    "1.0.0",
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	fetchDeploymentRequest := activities.FetchLatestDeploymentRequest{
+		FullRepositoryName: repo.GetFullName(),
+		RootName:           deploymentInfo.Root.Name,
+	}
+
+	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
+		DeploymentInfo: nil,
+	}
+
+	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+		DeploymentInfo: &deployment.Info{
+			Version:    deployment.InfoSchemaVersion,
+			ID:         deploymentInfo.ID.String(),
+			CheckRunID: deploymentInfo.CheckRunID,
+			Revision:   deploymentInfo.Revision,
+			Root:       deploymentInfo.Root,
+			Repo:       repo,
+		},
+	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+		Info: deploymentInfo,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp *deployment.Info
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, latestDeployedRevision, resp)
+}
+
+func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	da := &testDeployActivity{}
+	env.RegisterActivity(da)
+
+	repo := github.Repo{
+		Owner: "owner",
+		Name:  "test",
+	}
+
+	root := model.Root{
+		Name: "root_1",
+	}
+
+	deploymentInfo := terraform.DeploymentInfo{
+		ID:         uuid.UUID{},
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	latestDeployedRevision := &deployment.Info{
+		ID:         deploymentInfo.ID.String(),
+		Version:    "1.0.0",
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	fetchDeploymentRequest := activities.FetchLatestDeploymentRequest{
+		FullRepositoryName: repo.GetFullName(),
+		RootName:           deploymentInfo.Root.Name,
+	}
+
+	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
+		DeploymentInfo: &deployment.Info{
+			Revision: latestDeployedRevision.Revision,
+			Repo:     repo,
+		},
+	}
+
+	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+		DeploymentInfo: &deployment.Info{
+			Version:    deployment.InfoSchemaVersion,
+			ID:         deploymentInfo.ID.String(),
+			CheckRunID: deploymentInfo.CheckRunID,
+			Revision:   deploymentInfo.Revision,
+			Root:       deploymentInfo.Root,
+			Repo:       repo,
+		},
+	}
+
+	compareCommitRequest := activities.CompareCommitRequest{
+		Repo:                   repo,
+		DeployRequestRevision:  deploymentInfo.Revision,
+		LatestDeployedRevision: latestDeployedRevision.Revision,
+	}
+
+	compareCommitResponse := activities.CompareCommitResponse{
+		CommitComparison: activities.DirectionAhead,
+	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+		Info: deploymentInfo,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp *deployment.Info
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, latestDeployedRevision, resp)
+}
+
+func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	da := &testDeployActivity{}
+	env.RegisterActivity(da)
+
+	repo := github.Repo{
+		Owner: "owner",
+		Name:  "test",
+	}
+
+	root := model.Root{
+		Name: "root_1",
+	}
+
+	deploymentInfo := terraform.DeploymentInfo{
+		ID:         uuid.UUID{},
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	latestDeployedRevision := &deployment.Info{
+		ID:         deploymentInfo.ID.String(),
+		Version:    "1.0.0",
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	fetchDeploymentRequest := activities.FetchLatestDeploymentRequest{
+		FullRepositoryName: repo.GetFullName(),
+		RootName:           deploymentInfo.Root.Name,
+	}
+
+	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
+		DeploymentInfo: &deployment.Info{
+			Revision: latestDeployedRevision.Revision,
+			Repo:     repo,
+		},
+	}
+
+	compareCommitRequest := activities.CompareCommitRequest{
+		Repo:                   repo,
+		DeployRequestRevision:  deploymentInfo.Revision,
+		LatestDeployedRevision: latestDeployedRevision.Revision,
+	}
+
+	compareCommitResponse := activities.CompareCommitResponse{
+		CommitComparison: activities.DirectionBehind,
+	}
+
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+		State:   github.CheckRunFailure,
+		Repo:    repo,
+		ID:      deploymentInfo.CheckRunID,
+		Summary: queue.DirectionBehindSummary,
+	}
+
+	updateCheckRunResponse := activities.UpdateCheckRunResponse{
+		ID: updateCheckRunRequest.ID,
+	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+
+	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+		Info: deploymentInfo,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp *deployment.Info
+	err := env.GetWorkflowResult(&resp)
+	assert.Error(t, err)
+
+	assert.Nil(t, resp)
+
+}
+
+func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	da := &testDeployActivity{}
+	env.RegisterActivity(da)
+
+	repo := github.Repo{
+		Owner: "owner",
+		Name:  "test",
+	}
+
+	root := model.Root{
+		Name: "root_1",
+	}
+
+	deploymentInfo := terraform.DeploymentInfo{
+		ID:         uuid.UUID{},
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	latestDeployedRevision := &deployment.Info{
+		ID:         deploymentInfo.ID.String(),
+		Version:    "1.0.0",
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	fetchDeploymentRequest := activities.FetchLatestDeploymentRequest{
+		FullRepositoryName: repo.GetFullName(),
+		RootName:           deploymentInfo.Root.Name,
+	}
+
+	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
+		DeploymentInfo: &deployment.Info{
+			Revision: latestDeployedRevision.Revision,
+			Repo:     repo,
+		},
+	}
+
+	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+		DeploymentInfo: &deployment.Info{
+			Version:    deployment.InfoSchemaVersion,
+			ID:         deploymentInfo.ID.String(),
+			CheckRunID: deploymentInfo.CheckRunID,
+			Revision:   deploymentInfo.Revision,
+			Root:       deploymentInfo.Root,
+			Repo:       repo,
+		},
+	}
+
+	compareCommitRequest := activities.CompareCommitRequest{
+		Repo:                   repo,
+		DeployRequestRevision:  deploymentInfo.Revision,
+		LatestDeployedRevision: latestDeployedRevision.Revision,
+	}
+
+	compareCommitResponse := activities.CompareCommitResponse{
+		CommitComparison: activities.DirectionDiverged,
+	}
+
+	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
+	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+		Info: deploymentInfo,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp *deployment.Info
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, latestDeployedRevision, resp)
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -89,15 +89,15 @@ func TestDeployer_FirstDeploy(t *testing.T) {
 	}
 
 	latestDeployedRevision := &deployment.Info{
-		ID:         deploymentInfo.ID.String(),
-		Version:    1.0,
-		Revision:   "3455",
+		ID:       deploymentInfo.ID.String(),
+		Version:  1.0,
+		Revision: "3455",
 		Root: deployment.Root{
 			Name: deploymentInfo.Root.Name,
 		},
 		Repo: deployment.Repo{
 			Owner: deploymentInfo.Repo.Owner,
-			Name: deploymentInfo.Repo.Name,
+			Name:  deploymentInfo.Repo.Name,
 		},
 	}
 
@@ -112,15 +112,15 @@ func TestDeployer_FirstDeploy(t *testing.T) {
 
 	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         deploymentInfo.ID.String(),
-			Revision:   deploymentInfo.Revision,
+			Version:  deployment.InfoSchemaVersion,
+			ID:       deploymentInfo.ID.String(),
+			Revision: deploymentInfo.Revision,
 			Root: deployment.Root{
 				Name: deploymentInfo.Root.Name,
 			},
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}
@@ -166,15 +166,15 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 	}
 
 	latestDeployedRevision := &deployment.Info{
-		ID:         deploymentInfo.ID.String(),
-		Version:    1.0,
-		Revision:   "3455",
+		ID:       deploymentInfo.ID.String(),
+		Version:  1.0,
+		Revision: "3455",
 		Root: deployment.Root{
 			Name: deploymentInfo.Root.Name,
 		},
 		Repo: deployment.Repo{
 			Owner: deploymentInfo.Repo.Owner,
-			Name: deploymentInfo.Repo.Name,
+			Name:  deploymentInfo.Repo.Name,
 		},
 	}
 
@@ -188,22 +188,22 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 			Revision: latestDeployedRevision.Revision,
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}
 
 	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         deploymentInfo.ID.String(),
-			Revision:   deploymentInfo.Revision,
+			Version:  deployment.InfoSchemaVersion,
+			ID:       deploymentInfo.ID.String(),
+			Revision: deploymentInfo.Revision,
 			Root: deployment.Root{
 				Name: deploymentInfo.Root.Name,
 			},
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}
@@ -260,15 +260,15 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 	}
 
 	latestDeployedRevision := &deployment.Info{
-		ID:         deploymentInfo.ID.String(),
-		Version:    1.0,
-		Revision:   "3455",
+		ID:       deploymentInfo.ID.String(),
+		Version:  1.0,
+		Revision: "3455",
 		Root: deployment.Root{
 			Name: deploymentInfo.Root.Name,
 		},
 		Repo: deployment.Repo{
 			Owner: deploymentInfo.Repo.Owner,
-			Name: deploymentInfo.Repo.Name,
+			Name:  deploymentInfo.Repo.Name,
 		},
 	}
 
@@ -282,7 +282,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			Revision: latestDeployedRevision.Revision,
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}
@@ -352,15 +352,15 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 	}
 
 	latestDeployedRevision := &deployment.Info{
-		ID:         deploymentInfo.ID.String(),
-		Version:    1.0,
-		Revision:   "3455",
+		ID:       deploymentInfo.ID.String(),
+		Version:  1.0,
+		Revision: "3455",
 		Root: deployment.Root{
 			Name: deploymentInfo.Root.Name,
 		},
 		Repo: deployment.Repo{
 			Owner: deploymentInfo.Repo.Owner,
-			Name: deploymentInfo.Repo.Name,
+			Name:  deploymentInfo.Repo.Name,
 		},
 	}
 
@@ -374,22 +374,22 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 			Revision: latestDeployedRevision.Revision,
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}
 
 	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
 		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         deploymentInfo.ID.String(),
-			Revision:   deploymentInfo.Revision,
+			Version:  deployment.InfoSchemaVersion,
+			ID:       deploymentInfo.ID.String(),
+			Revision: deploymentInfo.Revision,
 			Root: deployment.Root{
 				Name: deploymentInfo.Root.Name,
 			},
 			Repo: deployment.Repo{
 				Owner: deploymentInfo.Repo.Owner,
-				Name: deploymentInfo.Repo.Name,
+				Name:  deploymentInfo.Repo.Name,
 			},
 		},
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -2,37 +2,107 @@ package queue
 
 import (
 	"container/list"
+	"fmt"
 
+	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 )
 
-// Queue is a standard queue implementation
-type Queue struct {
-	queue *list.List
+type LockStatus int
+
+const (
+	UnlockedStatus LockStatus = iota
+	LockedStatus
+)
+
+type Deploy struct {
+	queue priority
+
+	// mutable: default is unlocked
+	lock LockStatus
 }
 
-func NewQueue() *Queue {
-	return &Queue{
-		queue: list.New(),
+func NewQueue() *Deploy {
+	return &Deploy{
+		queue: *newPriorityQueue(),
+	}
+
+}
+
+func (q *Deploy) SetLockStatusForMergedTrigger(status LockStatus) {
+	q.lock = status
+}
+
+func (q *Deploy) CanPop() bool {
+	return q.lock == LockedStatus && q.queue.HasItemsOfPriority(High) || (q.lock == UnlockedStatus && q.queue.IsEmpty())
+}
+
+func (q *Deploy) Pop() (terraform.DeploymentInfo, error) {
+	return q.queue.Pop()
+}
+
+func (q *Deploy) IsEmpty() bool {
+	return q.queue.IsEmpty()
+}
+
+func (q *Deploy) Push(msg terraform.DeploymentInfo) {
+	if msg.Root.Trigger == activity.ManualTrigger {
+		q.queue.Push(msg, High)
+		return
+	}
+
+	q.queue.Push(msg, Low)
+}
+
+// Queue is a standard queue implementation
+type priority struct {
+	queues map[priorityType]*list.List
+}
+
+type priorityType int
+
+const (
+	Low priorityType = iota + 1
+	High
+)
+
+func newPriorityQueue() *priority {
+	return &priority{
+		queues: map[priorityType]*list.List{
+			High: list.New(),
+			Low:  list.New(),
+		},
 	}
 }
 
-func (q *Queue) IsEmpty() bool {
-	return q.queue.Len() == 0
+func (q *priority) IsEmpty() bool {
+	for _, q := range q.queues {
+		if q.Len() != 0 {
+			return false
+		}
+	}
+	return true
 }
 
-func (q *Queue) Push(msg terraform.DeploymentInfo) {
-	q.queue.PushBack(msg)
+func (q *priority) HasItemsOfPriority(priority priorityType) bool {
+	return q.queues[priority].Len() != 0
 }
 
-func (q *Queue) Peek() terraform.DeploymentInfo {
-	result := q.queue.Front()
-	return result.Value.(terraform.DeploymentInfo)
+func (q *priority) Push(msg terraform.DeploymentInfo, priority priorityType) {
+	q.queues[priority].PushBack(msg)
 }
 
-func (q *Queue) Pop() terraform.DeploymentInfo {
-	result := q.queue.Remove(q.queue.Front())
+func (q *priority) Pop() (terraform.DeploymentInfo, error) {
+	priority := High
+	if q.queues[High].Len() == 0 {
+		priority = Low
+	}
 
+	if q.queues[priority].Len() == 0 {
+		return terraform.DeploymentInfo{}, fmt.Errorf("no items to pop")
+	}
+
+	result := q.queues[priority].Remove(q.queues[priority].Front())
 	// naughty casting
-	return result.(terraform.DeploymentInfo)
+	return result.(terraform.DeploymentInfo), nil
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -16,7 +16,7 @@ const (
 )
 
 type Deploy struct {
-	queue priority
+	queue *priority
 
 	// mutable: default is unlocked
 	lock LockStatus
@@ -24,7 +24,7 @@ type Deploy struct {
 
 func NewQueue() *Deploy {
 	return &Deploy{
-		queue: *newPriorityQueue(),
+		queue: newPriorityQueue(),
 	}
 
 }
@@ -34,7 +34,7 @@ func (q *Deploy) SetLockStatusForMergedTrigger(status LockStatus) {
 }
 
 func (q *Deploy) CanPop() bool {
-	return q.lock == LockedStatus && q.queue.HasItemsOfPriority(High) || (q.lock == UnlockedStatus && q.queue.IsEmpty())
+	return q.lock == LockedStatus && q.queue.HasItemsOfPriority(High) || (q.lock == UnlockedStatus && !q.queue.IsEmpty())
 }
 
 func (q *Deploy) Pop() (terraform.DeploymentInfo, error) {
@@ -54,7 +54,8 @@ func (q *Deploy) Push(msg terraform.DeploymentInfo) {
 	q.queue.Push(msg, Low)
 }
 
-// Queue is a standard queue implementation
+// priority is a simple 2 priority queue implementation
+// priority is determined before an item enters a queue and does not change
 type priority struct {
 	queues map[priorityType]*list.List
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -34,7 +34,7 @@ func (q *Deploy) SetLockStatusForMergedTrigger(status LockStatus) {
 }
 
 func (q *Deploy) CanPop() bool {
-	return q.lock == LockedStatus && q.queue.HasItemsOfPriority(High) || (q.lock == UnlockedStatus && !q.queue.IsEmpty())
+	return q.queue.HasItemsOfPriority(High) || (q.lock == UnlockedStatus && !q.queue.IsEmpty())
 }
 
 func (q *Deploy) Pop() (terraform.DeploymentInfo, error) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
@@ -1,0 +1,75 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	t.Run("priority order", func(t *testing.T) {
+		q := newPriorityQueue()
+
+		q.Push(wrap("1"), Low)
+		q.Push(wrap("2"), High)
+		q.Push(wrap("3"), High)
+		q.Push(wrap("4"), Low)
+
+		info, err := q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, "2", unwrap(info))
+
+		info, err = q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, "3", unwrap(info))
+
+		info, err = q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, "1", unwrap(info))
+
+		info, err = q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, "4", unwrap(info))
+	})
+
+	t.Run("pop empty queue", func(t *testing.T) {
+		q := newPriorityQueue()
+
+		_, err := q.Pop()
+		assert.Error(t, err)
+	})
+
+	priorities := []priorityType{
+		Low,
+		High,	
+	}
+
+	for _, p := range priorities {
+		t.Run("has items of priority", func(t *testing.T) {
+			q := newPriorityQueue()
+			assert.False(t, q.HasItemsOfPriority(p))
+
+			q.Push(wrap("1"), p)
+			assert.True(t, q.HasItemsOfPriority(p))
+
+		})
+
+		t.Run("empty", func(t *testing.T) {
+			q := newPriorityQueue()
+	
+			assert.True(t, q.IsEmpty())
+			q.Push(wrap("1"), p)
+			assert.False(t, q.IsEmpty())
+		})
+	}
+}
+
+func wrap(msg string) terraform.DeploymentInfo {
+	return terraform.DeploymentInfo{Revision: msg}
+
+}
+
+func unwrap(msg terraform.DeploymentInfo) string {
+	return msg.Revision
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
@@ -42,7 +42,7 @@ func TestPriorityQueue(t *testing.T) {
 
 	priorities := []priorityType{
 		Low,
-		High,	
+		High,
 	}
 
 	for _, p := range priorities {
@@ -57,7 +57,7 @@ func TestPriorityQueue(t *testing.T) {
 
 		t.Run("empty", func(t *testing.T) {
 			q := newPriorityQueue()
-	
+
 			assert.True(t, q.IsEmpty())
 			q.Push(wrap("1"), p)
 			assert.False(t, q.IsEmpty())

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -1,11 +1,11 @@
 package queue_test
 
 import (
-	"testing"
+	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
-	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestQueue(t *testing.T) {
@@ -16,7 +16,6 @@ func TestQueue(t *testing.T) {
 		q.Push(msg1)
 		msg2 := wrap("2", activity.ManualTrigger)
 		q.Push(msg2)
-
 
 		info, err := q.Pop()
 		assert.NoError(t, err)

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -2,35 +2,72 @@ package queue_test
 
 import (
 	"testing"
-
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestQueue(t *testing.T) {
-	q := queue.NewQueue()
+	t.Run("priority", func(t *testing.T) {
+		q := queue.NewQueue()
 
-	assert.True(t, q.IsEmpty())
+		msg1 := wrap("1", activity.MergeTrigger)
+		q.Push(msg1)
+		msg2 := wrap("2", activity.ManualTrigger)
+		q.Push(msg2)
 
-	q.Push(wrap("1"))
-	q.Push(wrap("2"))
-	q.Push(wrap("3"))
 
-	assert.False(t, q.IsEmpty())
+		info, err := q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, msg2, info)
 
-	assert.Equal(t, "1", unwrap(q.Pop()))
-	assert.Equal(t, "2", unwrap(q.Pop()))
-	assert.Equal(t, "3", unwrap(q.Pop()))
+		info, err = q.Pop()
+		assert.NoError(t, err)
+		assert.Equal(t, msg1, info)
+	})
 
-	assert.True(t, q.IsEmpty())
+	t.Run("can pop empty queue unlocked", func(t *testing.T) {
+		q := queue.NewQueue()
+		assert.Equal(t, false, q.CanPop())
+	})
+
+	t.Run("can pop empty queue locked", func(t *testing.T) {
+		q := queue.NewQueue()
+		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		assert.Equal(t, false, q.CanPop())
+	})
+	t.Run("can pop manual trigger locked", func(t *testing.T) {
+		q := queue.NewQueue()
+		msg1 := wrap("1", activity.ManualTrigger)
+		q.Push(msg1)
+		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		assert.Equal(t, true, q.CanPop())
+	})
+	t.Run("can pop manual trigger unlocked", func(t *testing.T) {
+		q := queue.NewQueue()
+		msg1 := wrap("1", activity.ManualTrigger)
+		q.Push(msg1)
+		assert.Equal(t, true, q.CanPop())
+	})
+	t.Run("can pop merge trigger locked", func(t *testing.T) {
+		q := queue.NewQueue()
+		msg1 := wrap("1", activity.MergeTrigger)
+		q.Push(msg1)
+		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		assert.Equal(t, false, q.CanPop())
+	})
+	t.Run("can pop merge trigger unlocked", func(t *testing.T) {
+		q := queue.NewQueue()
+		msg1 := wrap("1", activity.MergeTrigger)
+		q.Push(msg1)
+		assert.Equal(t, true, q.CanPop())
+	})
 }
 
-func wrap(msg string) terraform.DeploymentInfo {
-	return terraform.DeploymentInfo{Revision: msg}
+func wrap(msg string, trigger activity.Trigger) terraform.DeploymentInfo {
+	return terraform.DeploymentInfo{Revision: msg, Root: activity.Root{
+		Trigger: trigger,
+	}}
 
-}
-
-func unwrap(msg terraform.DeploymentInfo) string {
-	return msg.Revision
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/revision_processor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -63,10 +62,6 @@ func (p *RevisionProcessor) Process(ctx workflow.Context, requestedDeployment te
 		if err = p.updateCheckRun(ctx, requestedDeployment, github.CheckRunFailure, DirectionBehindSummary, nil); err != nil {
 			return nil, errors.Wrap(err, "updating check run")
 		}
-	case activities.DirectionDiverged:
-		if err = p.waitForUserUnlock(ctx, requestedDeployment); err != nil {
-			return nil, errors.Wrap(err, "waiting for user unlock")
-		}
 	}
 	err = p.TerraformWorkflowRunner.Run(ctx, requestedDeployment)
 	if err != nil {
@@ -107,24 +102,6 @@ func (p *RevisionProcessor) updateCheckRun(ctx workflow.Context, deployRequest t
 		Summary: summary,
 		Actions: actions,
 	}).Get(ctx, nil)
-}
-
-// For merged deployments, notify user of a force apply lock status and lock future deployments until signal is received
-func (p *RevisionProcessor) waitForUserUnlock(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo) error {
-	// We won't lock a manually triggered root
-	if deploymentInfo.Root.Trigger == terraform.ManualTrigger {
-		return nil
-	}
-	err := p.updateCheckRun(ctx, deploymentInfo, github.CheckRunPending, DivergedCommitsSummary, []github.CheckRunAction{github.CreateUnlockAction()})
-	if err != nil {
-		return errors.Wrap(err, "updating check run")
-	}
-	// Wait for unlock signal
-	signalChan := workflow.GetSignalChannel(ctx, UnlockSignalName)
-	var unlockRequest UnlockSignalRequest
-	_ = signalChan.Receive(ctx, &unlockRequest)
-	// TODO: store info on user that unlocked revision, maybe within the check run or just log it?
-	return nil
 }
 
 func (p *RevisionProcessor) fetchLatestDeployment(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo, latestDeployment *deployment.Info) (*deployment.Info, error) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -13,7 +13,6 @@ import (
 )
 
 type queue interface {
-	Push(terraform.DeploymentInfo)
 	IsEmpty() bool
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -1,73 +1,119 @@
 package queue_test
 
 import (
-	"context"
+	"container/list"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
 
-type testTerraformWorkflowRunner struct {
+type testQueue struct {
+	Queue      *list.List
+	LockStatus queue.LockStatus
 }
 
-func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo) error {
-	return nil
+func (q *testQueue) IsEmpty() bool {
+	return q.Queue.Len() == 0
+}
+func (q *testQueue) CanPop() bool {
+	return !q.IsEmpty()
+}
+func (q *testQueue) Pop() (terraformWorkflow.DeploymentInfo, error) {
+	if q.IsEmpty() {
+		return terraformWorkflow.DeploymentInfo{}, fmt.Errorf("calling pop on empty queue")
+	}
+
+	result := q.Queue.Remove(q.Queue.Front())
+	return result.(terraformWorkflow.DeploymentInfo), nil
 }
 
-type request struct {
-	Queue []terraformWorkflow.DeploymentInfo
+func (q *testQueue) Push(msg terraformWorkflow.DeploymentInfo) {
+	q.Queue.PushBack(msg)
 }
 
-type response struct {
+func (q *testQueue) SetLockStatusForMergedTrigger(status queue.LockStatus) {
+	q.LockStatus = status
+}
+
+type workerRequest struct {
+	Queue                   []terraformWorkflow.DeploymentInfo
+	ExpectedValidationError *queue.ValidationError
+	InitialLockStatus       queue.LockStatus
+}
+
+type workerResponse struct {
 	QueueIsEmpty bool
 	EndState     queue.WorkerState
+	CapturedArgs []*deployment.Info
 }
 
 type queueAndState struct {
 	QueueIsEmpty bool
 	State        queue.WorkerState
+	LockStatus   queue.LockStatus
 }
 
-func testWorkflow(ctx workflow.Context, r request) (response, error) {
+type testDeployer struct {
+	expectedRevisions       []*deployment.Info
+	expectedValidationError *queue.ValidationError
+
+	capturedLatestDeployments []*deployment.Info
+
+	// keeps track of where we are in expected revisions, panics
+	// if we go to far
+	count int
+}
+
+func (d *testDeployer) Deploy(ctx workflow.Context, requestedDeployment terraformWorkflow.DeploymentInfo, latestDeployment *deployment.Info) (*deployment.Info, error) {
+	d.capturedLatestDeployments = append(d.capturedLatestDeployments, latestDeployment)
+	info := d.expectedRevisions[d.count]
+
+	var err error
+	if d.count == 0 && d.expectedValidationError != nil {
+		err = d.expectedValidationError
+	}
+	d.count++
+
+	return info, err
+}
+
+func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
 	})
-	info := workflow.GetInfo(ctx)
-	execution := info.WorkflowExecution
 
-	payload := queue.UnlockSignalRequest{User: "username"}
-	if err := workflow.SignalExternalWorkflow(ctx, execution.ID, execution.RunID, queue.UnlockSignalName, payload).Get(ctx, nil); err != nil {
-		return response{}, err
+	q := &testQueue{
+		Queue: list.New(),
 	}
 
-	if err := workflow.Sleep(ctx, 1*time.Second); err != nil {
-		return response{}, err
-	}
+	q.SetLockStatusForMergedTrigger(r.InitialLockStatus)
 
-	q := queue.NewQueue()
-
+	var infos []*deployment.Info
 	for _, s := range r.Queue {
+		infos = append(infos, &deployment.Info{
+			Revision: s.Revision,
+		})
 		q.Push(s)
 	}
 
-	var wa *testDeployActivity
+	deployer := &testDeployer{
+		expectedRevisions:       infos,
+		expectedValidationError: r.ExpectedValidationError,
+	}
+
 	worker := queue.Worker{
-		Queue: q,
-		RevisionProcessor: &queue.RevisionProcessor{
-			Activities:              wa,
-			TerraformWorkflowRunner: &testTerraformWorkflowRunner{},
-		},
+		Queue:    q,
+		Deployer: deployer,
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {
@@ -75,25 +121,73 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		return queueAndState{
 			QueueIsEmpty: q.IsEmpty(),
 			State:        worker.GetState(),
+			LockStatus:   q.LockStatus,
 		}, nil
 	})
 	if err != nil {
-		return response{}, err
+		return workerResponse{}, err
 	}
 
 	worker.Work(ctx)
 
-	return response{
+	return workerResponse{
 		QueueIsEmpty: q.IsEmpty(),
 		EndState:     worker.GetState(),
+		CapturedArgs: deployer.capturedLatestDeployments,
 	}, nil
 }
 
-func TestWorker_FetchLatestDeploymentOnStartupOnly(t *testing.T) {
+func TestWorker_ReceivesUnlockSignal(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	da := testDeployActivity{}
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(queue.UnlockSignalName, queue.UnlockSignalRequest{User: "username"})
+	}, 5*time.Second)
+
+	// we set this callback so we can query the state of the queue
+	// after all processing has complete to determine whether we should
+	// shutdown the worker
+	env.RegisterDelayedCallback(func() {
+		encoded, err := env.QueryWorkflow("queue")
+
+		assert.NoError(t, err)
+
+		var q queueAndState
+		err = encoded.Get(&q)
+
+		assert.NoError(t, err)
+
+		assert.True(t, q.QueueIsEmpty)
+		assert.Equal(t, queue.UnlockedStatus, q.LockStatus)
+		assert.Equal(t, queue.WaitingWorkerState, q.State)
+
+		env.CancelWorkflow()
+
+	}, 10*time.Second)
+
+	env.ExecuteWorkflow(testWorkerWorkflow, workerRequest{
+		// start locked and ensure we can unlock it.
+		InitialLockStatus: queue.LockedStatus,
+	})
+
+	env.AssertExpectations(t)
+
+	var resp workerResponse
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	// deploy should never be called
+	assert.Len(t, resp.CapturedArgs, 0)
+
+	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
+	assert.True(t, resp.QueueIsEmpty)
+}
+
+func TestWorker_DeploysItems(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
 	// we set this callback so we can query the state of the queue
 	// after all processing has complete to determine whether we should
 	// shutdown the worker
@@ -140,159 +234,29 @@ func TestWorker_FetchLatestDeploymentOnStartupOnly(t *testing.T) {
 		},
 	}
 
-	latestDeployment := deployment.Info{
-		Revision: "2345",
-	}
-
-	// Mock FetchLatestDeploymentRequest only once to assert it's only being called for the first deploy
-	env.OnActivity(da.FetchLatestDeployment, mock.Anything, activities.FetchLatestDeploymentRequest{
-		FullRepositoryName: repo.GetFullName(),
-		RootName:           deploymentInfoList[0].Root.Name,
-	}).Return(activities.FetchLatestDeploymentResponse{
-		DeploymentInfo: &latestDeployment,
-	}, nil)
-
-	// Mock CompareCommits for both the deploy request
-	env.OnActivity(da.CompareCommit, mock.Anything, activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfoList[0].Revision,
-		LatestDeployedRevision: latestDeployment.Revision,
-	}).Return(activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionAhead,
-	}, nil)
-	env.OnActivity(da.CompareCommit, mock.Anything, activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfoList[1].Revision,
-		LatestDeployedRevision: deploymentInfoList[0].Revision,
-	}).Return(activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionAhead,
-	}, nil)
-
-	// Mock StoreLatestDeploymentRequest for both requests
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         uuid.UUID{}.String(),
-			CheckRunID: deploymentInfoList[0].CheckRunID,
-			Revision:   deploymentInfoList[0].Revision,
-			Repo:       repo,
-			Root: terraform.Root{
-				Name: deploymentInfoList[0].Root.Name,
-			},
-		},
-	}).Return(nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         uuid.UUID{}.String(),
-			CheckRunID: deploymentInfoList[1].CheckRunID,
-			Revision:   deploymentInfoList[1].Revision,
-			Repo:       repo,
-			Root: terraform.Root{
-				Name: deploymentInfoList[1].Root.Name,
-			},
-		},
-	}).Return(nil)
-
-	env.ExecuteWorkflow(testWorkflow, request{
+	env.ExecuteWorkflow(testWorkerWorkflow, workerRequest{
 		Queue: deploymentInfoList,
 	})
 
 	env.AssertExpectations(t)
 
-	var resp response
+	var resp workerResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
+	assert.Equal(t, []*deployment.Info{
+		nil, {
+			Revision: "1",
+		},
+	}, resp.CapturedArgs)
 	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
 	assert.True(t, resp.QueueIsEmpty)
 }
 
-func TestWorker_CompareCommit_SkipDeploy(t *testing.T) {
-	deploymentInfo, _, repo, fetchDeploymentRequest, fetchDeploymentResponse, compareCommitRequest, _ := getTestArtifacts()
-
-	cases := []struct {
-		description           string
-		compareCommitResponse activities.CompareCommitResponse
-		updateCheckRunRequest activities.UpdateCheckRunRequest
-	}{
-		{
-			description: "behind",
-			compareCommitResponse: activities.CompareCommitResponse{
-				CommitComparison: activities.DirectionBehind,
-			},
-			updateCheckRunRequest: activities.UpdateCheckRunRequest{
-				Title:   terraformWorkflow.BuildCheckRunTitle(deploymentInfo.Root.Name),
-				State:   github.CheckRunFailure,
-				Repo:    repo,
-				ID:      deploymentInfo.CheckRunID,
-				Summary: queue.DirectionBehindSummary,
-			},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.description, func(t *testing.T) {
-			ts := testsuite.WorkflowTestSuite{}
-			env := ts.NewTestWorkflowEnvironment()
-
-			da := testDeployActivity{}
-			// we set this callback so we can query the state of the queue
-			// after all processing has complete to determine whether we should
-			// shutdown the worker
-			env.RegisterDelayedCallback(func() {
-				encoded, err := env.QueryWorkflow("queue")
-
-				assert.NoError(t, err)
-
-				var q queueAndState
-				err = encoded.Get(&q)
-
-				assert.NoError(t, err)
-
-				assert.True(t, q.QueueIsEmpty)
-				assert.Equal(t, queue.WaitingWorkerState, q.State)
-
-				env.CancelWorkflow()
-
-			}, 10*time.Second)
-
-			deploymentInfoList := []terraformWorkflow.DeploymentInfo{
-				deploymentInfo,
-			}
-
-			env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
-			env.OnActivity(da.UpdateCheckRun, mock.Anything, c.updateCheckRunRequest).Return(activities.UpdateCheckRunResponse{
-				ID: c.updateCheckRunRequest.ID,
-			}, nil)
-			env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(c.compareCommitResponse, nil)
-
-			env.ExecuteWorkflow(testWorkflow, request{
-				Queue: deploymentInfoList,
-			})
-
-			env.AssertExpectations(t)
-
-			var resp response
-			err := env.GetWorkflowResult(&resp)
-			assert.NoError(t, err)
-
-			assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
-			assert.True(t, resp.QueueIsEmpty)
-		})
-	}
-
-}
-
-func TestWorker_CompareCommit_DeployAhead(t *testing.T) {
-	deploymentInfo, _, _, fetchDeploymentRequest, fetchDeploymentResponse, compareCommitRequest, storeLatestDeploymentReq := getTestArtifacts()
+func TestWorker_DeploysItems_ValidationError(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionAhead,
-	}
-
-	da := testDeployActivity{}
 	// we set this callback so we can query the state of the queue
 	// after all processing has complete to determine whether we should
 	// shutdown the worker
@@ -313,218 +277,46 @@ func TestWorker_CompareCommit_DeployAhead(t *testing.T) {
 
 	}, 10*time.Second)
 
-	deploymentInfoList := []terraformWorkflow.DeploymentInfo{
-		deploymentInfo,
-	}
-
-	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
-
-	env.ExecuteWorkflow(testWorkflow, request{
-		Queue: deploymentInfoList,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp response
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
-	assert.True(t, resp.QueueIsEmpty)
-
-}
-
-func TestWorker_CompareCommit_DeployDiverged(t *testing.T) {
-	deploymentInfo, _, _, fetchDeploymentRequest, fetchDeploymentResponse, compareCommitRequest, storeLatestDeploymentReq := getTestArtifacts()
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionDiverged,
-	}
-
-	da := testDeployActivity{}
-	// we set this callback so we can query the state of the queue
-	// after all processing has complete to determine whether we should
-	// shutdown the worker
-	env.RegisterDelayedCallback(func() {
-		encoded, err := env.QueryWorkflow("queue")
-
-		assert.NoError(t, err)
-
-		var q queueAndState
-		err = encoded.Get(&q)
-
-		assert.NoError(t, err)
-
-		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.WaitingWorkerState, q.State)
-
-		env.CancelWorkflow()
-
-	}, 10*time.Second)
-
-	deploymentInfoList := []terraformWorkflow.DeploymentInfo{
-		deploymentInfo,
-	}
-	updateCheckRunRequest := activities.UpdateCheckRunRequest{
-		Title:   terraformWorkflow.BuildCheckRunTitle(deploymentInfo.Root.Name),
-		State:   github.CheckRunPending,
-		Repo:    deploymentInfo.Repo,
-		ID:      deploymentInfo.CheckRunID,
-		Summary: queue.DivergedCommitsSummary,
-		Actions: []github.CheckRunAction{github.CreateUnlockAction()},
-	}
-
-	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
-	env.OnActivity(da.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(activities.UpdateCheckRunResponse{
-		ID: int64(1),
-	}, nil)
-
-	env.ExecuteWorkflow(testWorkflow, request{
-		Queue: deploymentInfoList,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp response
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
-	assert.True(t, resp.QueueIsEmpty)
-
-}
-
-func TestWorker_FirstDeploy(t *testing.T) {
-	deploymentInfo, _, _, fetchDeploymentRequest, _, _, storeLatestDeploymentReq := getTestArtifacts()
-	fetchDeploymentResponse := activities.FetchLatestDeploymentResponse{
-		DeploymentInfo: nil,
-	}
-
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	da := testDeployActivity{}
-	// we set this callback so we can query the state of the queue
-	// after all processing has complete to determine whether we should
-	// shutdown the worker
-	env.RegisterDelayedCallback(func() {
-		encoded, err := env.QueryWorkflow("queue")
-
-		assert.NoError(t, err)
-
-		var q queueAndState
-		err = encoded.Get(&q)
-
-		assert.NoError(t, err)
-
-		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.WaitingWorkerState, q.State)
-
-		env.CancelWorkflow()
-
-	}, 10*time.Second)
-
-	deploymentInfoList := []terraformWorkflow.DeploymentInfo{
-		deploymentInfo,
-	}
-
-	env.OnActivity(da.FetchLatestDeployment, mock.Anything, fetchDeploymentRequest).Return(fetchDeploymentResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeLatestDeploymentReq).Return(nil)
-
-	env.ExecuteWorkflow(testWorkflow, request{
-		Queue: deploymentInfoList,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp response
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
-	assert.True(t, resp.QueueIsEmpty)
-}
-
-type testDeployActivity struct{}
-
-func (t *testDeployActivity) FetchLatestDeployment(ctx context.Context, request activities.FetchLatestDeploymentRequest) (activities.FetchLatestDeploymentResponse, error) {
-	return activities.FetchLatestDeploymentResponse{}, nil
-}
-
-func (t *testDeployActivity) StoreLatestDeployment(ctx context.Context, request activities.StoreLatestDeploymentRequest) error {
-	return nil
-}
-
-func (t *testDeployActivity) CompareCommit(ctx context.Context, request activities.CompareCommitRequest) (activities.CompareCommitResponse, error) {
-	return activities.CompareCommitResponse{}, nil
-}
-
-func (t *testDeployActivity) UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
-	return activities.UpdateCheckRunResponse{}, nil
-}
-
-// Setup test artifacts for compare commit tests
-func getTestArtifacts() (
-	deploymentInfo terraformWorkflow.DeploymentInfo,
-	latestDeployedRevision deployment.Info,
-	repo github.Repo,
-	fetchDeploymentRequest activities.FetchLatestDeploymentRequest,
-	fetchDeploymentResponse activities.FetchLatestDeploymentResponse,
-	compareCommitRequest activities.CompareCommitRequest,
-	storeDeploymentRequest activities.StoreLatestDeploymentRequest,
-) {
-	repo = github.Repo{
+	repo := github.Repo{
 		Owner: "owner",
 		Name:  "test",
 	}
 
-	deploymentInfo = terraformWorkflow.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "1",
-		CheckRunID: 1234,
-		Root: terraform.Root{
-			Name: "root_1",
+	deploymentInfoList := []terraformWorkflow.DeploymentInfo{
+		{
+			ID:         uuid.UUID{},
+			Revision:   "1",
+			CheckRunID: 1234,
+			Root: terraform.Root{
+				Name: "root_1",
+			},
+			Repo: repo,
 		},
-		Repo: repo,
-	}
-
-	latestDeployedRevision = deployment.Info{
-		Revision: "3455",
-	}
-
-	fetchDeploymentRequest = activities.FetchLatestDeploymentRequest{
-		FullRepositoryName: repo.GetFullName(),
-		RootName:           deploymentInfo.Root.Name,
-	}
-
-	fetchDeploymentResponse = activities.FetchLatestDeploymentResponse{
-		DeploymentInfo: &deployment.Info{
-			Revision: latestDeployedRevision.Revision,
-			Repo:     repo,
+		{
+			ID:         uuid.UUID{},
+			Revision:   "2",
+			CheckRunID: 5678,
+			Root: terraform.Root{
+				Name: "root_2",
+			},
+			Repo: repo,
 		},
 	}
 
-	compareCommitRequest = activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfo.Revision,
-		LatestDeployedRevision: latestDeployedRevision.Revision,
-	}
+	env.ExecuteWorkflow(testWorkerWorkflow, workerRequest{
+		Queue:                   deploymentInfoList,
+		ExpectedValidationError: queue.NewValidationError("err"),
+	})
 
-	storeDeploymentRequest = activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:    deployment.InfoSchemaVersion,
-			ID:         deploymentInfo.ID.String(),
-			CheckRunID: deploymentInfo.CheckRunID,
-			Revision:   deploymentInfo.Revision,
-			Root:       deploymentInfo.Root,
-			Repo:       repo,
-		},
-	}
-	return
+	env.AssertExpectations(t)
+
+	var resp workerResponse
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, queue.CompleteWorkerState, resp.EndState)
+	assert.Equal(t, []*deployment.Info{
+		nil, nil,
+	}, resp.CapturedArgs)
+	assert.True(t, resp.QueueIsEmpty)
 }

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request/converter"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -25,6 +27,7 @@ type NewRevisionRequest struct {
 
 type Queue interface {
 	Push(terraform.DeploymentInfo)
+	SetLockStatusForMergedTrigger(status queue.LockStatus)
 }
 
 type Activities interface {
@@ -82,6 +85,12 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 	// don't block on error here, we'll just try again later when we have our result.
 	if err != nil {
 		logger.Error(ctx, err.Error())
+	}
+
+	// lock the queue on a manual deployment
+	if root.Trigger == activity.ManualTrigger {
+		n.queue.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		return
 	}
 
 	n.queue.Push(terraform.DeploymentInfo{

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -90,7 +90,6 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 	// lock the queue on a manual deployment
 	if root.Trigger == activity.ManualTrigger {
 		n.queue.SetLockStatusForMergedTrigger(queue.LockedStatus)
-		return
 	}
 
 	n.queue.Push(terraform.DeploymentInfo{

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -74,14 +74,14 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	revisionQueue := queue.NewQueue()
 	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, a, sideeffect.GenerateUUID)
 	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow)
-	revisionProcessor := &queue.RevisionProcessor{
+	deployer := &queue.Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,
 	}
 
 	worker := &queue.Worker{
-		Queue:             revisionQueue,
-		RevisionProcessor: revisionProcessor,
+		Queue:    revisionQueue,
+		Deployer: deployer,
 	}
 
 	return &Runner{


### PR DESCRIPTION
Attempt at solving the problem described in https://github.com/lyft/atlantis/pull/420

Other things I ended up doing in this PR:
* Don't log context keys if the values are nil, this seems to just pollute our logs.
* Change revision_processor to deployer. It's a bit more concise and descriptive enough imo

Follow up things needed to be done (in another PR):
* Extract fetching a previous deployment to something we do at startup and use that value to infer the queue lock status
* Add a way to update the checkrun with the unlock button