### PR TITLE
Rebuild lock state on workflow startup.

### DIFF
--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -82,7 +82,14 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(
 		},
 		options,
 		workflows.Deploy,
-		workflows.DeployRequest{},
+		workflows.DeployRequest{
+			Repo: workflows.DeployRequestRepo{
+				FullName: repo.FullName,
+			},
+			Root: workflows.DeployRequestRoot{
+				Name: rootCfg.Name,
+			},
+		},
 	)
 	return run, err
 }

--- a/server/neptune/gateway/event/deploy_workflow_signaler_test.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler_test.go
@@ -143,7 +143,14 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 			expectedOptions: client.StartWorkflowOptions{
 				TaskQueue: workflows.DeployTaskQueue,
 			},
-			expectedWorkflowArgs: workflows.DeployRequest{},
+			expectedWorkflowArgs: workflows.DeployRequest{
+				Repo: workflows.DeployRequestRepo{
+					FullName: repoFullName,
+				},
+				Root: workflows.DeployRequestRoot{
+					Name: rootCfg.Name,
+				},
+			},
 		}
 		deploySignaler := event.DeployWorkflowSignaler{
 			TemporalClient: testSignaler,
@@ -205,7 +212,14 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 			expectedOptions: client.StartWorkflowOptions{
 				TaskQueue: workflows.DeployTaskQueue,
 			},
-			expectedWorkflowArgs: workflows.DeployRequest{},
+			expectedWorkflowArgs: workflows.DeployRequest{
+				Repo: workflows.DeployRequestRepo{
+					FullName: repoFullName,
+				},
+				Root: workflows.DeployRequestRoot{
+					Name: rootCfg.Name,
+				},
+			},
 		}
 		deploySignaler := event.DeployWorkflowSignaler{
 			TemporalClient: testSignaler,
@@ -285,8 +299,15 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 		expectedOptions: client.StartWorkflowOptions{
 			TaskQueue: workflows.DeployTaskQueue,
 		},
-		expectedWorkflowArgs: workflows.DeployRequest{},
-		expectedErr:          expectedErr,
+		expectedWorkflowArgs: workflows.DeployRequest{
+			Repo: workflows.DeployRequestRepo{
+				FullName: repoFullName,
+			},
+			Root: workflows.DeployRequestRoot{
+				Name: rootCfg.Name,
+			},
+		},
+		expectedErr: expectedErr,
 	}
 	deploySignaler := event.DeployWorkflowSignaler{
 		TemporalClient: testSignaler,

--- a/server/neptune/workflows/activities/deployment/info.go
+++ b/server/neptune/workflows/activities/deployment/info.go
@@ -23,5 +23,6 @@ func (r Repo) GetFullName() string {
 }
 
 type Root struct {
-	Name string
+	Name    string
+	Trigger string
 }

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -10,6 +10,8 @@ import (
 
 // Export anything that callers need such as requests, signals, etc.
 type DeployRequest = deploy.Request
+type DeployRequestRepo = deploy.Repo
+type DeployRequestRoot = deploy.Root
 type Repo = request.Repo
 type Root = request.Root
 type Job = request.Job

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -50,7 +50,14 @@ func TestDeployWorkflow(t *testing.T) {
 		signalWorkflow(env)
 	}, 5*time.Second)
 
-	env.ExecuteWorkflow(workflows.Deploy, workflows.DeployRequest{})
+	env.ExecuteWorkflow(workflows.Deploy, workflows.DeployRequest{
+		Root: workflows.DeployRequestRoot{
+			Name: "my test root",
+		},
+		Repo: workflows.DeployRequestRepo{
+			FullName: "nish/repo",
+		},
+	})
 	assert.NoError(t, env.GetWorkflowError())
 
 	// for now we just assert the correct number of updates were called.

--- a/server/neptune/workflows/internal/deploy/request.go
+++ b/server/neptune/workflows/internal/deploy/request.go
@@ -1,4 +1,18 @@
 package deploy
 
 type Request struct {
+	Repo Repo
+	Root Root
+}
+
+// Repo Names and Root Names are assumed to be static throughout the lifetime
+// of a workflow since that's what our ID is based on
+//
+// We need these values at minimum during startup atm.
+type Repo struct {
+	FullName string
+}
+
+type Root struct {
+	Name string
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -50,8 +50,8 @@ type Worker struct {
 	Deployer deployer
 
 	// mutable
-	state              WorkerState
-	previousDeployment *deployment.Info
+	state            WorkerState
+	latestDeployment *deployment.Info
 }
 
 type actionType string
@@ -90,9 +90,9 @@ func NewWorker(
 	}
 
 	return &Worker{
-		Queue:              q,
-		Deployer:           deployer,
-		previousDeployment: latestDeployment,
+		Queue:            q,
+		Deployer:         deployer,
+		latestDeployment: latestDeployment,
 	}, nil
 }
 
@@ -145,7 +145,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 			return
 		case process:
 			logger.Info(ctx, "Processing... ")
-			currentDeployment, err = w.deploy(ctx, w.previousDeployment)
+			currentDeployment, err = w.deploy(ctx, w.latestDeployment)
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
 			w.Queue.SetLockForMergedItems(ctx, LockState{
@@ -171,7 +171,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 		}
 
 		// we assume that regardless of error we should count this as a deploy
-		w.previousDeployment = currentDeployment
+		w.latestDeployment = currentDeployment
 		selector.AddFuture(w.awaitWork(ctx), callback)
 	}
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -1,11 +1,14 @@
 package queue
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
+	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"go.temporal.io/sdk/temporal"
@@ -21,6 +24,11 @@ type queue interface {
 
 type deployer interface {
 	Deploy(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *deployment.Info) (*deployment.Info, error)
+}
+
+type workerActivities interface {
+	deployerActivities
+	AuditJob(ctx context.Context, request activities.AuditJobRequest) error
 }
 
 type WorkerState string
@@ -42,7 +50,8 @@ type Worker struct {
 	Deployer deployer
 
 	// mutable
-	state WorkerState
+	state              WorkerState
+	previousDeployment *deployment.Info
 }
 
 type actionType string
@@ -53,6 +62,40 @@ const (
 	receive  = "receive"
 )
 
+func NewWorker(
+	ctx workflow.Context,
+	q queue,
+	a workerActivities,
+	tfWorkflow terraform.Workflow,
+	repoName, rootName string,
+) (*Worker, error) {
+	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow)
+	deployer := &Deployer{
+		Activities:              a,
+		TerraformWorkflowRunner: tfWorkflowRunner,
+	}
+
+	latestDeployment, err := deployer.FetchLatestDeployment(ctx, repoName, rootName)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching current deployment")
+	}
+
+	// we don't persist lock state anywhere so in the case of workflow completion we need to rebuild
+	// the lock state
+	if latestDeployment != nil && latestDeployment.Root.Trigger == string(tfModel.ManualTrigger) {
+		q.SetLockForMergedItems(ctx, LockState{
+			Status:   LockedStatus,
+			Revision: latestDeployment.Revision,
+		})
+	}
+
+	return &Worker{
+		Queue:              q,
+		Deployer:           deployer,
+		previousDeployment: latestDeployment,
+	}, nil
+}
+
 // Work pops work off the queue and if the queue is empty,
 // it waits for the queue to be non-empty or a cancelation signal
 func (w *Worker) Work(ctx workflow.Context) {
@@ -61,7 +104,6 @@ func (w *Worker) Work(ctx workflow.Context) {
 		w.state = CompleteWorkerState
 	}()
 
-	var previousDeployment *deployment.Info
 	var currentAction actionType
 	callback := func(f workflow.Future) {
 		err := f.Get(ctx, nil)
@@ -103,7 +145,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 			return
 		case process:
 			logger.Info(ctx, "Processing... ")
-			currentDeployment, err = w.deploy(ctx, previousDeployment)
+			currentDeployment, err = w.deploy(ctx, w.previousDeployment)
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
 			w.Queue.SetLockForMergedItems(ctx, LockState{
@@ -129,7 +171,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 		}
 
 		// we assume that regardless of error we should count this as a deploy
-		previousDeployment = currentDeployment
+		w.previousDeployment = currentDeployment
 		selector.AddFuture(w.awaitWork(ctx), callback)
 	}
 }

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 
@@ -17,6 +18,22 @@ type DeploymentInfo struct {
 	Root           terraform.Root
 	Repo           github.Repo
 	Tags           map[string]string
+}
+
+func (i DeploymentInfo) BuildPersistableInfo() *deployment.Info {
+	return &deployment.Info{
+		Version:  deployment.InfoSchemaVersion,
+		ID:       i.ID.String(),
+		Revision: i.Revision,
+		Root: deployment.Root{
+			Name: i.Root.Name,
+			Trigger: string(i.Root.Trigger),
+		},
+		Repo: deployment.Repo{
+			Name:  i.Repo.Name,
+			Owner: i.Repo.Owner,
+		},
+	}
 }
 
 func BuildCheckRunTitle(rootName string) string {

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -26,7 +26,7 @@ func (i DeploymentInfo) BuildPersistableInfo() *deployment.Info {
 		ID:       i.ID.String(),
 		Revision: i.Revision,
 		Root: deployment.Root{
-			Name: i.Root.Name,
+			Name:    i.Root.Name,
 			Trigger: string(i.Root.Trigger),
 		},
 		Repo: deployment.Repo{


### PR DESCRIPTION
Moved things around so that FetchDeployment is called on workflow startup.  Using this we can rebuild the lock state.