### PR TITLE
New metrics

### DIFF
--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -6,9 +6,9 @@ const (
 	ExecutionErrorMetric   = "execution_error"
 	ExecutionFailureMetric = "execution_failure"
 
-	FilterPassMetric  = "pass"
-	FilterFailMetric  = "fail"
-	FilterErrorMetric = "error"
+	FilterPresentMetric = "present"
+	FilterAbsentMetric  = "absent"
+	FilterErrorMetric   = "error"
 
 	RootTag = "root"
 	RepoTag = "repo"

--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -6,6 +6,10 @@ const (
 	ExecutionErrorMetric   = "execution_error"
 	ExecutionFailureMetric = "execution_failure"
 
+	FilterPassMetric  = "pass"
+	FilterFailMetric  = "fail"
+	FilterErrorMetric = "error"
+
 	RootTag = "root"
 	RepoTag = "repo"
 )

--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -5,4 +5,7 @@ const (
 	ExecutionSuccessMetric = "execution_success"
 	ExecutionErrorMetric   = "execution_error"
 	ExecutionFailureMetric = "execution_failure"
+
+	RootTag = "root"
+	RepoTag = "repo"
 )

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -34,7 +34,7 @@ func TestCheckRunHandler(t *testing.T) {
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("test"),
-			Name:   "atlantis/deploy",
+			Name:   "atlantis/deploy: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestCheckRunHandler(t *testing.T) {
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("requested_action"),
-			Name:   "atlantis/deploy",
+			Name:   "atlantis/deploy: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.Error(t, err)
@@ -66,7 +66,7 @@ func TestCheckRunHandler(t *testing.T) {
 			Action: event.RequestedActionChecksAction{
 				Identifier: "some random thing",
 			},
-			Name: "atlantis/deploy",
+			Name: "atlantis/deploy: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.Error(t, err)
@@ -95,7 +95,7 @@ func TestCheckRunHandler(t *testing.T) {
 			},
 			ExternalID: workflowID,
 			User:       user,
-			Name:       "atlantis/deploy",
+			Name:       "atlantis/deploy: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.NoError(t, err)
@@ -173,7 +173,7 @@ func TestCheckRunHandler(t *testing.T) {
 			},
 			ExternalID: workflowID,
 			User:       user,
-			Name:       "atlantis/deploy",
+			Name:       "atlantis/deploy: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.Error(t, err)

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -53,14 +53,14 @@ type RootConfigBuilder struct {
 func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, installationToken)
 	if err != nil {
-		b.Scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
+		b.Scope.Counter("error").Inc(1)
 		return nil, err
 	}
 	if len(mergedRootCfgs) == 0 {
 		b.Scope.Counter(metrics.ExecutionFailureMetric).Inc(1)
 		return mergedRootCfgs, nil
 	}
-	b.Scope.Counter(metrics.ExecutionSuccessMetric)
+	b.Scope.Counter("success")
 	return mergedRootCfgs, nil
 }
 

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -57,10 +57,10 @@ func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch 
 		return nil, err
 	}
 	if len(mergedRootCfgs) == 0 {
-		b.Scope.Counter(metrics.FilterFailMetric).Inc(1)
+		b.Scope.Counter(metrics.FilterAbsentMetric).Inc(1)
 		return mergedRootCfgs, nil
 	}
-	b.Scope.Counter(metrics.FilterPassMetric)
+	b.Scope.Counter(metrics.FilterPresentMetric)
 	return mergedRootCfgs, nil
 }
 

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -53,14 +53,14 @@ type RootConfigBuilder struct {
 func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, installationToken)
 	if err != nil {
-		b.Scope.Counter("error").Inc(1)
+		b.Scope.Counter(metrics.FilterErrorMetric).Inc(1)
 		return nil, err
 	}
 	if len(mergedRootCfgs) == 0 {
-		b.Scope.Counter(metrics.ExecutionFailureMetric).Inc(1)
+		b.Scope.Counter(metrics.FilterFailMetric).Inc(1)
 		return mergedRootCfgs, nil
 	}
-	b.Scope.Counter("success")
+	b.Scope.Counter(metrics.FilterPassMetric)
 	return mergedRootCfgs, nil
 }
 

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -6,8 +6,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/metrics"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/uber-go/tally/v4"
 )
 
 // repoFetcher manages a cloned repo's workspace on disk for running commands.
@@ -45,9 +47,24 @@ type RootConfigBuilder struct {
 	FileFetcher     fileFetcher
 	GlobalCfg       valid.GlobalCfg
 	Logger          logging.Logger
+	Scope           tally.Scope
 }
 
 func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
+	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, installationToken)
+	if err != nil {
+		b.Scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
+		return nil, err
+	}
+	if len(mergedRootCfgs) == 0 {
+		b.Scope.Counter(metrics.ExecutionFailureMetric).Inc(1)
+		return mergedRootCfgs, nil
+	}
+	b.Scope.Counter(metrics.ExecutionSuccessMetric)
+	return mergedRootCfgs, nil
+}
+
+func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	// Generate a new filepath location and clone repo into it
 	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, branch, sha)
 	if err != nil {

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -3,6 +3,7 @@ package event_test
 import (
 	"context"
 	"errors"
+	"github.com/uber-go/tally/v4"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -36,6 +37,7 @@ func setupTesting(t *testing.T) {
 		FileFetcher:     &mockFileFetcher{},
 		GlobalCfg:       globalCfg,
 		Logger:          logging.NewNoopCtxLogger(t),
+		Scope:           tally.NewTestScope("test", map[string]string{}),
 	}
 }
 

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -286,7 +286,7 @@ func NewServer(config Config) (*Server, error) {
 		FileFetcher:     &github.RemoteFileFetcher{ClientCreator: clientCreator},
 		GlobalCfg:       globalCfg,
 		Logger:          ctxLogger,
-		Scope:           statsScope.SubScope("terraform_event"),
+		Scope:           statsScope.SubScope("event.terraform"),
 	}
 
 	gatewayEventsController := lyft_gateway.NewVCSEventsController(

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -286,7 +286,7 @@ func NewServer(config Config) (*Server, error) {
 		FileFetcher:     &github.RemoteFileFetcher{ClientCreator: clientCreator},
 		GlobalCfg:       globalCfg,
 		Logger:          ctxLogger,
-		Scope:           statsScope.SubScope("event.terraform"),
+		Scope:           statsScope.SubScope("event.filters.root"),
 	}
 
 	gatewayEventsController := lyft_gateway.NewVCSEventsController(

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -286,6 +286,7 @@ func NewServer(config Config) (*Server, error) {
 		FileFetcher:     &github.RemoteFileFetcher{ClientCreator: clientCreator},
 		GlobalCfg:       globalCfg,
 		Logger:          ctxLogger,
+		Scope:           statsScope.SubScope("terraform_event"),
 	}
 
 	gatewayEventsController := lyft_gateway.NewVCSEventsController(

--- a/server/neptune/temporal/client.go
+++ b/server/neptune/temporal/client.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/events/metrics"
+	contextInternal "github.com/runatlantis/atlantis/server/neptune/gateway/context"
 	"io"
 	"time"
 
@@ -132,6 +134,10 @@ type clientMetricsOutboundInterceptor struct {
 
 func (i *clientMetricsOutboundInterceptor) ExecuteWorkflow(ctx context.Context, in *interceptor.ClientExecuteWorkflowInput) (client.WorkflowRun, error) {
 	s := i.scope.SubScope("execute_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -150,6 +156,10 @@ func (i *clientMetricsOutboundInterceptor) ExecuteWorkflow(ctx context.Context, 
 
 func (i *clientMetricsOutboundInterceptor) SignalWorkflow(ctx context.Context, in *interceptor.ClientSignalWorkflowInput) error {
 	s := i.scope.SubScope("signal_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -165,6 +175,10 @@ func (i *clientMetricsOutboundInterceptor) SignalWorkflow(ctx context.Context, i
 
 func (i *clientMetricsOutboundInterceptor) SignalWithStartWorkflow(ctx context.Context, in *interceptor.ClientSignalWithStartWorkflowInput) (client.WorkflowRun, error) {
 	s := i.scope.SubScope("signal_with_start_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -182,6 +196,10 @@ func (i *clientMetricsOutboundInterceptor) SignalWithStartWorkflow(ctx context.C
 
 func (i *clientMetricsOutboundInterceptor) CancelWorkflow(ctx context.Context, in *interceptor.ClientCancelWorkflowInput) error {
 	s := i.scope.SubScope("cancel_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -197,6 +215,10 @@ func (i *clientMetricsOutboundInterceptor) CancelWorkflow(ctx context.Context, i
 
 func (i *clientMetricsOutboundInterceptor) TerminateWorkflow(ctx context.Context, in *interceptor.ClientTerminateWorkflowInput) error {
 	s := i.scope.SubScope("terminate_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -212,6 +234,10 @@ func (i *clientMetricsOutboundInterceptor) TerminateWorkflow(ctx context.Context
 
 func (i *clientMetricsOutboundInterceptor) QueryWorkflow(ctx context.Context, in *interceptor.ClientQueryWorkflowInput) (converter.EncodedValue, error) {
 	s := i.scope.SubScope("query_workflow")
+	s = s.Tagged(map[string]string{
+		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
+		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
+	})
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()

--- a/server/neptune/temporal/client.go
+++ b/server/neptune/temporal/client.go
@@ -134,10 +134,7 @@ type clientMetricsOutboundInterceptor struct {
 
 func (i *clientMetricsOutboundInterceptor) ExecuteWorkflow(ctx context.Context, in *interceptor.ClientExecuteWorkflowInput) (client.WorkflowRun, error) {
 	s := i.scope.SubScope("execute_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -156,10 +153,7 @@ func (i *clientMetricsOutboundInterceptor) ExecuteWorkflow(ctx context.Context, 
 
 func (i *clientMetricsOutboundInterceptor) SignalWorkflow(ctx context.Context, in *interceptor.ClientSignalWorkflowInput) error {
 	s := i.scope.SubScope("signal_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -175,10 +169,7 @@ func (i *clientMetricsOutboundInterceptor) SignalWorkflow(ctx context.Context, i
 
 func (i *clientMetricsOutboundInterceptor) SignalWithStartWorkflow(ctx context.Context, in *interceptor.ClientSignalWithStartWorkflowInput) (client.WorkflowRun, error) {
 	s := i.scope.SubScope("signal_with_start_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -196,10 +187,7 @@ func (i *clientMetricsOutboundInterceptor) SignalWithStartWorkflow(ctx context.C
 
 func (i *clientMetricsOutboundInterceptor) CancelWorkflow(ctx context.Context, in *interceptor.ClientCancelWorkflowInput) error {
 	s := i.scope.SubScope("cancel_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -215,10 +203,7 @@ func (i *clientMetricsOutboundInterceptor) CancelWorkflow(ctx context.Context, i
 
 func (i *clientMetricsOutboundInterceptor) TerminateWorkflow(ctx context.Context, in *interceptor.ClientTerminateWorkflowInput) error {
 	s := i.scope.SubScope("terminate_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -234,10 +219,7 @@ func (i *clientMetricsOutboundInterceptor) TerminateWorkflow(ctx context.Context
 
 func (i *clientMetricsOutboundInterceptor) QueryWorkflow(ctx context.Context, in *interceptor.ClientQueryWorkflowInput) (converter.EncodedValue, error) {
 	s := i.scope.SubScope("query_workflow")
-	s = s.Tagged(map[string]string{
-		metrics.RootTag: ctx.Value(contextInternal.ProjectKey).(string),
-		metrics.RepoTag: ctx.Value(contextInternal.RepositoryKey).(string),
-	})
+	s = addTags(ctx, s)
 
 	timer := s.Timer("latency").Start()
 	defer timer.Stop()
@@ -251,4 +233,15 @@ func (i *clientMetricsOutboundInterceptor) QueryWorkflow(ctx context.Context, in
 
 	s.Counter("success").Inc(1)
 	return val, err
+}
+
+func addTags(ctx context.Context, scope tally.Scope) tally.Scope {
+	tags := make(map[string]string)
+	if ctx.Value(contextInternal.ProjectKey) != nil {
+		tags[metrics.RootTag] = ctx.Value(contextInternal.ProjectKey).(string)
+	}
+	if ctx.Value(contextInternal.RepositoryKey) != nil {
+		tags[metrics.RepoTag] = ctx.Value(contextInternal.RepositoryKey).(string)
+	}
+	return scope.Tagged(tags)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -3,7 +3,6 @@ package queue
 import (
 	"context"
 	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
@@ -49,8 +48,6 @@ type Deployer struct {
 const (
 	DirectionBehindSummary   = "This revision is behind the current revision and will not be deployed.  If this is intentional, revert the default branch to this revision to trigger a new deployment."
 	UpdateCheckRunRetryCount = 5
-
-	DivergedCommitsSummary = "The current deployment has diverged from the default branch, so we have locked the root. This is most likely the result of this PR performing a manual deployment. To override that lock and allow the main branch to perform new deployments, select the Unlock button."
 )
 
 func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWorkflow.DeploymentInfo, latestDeployment *deployment.Info) (*deployment.Info, error) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -21,7 +21,7 @@ const (
 	UnlockedStatus LockStatus = iota
 	LockedStatus
 
-	QueueDepthStat = "queue_depth"
+	QueueDepthStat = "queue.depth"
 )
 
 type Deploy struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -69,7 +69,7 @@ func (q *Deploy) IsEmpty() bool {
 }
 
 func (q *Deploy) Push(msg terraform.DeploymentInfo) {
-	defer q.metricsHandler.Gauge("queue_depth").Update(float64(q.queue.Size()))
+	defer q.metricsHandler.Gauge(QueueDepthStat).Update(float64(q.queue.Size()))
 	if msg.Root.Trigger == activity.ManualTrigger {
 		q.queue.Push(msg, High)
 		return

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_internal_test.go
@@ -16,6 +16,8 @@ func TestPriorityQueue(t *testing.T) {
 		q.Push(wrap("3"), High)
 		q.Push(wrap("4"), Low)
 
+		assert.Equal(t, 4, q.Size())
+
 		highQueue := q.Scan(High)
 		assert.Equal(t, []terraform.DeploymentInfo{
 			{
@@ -35,24 +37,29 @@ func TestPriorityQueue(t *testing.T) {
 			}}, lowQueue)
 
 		info, err := q.Pop()
+		assert.Equal(t, 3, q.Size())
 		assert.NoError(t, err)
 		assert.Equal(t, "2", unwrap(info))
 
 		info, err = q.Pop()
+		assert.Equal(t, 2, q.Size())
 		assert.NoError(t, err)
 		assert.Equal(t, "3", unwrap(info))
 
 		info, err = q.Pop()
+		assert.Equal(t, 1, q.Size())
 		assert.NoError(t, err)
 		assert.Equal(t, "1", unwrap(info))
 
 		info, err = q.Pop()
+		assert.Equal(t, 0, q.Size())
 		assert.NoError(t, err)
 		assert.Equal(t, "4", unwrap(info))
 	})
 
 	t.Run("pop empty queue", func(t *testing.T) {
 		q := newPriorityQueue()
+		assert.Equal(t, 0, q.Size())
 
 		_, err := q.Pop()
 		assert.Error(t, err)

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -1,6 +1,7 @@
 package queue_test
 
 import (
+	"go.temporal.io/sdk/client"
 	"testing"
 
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -15,7 +16,7 @@ func noopCallback(ctx workflow.Context, q *queue.Deploy) {}
 
 func TestQueue(t *testing.T) {
 	t.Run("priority", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(nil, client.MetricsNopHandler)
 
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
@@ -34,7 +35,7 @@ func TestQueue(t *testing.T) {
 		var called bool
 		q := queue.NewQueue(func(ctx workflow.Context, d *queue.Deploy) {
 			called = true
-		})
+		}, client.MetricsNopHandler)
 		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
@@ -43,19 +44,19 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("can pop empty queue unlocked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(nil, client.MetricsNopHandler)
 		assert.Equal(t, false, q.CanPop())
 	})
 
 	t.Run("can pop empty queue locked", func(t *testing.T) {
-		q := queue.NewQueue(noopCallback)
+		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
 		q.SetLockForMergedItems(test.Background(), queue.LockState{
 			Status: queue.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())
 	})
 	t.Run("can pop manual trigger locked", func(t *testing.T) {
-		q := queue.NewQueue(noopCallback)
+		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
 		q.SetLockForMergedItems(test.Background(), queue.LockState{
@@ -64,13 +65,13 @@ func TestQueue(t *testing.T) {
 		assert.Equal(t, true, q.CanPop())
 	})
 	t.Run("can pop manual trigger unlocked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(nil, client.MetricsNopHandler)
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
 		assert.Equal(t, true, q.CanPop())
 	})
 	t.Run("can pop merge trigger locked", func(t *testing.T) {
-		q := queue.NewQueue(noopCallback)
+		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
 		q.SetLockForMergedItems(test.Background(), queue.LockState{
@@ -79,7 +80,7 @@ func TestQueue(t *testing.T) {
 		assert.Equal(t, false, q.CanPop())
 	})
 	t.Run("can pop merge trigger unlocked", func(t *testing.T) {
-		q := queue.NewQueue(nil)
+		q := queue.NewQueue(nil, client.MetricsNopHandler)
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
 		assert.Equal(t, true, q.CanPop())

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -1,6 +1,7 @@
 package queue_test
 
 import (
+	"go.temporal.io/sdk/client"
 	"testing"
 	"time"
 
@@ -126,7 +127,7 @@ func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
 		Activities: a,
 	}
 
-	q := queue.NewQueue(noopCallback)
+	q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
 	for _, i := range r.Queue {
 		q.Push(i)
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -41,7 +41,7 @@ const (
 
 	UnlockSignalName = "unlock"
 
-	ActiveDeployWorkflowStat = "deploy_workflow.active"
+	ActiveDeployWorkflowStat = "workflow.deploy.active"
 )
 
 type UnlockSignalRequest struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -41,9 +41,8 @@ const (
 
 	UnlockSignalName = "unlock"
 
-	ActiveDeployWorkflowStat = "workflow.deploy.active"
-	ManualDeployWorkflowStat = "workflow.deploy.manual"
-	MergeDeployWorkflowStat  = "workflow.deploy.merge"
+	ManualDeployWorkflowStat = "workflow.deploy.revision.manual"
+	MergeDeployWorkflowStat  = "workflow.deploy.revision.merge"
 )
 
 type UnlockSignalRequest struct {
@@ -214,8 +213,6 @@ func (w *Worker) deploy(ctx workflow.Context, latestDeployment *deployment.Info)
 	} else {
 		w.MetricsHandler.Counter(MergeDeployWorkflowStat).Inc(1)
 	}
-	w.MetricsHandler.Gauge(ActiveDeployWorkflowStat).Update(1)
-	defer w.MetricsHandler.Gauge(ActiveDeployWorkflowStat).Update(0)
 
 	return w.Deployer.Deploy(ctx, msg, latestDeployment)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -41,8 +41,8 @@ const (
 
 	UnlockSignalName = "unlock"
 
-	ManualDeployWorkflowStat = "workflow.deploy.revision.manual"
-	MergeDeployWorkflowStat  = "workflow.deploy.revision.merge"
+	ManualDeployWorkflowStat = "workflow.deploy.trigger.manual"
+	MergeDeployWorkflowStat  = "workflow.deploy.trigger.merge"
 )
 
 type UnlockSignalRequest struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -3,6 +3,7 @@ package queue_test
 import (
 	"container/list"
 	"fmt"
+	"go.temporal.io/sdk/client"
 	"testing"
 	"time"
 
@@ -339,7 +340,7 @@ func TestNewWorker(t *testing.T) {
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
-		q := queue.NewQueue(noopCallback)
+		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
 		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
 		return res{
 			Lock: q.GetLockState(),

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -116,8 +116,9 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 	}
 
 	worker := queue.Worker{
-		Queue:    q,
-		Deployer: deployer,
+		Queue:          q,
+		Deployer:       deployer,
+		MetricsHandler: client.MetricsNopHandler,
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {
@@ -341,7 +342,7 @@ func TestNewWorker(t *testing.T) {
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
 		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
-		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
+		_, err := queue.NewWorker(ctx, q, client.MetricsNopHandler, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
 		return res{
 			Lock: q.GetLockState(),
 		}, err

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"github.com/runatlantis/atlantis/server/events/metrics"
 	"time"
 
 	"github.com/pkg/errors"
@@ -22,9 +23,6 @@ const (
 	NewRevisionSignalID = "new-revision"
 
 	RevisionReceiveTimeout = 60 * time.Minute
-
-	RootTag = "root"
-	RepoTag = "repo"
 )
 
 type workerActivities struct {
@@ -80,8 +78,8 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	var a *workerActivities
 
 	metricsHandler := workflow.GetMetricsHandler(ctx).WithTags(map[string]string{
-		RepoTag: request.Repo.FullName,
-		RootTag: request.Root.Name,
+		metrics.RepoTag: request.Repo.FullName,
+		metrics.RootTag: request.Root.Name,
 	})
 
 	lockStateUpdater := queue.LockStateUpdater{

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -22,6 +22,9 @@ const (
 	NewRevisionSignalID = "new-revision"
 
 	RevisionReceiveTimeout = 60 * time.Minute
+
+	RootTag = "root"
+	RepoTag = "repo"
 )
 
 type workerActivities struct {
@@ -77,8 +80,8 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	var a *workerActivities
 
 	metricsHandler := workflow.GetMetricsHandler(ctx).WithTags(map[string]string{
-		"repo": request.Repo.FullName,
-		"root": request.Root.Name,
+		RepoTag: request.Repo.FullName,
+		RootTag: request.Root.Name,
 	})
 
 	lockStateUpdater := queue.LockStateUpdater{
@@ -89,7 +92,7 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 	}, metricsHandler)
 	revisionReceiver := revision.NewReceiver(ctx, revisionQueue, a, sideeffect.GenerateUUID)
 
-	worker, err := queue.NewWorker(ctx, revisionQueue, a, tfWorkflow, request.Repo.FullName, request.Root.Name)
+	worker, err := queue.NewWorker(ctx, revisionQueue, metricsHandler, a, tfWorkflow, request.Repo.FullName, request.Root.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/server/neptune/workflows/internal/deploy/workflow_test.go
+++ b/server/neptune/workflows/internal/deploy/workflow_test.go
@@ -1,6 +1,7 @@
 package deploy_test
 
 import (
+	"go.temporal.io/sdk/client"
 	"testing"
 	"time"
 
@@ -63,6 +64,7 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		QueueWorker:              worker,
 		RevisionReceiver:         receiver,
 		NewRevisionSignalChannel: workflow.GetSignalChannel(ctx, testSignalID),
+		MetricsHandler:           client.MetricsNopHandler,
 	}
 
 	err := runner.Run(ctx)

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/events/metrics"
 	"go.temporal.io/sdk/client"
 	"time"
 
@@ -50,9 +51,7 @@ const (
 	ScheduleToCloseTimeout = 30 * time.Minute
 	HeartBeatTimeout       = 1 * time.Minute
 
-	ActiveTerraformWorkflowStat = "terraform_workflow.active"
-	RepoTag                     = "repo"
-	RootTag                     = "root"
+	ActiveTerraformWorkflowStat = "workflow.terraform.active"
 )
 
 func Workflow(ctx workflow.Context, request Request) error {
@@ -101,8 +100,8 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 		},
 		MetricsHandler: workflow.GetMetricsHandler(ctx).WithTags(
 			map[string]string{
-				RepoTag: request.Repo.GetFullName(),
-				RootTag: request.Root.Name,
+				metrics.RepoTag: request.Repo.GetFullName(),
+				metrics.RootTag: request.Root.Name,
 			}),
 		// We have critical things relying on this notification so this workflow provides guarantees around this. (ie. compliance auditing)  There should
 		// be no situation where we are deploying while this is failing.

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.temporal.io/sdk/client"
 	"net/url"
 	"testing"
 	"time"
@@ -137,7 +138,8 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 			Ta:      tAct,
 			Ga:      gAct,
 		},
-		JobRunner: runner,
+		JobRunner:      runner,
+		MetricsHandler: client.MetricsNopHandler,
 		Store: state.NewWorkflowStoreWithGenerator(
 			// add a notifier which just appends to a list which allows us to
 			// test every state change

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -160,17 +160,25 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 
 	switch event := event.(type) {
 	case *github.IssueCommentEvent:
-		err = h.handleCommentEvent(ctx, event, r)
 		scope = scope.SubScope(fmt.Sprintf("comment.%s", *event.Action))
+		timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
+		defer timer.Stop()
+		err = h.handleCommentEvent(ctx, event, r)
 	case *github.PullRequestEvent:
-		err = h.handlePullRequestEvent(ctx, event, r)
 		scope = scope.SubScope(fmt.Sprintf("pr.%s", *event.Action))
+		timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
+		defer timer.Stop()
+		err = h.handlePullRequestEvent(ctx, event, r)
 	case *github.PushEvent:
-		err = h.handlePushEvent(ctx, event)
 		scope = scope.SubScope("push")
+		timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
+		defer timer.Stop()
+		err = h.handlePushEvent(ctx, event)
 	case *github.CheckRunEvent:
-		err = h.handleCheckRunEvent(ctx, event)
 		scope = scope.SubScope("checkrun")
+		timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
+		defer timer.Stop()
+		err = h.handleCheckRunEvent(ctx, event)
 	default:
 		h.logger.WarnContext(ctx, "Ignoring unsupported event")
 	}


### PR DESCRIPTION
Added project(root) and repo tags to client metric interceptor

Added a few metrics:
- Gateway github event handler timer
- Gateway root config builder filter (is/isn't an event that needs to be scheduled onto our deploy workflow)
- Deploy workflow queue depth gauge
- Active deploy workflows gauge
- Active terraform workflows gauge
- Terraform workflow success/failure (separate from client metrics bc we have our own definition of success vs. failure)
- Plan review latency
- Manual vs. Merged revision counters