### PR TITLE
Add lock state updater.

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -56,6 +56,7 @@ type CreateCheckRunRequest struct {
 	Sha        string
 	Repo       internal.Repo
 	State      internal.CheckRunState
+	Actions    []internal.CheckRunAction
 	Summary    string
 	ExternalID string
 }
@@ -135,6 +136,17 @@ func (a *githubActivities) CreateCheckRun(ctx context.Context, request CreateChe
 		Status:     &state,
 		Output:     &output,
 		ExternalID: &request.ExternalID,
+	}
+
+	// update with any actions
+	if len(request.Actions) != 0 {
+		var actions []*github.CheckRunAction
+
+		for _, a := range request.Actions {
+			actions = append(actions, a.ToGithubAction())
+		}
+
+		opts.Actions = actions
 	}
 
 	if conclusion != "" {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -22,11 +22,11 @@ const (
 )
 
 type Deploy struct {
-	queue *priority
+	queue              *priority
+	lockStatusCallback func(workflow.Context, *Deploy)
 
 	// mutable: default is unlocked
-	lock               LockState
-	lockStatusCallback func(workflow.Context, *Deploy)
+	lock LockState
 }
 
 func NewQueue(callback func(workflow.Context, *Deploy)) *Deploy {
@@ -41,7 +41,7 @@ func (q *Deploy) GetLockState() LockState {
 	return q.lock
 }
 
-func (q *Deploy) SetLockForMergedQueue(ctx workflow.Context, state LockState) {
+func (q *Deploy) SetLockForMergedItems(ctx workflow.Context, state LockState) {
 	q.lock = state
 	q.lockStatusCallback(ctx, q)
 }
@@ -54,7 +54,7 @@ func (q *Deploy) Pop() (terraform.DeploymentInfo, error) {
 	return q.queue.Pop()
 }
 
-func (q *Deploy) GetMergedQueue() []terraform.DeploymentInfo {
+func (q *Deploy) GetOrderedMergedItems() []terraform.DeploymentInfo {
 	return q.queue.Scan(Low)
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -103,18 +103,10 @@ func (q *priority) IsEmpty() bool {
 }
 
 func (q *priority) Scan(priority priorityType) []terraform.DeploymentInfo {
-
 	var result []terraform.DeploymentInfo
-	first := q.queues[priority].Front()
 
-	result = append(result, first.Value.(terraform.DeploymentInfo))
-
-	for {
-		if e := first.Next(); e != nil {
-			result = append(result, e.Value.(terraform.DeploymentInfo))
-			continue
-		}
-		break
+	for e := q.queues[priority].Front(); e != nil; e = e.Next() {
+		result = append(result, e.Value.(terraform.DeploymentInfo))
 	}
 
 	return result

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
@@ -16,6 +16,24 @@ func TestPriorityQueue(t *testing.T) {
 		q.Push(wrap("3"), High)
 		q.Push(wrap("4"), Low)
 
+		highQueue := q.Scan(High)
+		assert.Equal(t, []terraform.DeploymentInfo{
+			{
+				Revision: "2",
+			},
+			{
+				Revision: "3",
+			}}, highQueue)
+
+		lowQueue := q.Scan(Low)
+		assert.Equal(t, []terraform.DeploymentInfo{
+			{
+				Revision: "1",
+			},
+			{
+				Revision: "4",
+			}}, lowQueue)
+
 		info, err := q.Pop()
 		assert.NoError(t, err)
 		assert.Equal(t, "2", unwrap(info))

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -11,6 +11,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+func noopCallback(ctx workflow.Context, q *queue.Deploy) {}
+
 func TestQueue(t *testing.T) {
 	t.Run("priority", func(t *testing.T) {
 		q := queue.NewQueue(nil)
@@ -46,14 +48,14 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("can pop empty queue locked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(noopCallback)
 		q.SetLockForMergedQueue(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())
 	})
 	t.Run("can pop manual trigger locked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(noopCallback)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
 		q.SetLockForMergedQueue(test.Background(), queue.LockState{
@@ -68,7 +70,7 @@ func TestQueue(t *testing.T) {
 		assert.Equal(t, true, q.CanPop())
 	})
 	t.Run("can pop merge trigger locked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(noopCallback)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
 		q.SetLockForMergedQueue(test.Background(), queue.LockState{

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -1,16 +1,19 @@
 package queue_test
 
 import (
+	"testing"
+
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"go.temporal.io/sdk/workflow"
 )
 
 func TestQueue(t *testing.T) {
 	t.Run("priority", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
@@ -25,39 +28,56 @@ func TestQueue(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, msg1, info)
 	})
+	t.Run("test lock state callback", func(t *testing.T) {
+		var called bool
+		q := queue.NewQueue(func(ctx workflow.Context, d *queue.Deploy) {
+			called = true
+		})
+		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+			Status: queue.LockedStatus,
+		})
+
+		assert.True(t, called)
+	})
 
 	t.Run("can pop empty queue unlocked", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 		assert.Equal(t, false, q.CanPop())
 	})
 
 	t.Run("can pop empty queue locked", func(t *testing.T) {
-		q := queue.NewQueue()
-		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		q := queue.NewQueue(nil)
+		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+			Status: queue.LockedStatus,
+		})
 		assert.Equal(t, false, q.CanPop())
 	})
 	t.Run("can pop manual trigger locked", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
-		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+			Status: queue.LockedStatus,
+		})
 		assert.Equal(t, true, q.CanPop())
 	})
 	t.Run("can pop manual trigger unlocked", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
 		assert.Equal(t, true, q.CanPop())
 	})
 	t.Run("can pop merge trigger locked", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
-		q.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+			Status: queue.LockedStatus,
+		})
 		assert.Equal(t, false, q.CanPop())
 	})
 	t.Run("can pop merge trigger unlocked", func(t *testing.T) {
-		q := queue.NewQueue()
+		q := queue.NewQueue(nil)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
 		assert.Equal(t, true, q.CanPop())

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -35,7 +35,7 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(func(ctx workflow.Context, d *queue.Deploy) {
 			called = true
 		})
-		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 
@@ -49,7 +49,7 @@ func TestQueue(t *testing.T) {
 
 	t.Run("can pop empty queue locked", func(t *testing.T) {
 		q := queue.NewQueue(noopCallback)
-		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())
@@ -58,7 +58,7 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(noopCallback)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
-		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 		assert.Equal(t, true, q.CanPop())
@@ -73,7 +73,7 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(noopCallback)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
-		q.SetLockForMergedQueue(test.Background(), queue.LockState{
+		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -16,7 +16,7 @@ type LockStateUpdater struct {
 
 func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy) {
 	lock := queue.GetLockState()
-	infos := queue.GetMergedQueue()
+	infos := queue.GetOrderedMergedItems()
 
 	var actions []github.CheckRunAction
 	var summary string

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -1,0 +1,42 @@
+package queue
+
+import (
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"go.temporal.io/sdk/workflow"
+)
+
+type LockStateUpdater struct {
+	Activities githubActivities
+}
+
+func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy) {
+	lock := queue.GetLockState()
+	infos := queue.GetMergedQueue()
+
+	var actions []github.CheckRunAction
+	var summary string
+	if lock.Status == LockedStatus {
+		actions = append(actions, github.CreateUnlockAction())
+		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
+	}
+
+	for _, i := range infos {
+		err := workflow.ExecuteActivity(ctx, u.Activities.UpdateCheckRun, activities.UpdateCheckRunRequest{
+			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
+			State:   github.CheckRunQueued,
+			Repo:    i.Repo,
+			ID:      i.CheckRunID,
+			Summary: summary,
+			Actions: actions,
+		}).Get(ctx, nil)
+
+		if err != nil {
+			logger.Error(ctx, fmt.Sprintf("updating check run for revision %s", i.Revision))
+		}
+	}
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -36,7 +36,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 		}).Get(ctx, nil)
 
 		if err != nil {
-			logger.Error(ctx, fmt.Sprintf("updating check run for revision %s", i.Revision))
+			logger.Error(ctx, fmt.Sprintf("updating check run for revision %s", i.Revision), "err", err)
 		}
 	}
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -1,0 +1,138 @@
+package queue_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	tfActivity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestLockStateUpdater_unlocked(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testDeployActivity{}
+	env.RegisterActivity(a)
+
+	info := terraform.DeploymentInfo{
+		CheckRunID: 123,
+		ID:         uuid.New(),
+		Revision:   "1",
+		Root: tfActivity.Root{
+			Name:    "root",
+			Trigger: tfActivity.MergeTrigger,
+		},
+		Repo: github.Repo{
+			Name: "repo",
+		},
+	}
+
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title: terraform.BuildCheckRunTitle(info.Root.Name),
+		State: github.CheckRunQueued,
+		Repo:  info.Repo,
+		ID:    info.CheckRunID,
+	}
+
+	updateCheckRunResponse := activities.UpdateCheckRunResponse{
+		ID: updateCheckRunRequest.ID,
+	}
+
+	env.OnActivity(a.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+
+	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
+		Queue: []terraform.DeploymentInfo{info},
+	})
+
+	err := env.GetWorkflowResult(nil)
+	env.AssertExpectations(t)
+
+	assert.NoError(t, err)
+}
+
+func TestLockStateUpdater_locked(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testDeployActivity{}
+	env.RegisterActivity(a)
+
+	info := terraform.DeploymentInfo{
+		CheckRunID: 123,
+		ID:         uuid.New(),
+		Revision:   "1",
+		Root: tfActivity.Root{
+			Name:    "root",
+			Trigger: tfActivity.MergeTrigger,
+		},
+		Repo: github.Repo{
+			Name: "repo",
+		},
+	}
+
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(info.Root.Name),
+		State:   github.CheckRunQueued,
+		Repo:    info.Repo,
+		ID:      info.CheckRunID,
+		Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+		Actions: []github.CheckRunAction{
+			github.CreateUnlockAction(),
+		},
+	}
+
+	updateCheckRunResponse := activities.UpdateCheckRunResponse{
+		ID: updateCheckRunRequest.ID,
+	}
+
+	env.OnActivity(a.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+
+	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
+		Queue: []terraform.DeploymentInfo{info},
+		Lock: queue.LockState{
+			Status:   queue.LockedStatus,
+			Revision: "1234",
+		},
+	})
+
+	err := env.GetWorkflowResult(nil)
+	env.AssertExpectations(t)
+
+	assert.NoError(t, err)
+}
+
+type updaterReq struct {
+	Queue []terraform.DeploymentInfo
+	Lock  queue.LockState
+}
+
+func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
+	options := workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, options)
+	var a *testDeployActivity
+	subject := &queue.LockStateUpdater{
+		Activities: a,
+	}
+
+	q := queue.NewQueue(noopCallback)
+	for _, i := range r.Queue {
+		q.Push(i)
+	}
+
+	q.SetLockForMergedQueue(ctx, r.Lock)
+	subject.UpdateQueuedRevisions(ctx, q)
+
+	return nil
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -131,7 +131,7 @@ func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
 		q.Push(i)
 	}
 
-	q.SetLockForMergedQueue(ctx, r.Lock)
+	q.SetLockForMergedItems(ctx, r.Lock)
 	subject.UpdateQueuedRevisions(ctx, q)
 
 	return nil

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -16,7 +16,7 @@ type queue interface {
 	IsEmpty() bool
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)
-	SetLockStatusForMergedTrigger(status LockStatus)
+	SetLockForMergedQueue(ctx workflow.Context, state LockState)
 }
 
 type deployer interface {
@@ -106,7 +106,9 @@ func (w *Worker) Work(ctx workflow.Context) {
 			currentDeployment, err = w.deploy(ctx, previousDeployment)
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
-			w.Queue.SetLockStatusForMergedTrigger(UnlockedStatus)
+			w.Queue.SetLockForMergedQueue(ctx, LockState{
+				Status: UnlockedStatus,
+			})
 			continue
 		default:
 			logger.Warn(ctx, fmt.Sprintf("%s action not configured. This is probably a bug, skipping for now", currentAction))

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -16,7 +16,7 @@ type queue interface {
 	IsEmpty() bool
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)
-	SetLockForMergedQueue(ctx workflow.Context, state LockState)
+	SetLockForMergedItems(ctx workflow.Context, state LockState)
 }
 
 type deployer interface {
@@ -106,7 +106,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 			currentDeployment, err = w.deploy(ctx, previousDeployment)
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
-			w.Queue.SetLockForMergedQueue(ctx, LockState{
+			w.Queue.SetLockForMergedItems(ctx, LockState{
 				Status: UnlockedStatus,
 			})
 			continue

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 type testQueue struct {
-	Queue      *list.List
-	Lock queue.LockState
+	Queue *list.List
+	Lock  queue.LockState
 }
 
 func (q *testQueue) IsEmpty() bool {
@@ -60,7 +60,7 @@ type workerResponse struct {
 type queueAndState struct {
 	QueueIsEmpty bool
 	State        queue.WorkerState
-	Lock   queue.LockState
+	Lock         queue.LockState
 }
 
 type testDeployer struct {
@@ -121,7 +121,7 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 		return queueAndState{
 			QueueIsEmpty: q.IsEmpty(),
 			State:        worker.GetState(),
-			Lock:   q.Lock,
+			Lock:         q.Lock,
 		}, nil
 	})
 	if err != nil {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -41,7 +41,7 @@ func (q *testQueue) Push(msg terraformWorkflow.DeploymentInfo) {
 	q.Queue.PushBack(msg)
 }
 
-func (q *testQueue) SetLockForMergedQueue(ctx workflow.Context, state queue.LockState) {
+func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.LockState) {
 	q.Lock = state
 }
 
@@ -96,7 +96,7 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 		Queue: list.New(),
 	}
 
-	q.SetLockForMergedQueue(ctx, queue.LockState{Status: r.InitialLockStatus})
+	q.SetLockForMergedItems(ctx, queue.LockState{Status: r.InitialLockStatus})
 
 	var infos []*deployment.Info
 	for _, s := range r.Queue {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -19,7 +19,7 @@ import (
 
 type testQueue struct {
 	Queue      *list.List
-	LockStatus queue.LockStatus
+	Lock queue.LockState
 }
 
 func (q *testQueue) IsEmpty() bool {
@@ -41,8 +41,8 @@ func (q *testQueue) Push(msg terraformWorkflow.DeploymentInfo) {
 	q.Queue.PushBack(msg)
 }
 
-func (q *testQueue) SetLockStatusForMergedTrigger(status queue.LockStatus) {
-	q.LockStatus = status
+func (q *testQueue) SetLockForMergedQueue(ctx workflow.Context, state queue.LockState) {
+	q.Lock = state
 }
 
 type workerRequest struct {
@@ -60,7 +60,7 @@ type workerResponse struct {
 type queueAndState struct {
 	QueueIsEmpty bool
 	State        queue.WorkerState
-	LockStatus   queue.LockStatus
+	Lock   queue.LockState
 }
 
 type testDeployer struct {
@@ -96,7 +96,7 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 		Queue: list.New(),
 	}
 
-	q.SetLockStatusForMergedTrigger(r.InitialLockStatus)
+	q.SetLockForMergedQueue(ctx, queue.LockState{Status: r.InitialLockStatus})
 
 	var infos []*deployment.Info
 	for _, s := range r.Queue {
@@ -121,7 +121,7 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 		return queueAndState{
 			QueueIsEmpty: q.IsEmpty(),
 			State:        worker.GetState(),
-			LockStatus:   q.LockStatus,
+			Lock:   q.Lock,
 		}, nil
 	})
 	if err != nil {
@@ -159,7 +159,9 @@ func TestWorker_ReceivesUnlockSignal(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.UnlockedStatus, q.LockStatus)
+		assert.Equal(t, queue.LockState{
+			Status: queue.UnlockedStatus,
+		}, q.Lock)
 		assert.Equal(t, queue.WaitingWorkerState, q.State)
 
 		env.CancelWorkflow()

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -30,7 +30,7 @@ type NewRevisionRequest struct {
 type Queue interface {
 	Push(terraform.DeploymentInfo)
 	GetLockState() queue.LockState
-	SetLockForMergedQueue(ctx workflow.Context, state queue.LockState)
+	SetLockForMergedItems(ctx workflow.Context, state queue.LockState)
 }
 
 type Activities interface {
@@ -81,7 +81,7 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 
 	// lock the queue on a manual deployment
 	if root.Trigger == activity.ManualTrigger {
-		n.queue.SetLockForMergedQueue(ctx, queue.LockState{
+		n.queue.SetLockForMergedItems(ctx, queue.LockState{
 			Status:   queue.LockedStatus,
 			Revision: request.Revision,
 		})

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -2,9 +2,11 @@ package revision
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
@@ -27,7 +29,8 @@ type NewRevisionRequest struct {
 
 type Queue interface {
 	Push(terraform.DeploymentInfo)
-	SetLockStatusForMergedTrigger(status queue.LockStatus)
+	GetLockState() queue.LockState
+	SetLockForMergedQueue(ctx workflow.Context, state queue.LockState)
 }
 
 type Activities interface {
@@ -74,22 +77,14 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		logger.Error(ctx, "generating deployment id", "err", err)
 	}
 
-	var resp activities.CreateCheckRunResponse
-	err = workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
-		Title:      terraform.BuildCheckRunTitle(root.Name),
-		Sha:        request.Revision,
-		Repo:       repo,
-		ExternalID: id.String(),
-	}).Get(ctx, &resp)
-
-	// don't block on error here, we'll just try again later when we have our result.
-	if err != nil {
-		logger.Error(ctx, err.Error())
-	}
+	resp := n.createCheckRun(ctx, id.String(), request.Revision, root, repo)
 
 	// lock the queue on a manual deployment
 	if root.Trigger == activity.ManualTrigger {
-		n.queue.SetLockStatusForMergedTrigger(queue.LockedStatus)
+		n.queue.SetLockForMergedQueue(ctx, queue.LockState{
+			Status:   queue.LockedStatus,
+			Revision: request.Revision,
+		})
 	}
 
 	n.queue.Push(terraform.DeploymentInfo{
@@ -101,4 +96,32 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		InitiatingUser: initiatingUser,
 		Tags:           request.Tags,
 	})
+}
+
+func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, root activity.Root, repo github.Repo) activities.CreateCheckRunResponse {
+	lock := n.queue.GetLockState()
+	var actions []github.CheckRunAction
+	var summary string
+
+	if lock.Status == queue.LockedStatus && (root.Trigger == activity.MergeTrigger) {
+		actions = append(actions, github.CreateUnlockAction())
+		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
+	}
+
+	var resp activities.CreateCheckRunResponse
+	err := workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
+		Title:      terraform.BuildCheckRunTitle(root.Name),
+		Sha:        revision,
+		Repo:       repo,
+		ExternalID: id,
+		Summary:    summary,
+		Actions:    actions,
+	}).Get(ctx, &resp)
+
+	// don't block on error here, we'll just try again later when we have our result.
+	if err != nil {
+		logger.Error(ctx, err.Error())
+	}
+
+	return resp
 }

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -20,26 +20,31 @@ import (
 )
 
 type testQueue struct {
-	Queue      []terraformWorkflow.DeploymentInfo
-	LockStatus queue.LockStatus
+	Queue []terraformWorkflow.DeploymentInfo
+	Lock  queue.LockState
 }
 
 func (q *testQueue) Push(msg terraformWorkflow.DeploymentInfo) {
 	q.Queue = append(q.Queue, msg)
 }
 
-func (q *testQueue) SetLockStatusForMergedTrigger(status queue.LockStatus) {
-	q.LockStatus = status
+func (q *testQueue) GetLockState() queue.LockState {
+	return q.Lock
+}
+
+func (q *testQueue) SetLockForMergedQueue(ctx workflow.Context, state queue.LockState) {
+	q.Lock = state
 }
 
 type req struct {
-	ID uuid.UUID
+	ID   uuid.UUID
+	Lock queue.LockState
 }
 
 type response struct {
-	Queue      []terraformWorkflow.DeploymentInfo
-	LockStatus queue.LockStatus
-	Timeout    bool
+	Queue   []terraformWorkflow.DeploymentInfo
+	Lock    queue.LockState
+	Timeout bool
 }
 
 type testActivities struct{}
@@ -54,7 +59,9 @@ func testWorkflow(ctx workflow.Context, r req) (response, error) {
 		ScheduleToCloseTimeout: 5 * time.Second,
 	})
 	var timeout bool
-	queue := &testQueue{}
+	queue := &testQueue{
+		Lock: r.Lock,
+	}
 
 	var a *testActivities
 
@@ -74,9 +81,9 @@ func testWorkflow(ctx workflow.Context, r req) (response, error) {
 	}
 
 	return response{
-		Queue:      queue.Queue,
-		LockStatus: queue.LockStatus,
-		Timeout:    timeout,
+		Queue:   queue.Queue,
+		Lock:    queue.Lock,
+		Timeout: timeout,
 	}, nil
 }
 
@@ -128,7 +135,9 @@ func TestEnqueue(t *testing.T) {
 			Repo:       github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.UnlockedStatus, resp.LockStatus)
+	assert.Equal(t, queue.LockState{
+		Status: queue.UnlockedStatus,
+	}, resp.Lock)
 	assert.False(t, resp.Timeout)
 }
 
@@ -181,6 +190,133 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 			Repo:       github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.LockedStatus, resp.LockStatus)
+	assert.Equal(t, queue.LockState{
+		Status:   queue.LockedStatus,
+		Revision: "1234",
+	}, resp.Lock)
+	assert.False(t, resp.Timeout)
+}
+
+func TestEnqueue_ManualTrigger_queueAlreadyLocked(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	rev := "1234"
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow("test-signal", revision.NewRevisionRequest{
+			Revision: rev,
+			Root: request.Root{
+				Name:    "root",
+				Trigger: request.ManualTrigger,
+			},
+			Repo: request.Repo{Name: "nish"},
+		})
+	}, 0)
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	id := uuid.Must(uuid.NewUUID())
+
+	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      "atlantis/deploy: root",
+		Sha:        rev,
+		Repo:       github.Repo{Name: "nish"},
+		ExternalID: id.String(),
+	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, req{
+		ID: id,
+		Lock: queue.LockState{
+			// ensure that the lock gets updated
+			Status:   queue.LockedStatus,
+			Revision: "123334444555",
+		},
+	})
+	env.AssertExpectations(t)
+	assert.True(t, env.IsWorkflowCompleted())
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []terraformWorkflow.DeploymentInfo{
+		{
+			Revision:   rev,
+			CheckRunID: 1,
+			Root:       terraform.Root{Name: "root", Trigger: terraform.ManualTrigger},
+			ID:         id,
+			Repo:       github.Repo{Name: "nish"},
+		},
+	}, resp.Queue)
+	assert.Equal(t, queue.LockState{
+		Status:   queue.LockedStatus,
+		Revision: "1234",
+	}, resp.Lock)
+	assert.False(t, resp.Timeout)
+}
+
+func TestEnqueue_MergeTrigger_queueAlreadyLocked(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	rev := "1234"
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow("test-signal", revision.NewRevisionRequest{
+			Revision: rev,
+			Root: request.Root{
+				Name:    "root",
+				Trigger: request.MergeTrigger,
+			},
+			Repo: request.Repo{Name: "nish"},
+		})
+	}, 0)
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	id := uuid.Must(uuid.NewUUID())
+
+	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      "atlantis/deploy: root",
+		Sha:        rev,
+		Repo:       github.Repo{Name: "nish"},
+		ExternalID: id.String(),
+		Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
+		Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
+	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, req{
+		ID: id,
+		Lock: queue.LockState{
+			// ensure that the lock gets updated
+			Status:   queue.LockedStatus,
+			Revision: "123334444555",
+		},
+	})
+	env.AssertExpectations(t)
+	assert.True(t, env.IsWorkflowCompleted())
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []terraformWorkflow.DeploymentInfo{
+		{
+			Revision:   rev,
+			CheckRunID: 1,
+			Root:       terraform.Root{Name: "root", Trigger: terraform.MergeTrigger},
+			ID:         id,
+			Repo:       github.Repo{Name: "nish"},
+		},
+	}, resp.Queue)
+	assert.Equal(t, queue.LockState{
+		Status:   queue.LockedStatus,
+		Revision: "123334444555",
+	}, resp.Lock)
 	assert.False(t, resp.Timeout)
 }

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -32,7 +32,7 @@ func (q *testQueue) GetLockState() queue.LockState {
 	return q.Lock
 }
 
-func (q *testQueue) SetLockForMergedQueue(ctx workflow.Context, state queue.LockState) {
+func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.LockState) {
 	q.Lock = state
 }
 


### PR DESCRIPTION
This PR adds support for updating check runs with an unlock button.  This works as follows:
* Everytime the lock state is changed, a function is called which gets the existing merge queue by scanning the priority queue, then iterates through those items and updates the check run either the lock button, or lack of one
* Additionally, when a queue is locked, each new revision has its check run created with the unlock button.

## Decisions

I decided to update all check runs with the button instead of one because:
1.  It's clearer to the user why something is not progressing as they don't have to hunt for the revision that has the unlock button on it
2. It's a bit messy thinking about keeping track of the first merge triggered root after a manual deploy and doesn't seem worth the hassle.
