### PR TITLE
Remove path from download link.

### DIFF
--- a/server/neptune/storage/client_test.go
+++ b/server/neptune/storage/client_test.go
@@ -46,18 +46,6 @@ func (t *testContainer) RemoveItem(id string) error {
 	return nil
 }
 
-type testContainerResolver struct {
-	t         *testing.T
-	name      string
-	container stow.Container
-	err       error
-}
-
-func (t *testContainerResolver) Container(name string) (stow.Container, error) {
-	assert.Equal(t.t, t.name, name)
-	return t.container, t.err
-}
-
 func TestClient_Get(t *testing.T) {
 	id := "1234"
 	prefix := "prefix"

--- a/server/neptune/workflows/activities/cleanup.go
+++ b/server/neptune/workflows/activities/cleanup.go
@@ -5,13 +5,12 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 )
 
 type cleanupActivities struct{}
 
 type CleanupRequest struct {
-	LocalRoot *terraform.LocalRoot
+	DeployDirectory string
 }
 
 // Let's start off with an empty struct in case we ever need to add to it
@@ -20,8 +19,8 @@ type CleanupResponse struct{}
 // TODO: cleanup log streaming resources
 
 func (t *cleanupActivities) Cleanup(ctx context.Context, request CleanupRequest) (CleanupResponse, error) {
-	if err := os.RemoveAll(request.LocalRoot.Path); err != nil {
-		return CleanupResponse{}, errors.Wrapf(err, "deleting path: %s", request.LocalRoot.Path)
+	if err := os.RemoveAll(request.DeployDirectory); err != nil {
+		return CleanupResponse{}, errors.Wrapf(err, "deleting path: %s", request.DeployDirectory)
 	}
 	return CleanupResponse{}, nil
 }

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -229,7 +229,7 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "fetching and extracting zip")
 	}
-	localRoot := terraform.BuildLocalRoot(request.Root, request.Repo, destinationPath)
+	localRoot := terraform.BuildLocalRoot(request.Root, request.Repo, filepath.Join(destinationPath, request.Root.Path))
 	return FetchRootResponse{
 		LocalRoot: localRoot,
 	}, nil

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -3,15 +3,18 @@ package activities
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
 	"github.com/google/go-github/v45/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/logger"
 	internal "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"net/http"
-	"net/url"
-	"path/filepath"
 )
 
 type ClientContext struct {
@@ -200,6 +203,9 @@ type FetchRootRequest struct {
 
 type FetchRootResponse struct {
 	LocalRoot *terraform.LocalRoot
+
+	// if we do more with this, we can consider moving generation into it's own activity
+	DeployDirectory string
 }
 
 // FetchRoot fetches a link to the archive URL using the GH client, processes that URL into a download URL that the
@@ -211,7 +217,8 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "processing request ref")
 	}
-	destinationPath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)
+	deployBasePath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)
+	repositoryPath := filepath.Join(deployBasePath, "repo")
 	opts := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}
@@ -225,13 +232,23 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 		return FetchRootResponse{}, errors.Errorf("getting repo archive link returns non-302 status %d", resp.StatusCode)
 	}
 	downloadLink := a.LinkBuilder.BuildDownloadLinkFromArchive(archiveLink, request.Root, request.Repo, request.Revision)
-	err = a.Getter(ctx, destinationPath, downloadLink)
+	err = a.Getter(ctx, repositoryPath, downloadLink)
 	if err != nil {
 		return FetchRootResponse{}, errors.Wrap(err, "fetching and extracting zip")
 	}
-	localRoot := terraform.BuildLocalRoot(request.Root, request.Repo, filepath.Join(destinationPath, request.Root.Path))
+	rootPath := filepath.Join(repositoryPath, request.Root.Path)
+
+	// let's drop a symlink to the root in the deploy base path to make navigation easier
+	rootSymlink := filepath.Join(deployBasePath, "root")
+	err = os.Symlink(rootPath, rootSymlink)
+	if err != nil {
+		logger.Warn(ctx, "unable to symlink to terraform root", "err", err)
+	}
+
+	localRoot := terraform.BuildLocalRoot(request.Root, request.Repo, rootPath)
 	return FetchRootResponse{
-		LocalRoot: localRoot,
+		LocalRoot:       localRoot,
+		DeployDirectory: deployBasePath,
 	}, nil
 }
 

--- a/server/neptune/workflows/activities/github/link/builder.go
+++ b/server/neptune/workflows/activities/github/link/builder.go
@@ -3,7 +3,6 @@ package link
 import (
 	"fmt"
 	"net/url"
-	"path"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -24,8 +23,7 @@ func (b Builder) BuildDownloadLinkFromArchive(archiveURL *url.URL, root terrafor
 
 	// Append root subdirectory to path to trigger go-getter pkg to only copy the relevant files
 	archiveName := fmt.Sprintf("%s-%s-%s", repo.Owner, repo.Name, revision)
-	subDirPath := path.Join(archiveName, root.Path)
 
-	archiveURL.Path = fmt.Sprintf("%s//%s", archiveURL.Path, subDirPath)
+	archiveURL.Path = fmt.Sprintf("%s//%s", archiveURL.Path, archiveName)
 	return archiveURL.String()
 }

--- a/server/neptune/workflows/activities/github/link/builder_test.go
+++ b/server/neptune/workflows/activities/github/link/builder_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_BuildDownloadLinkFromArchive(t *testing.T) {
-	expectedURL := "https://github.com/testowner/testrepo/legacy.zip/refs/heads/main//testowner-testrepo-a1b2c3d/test/path?archive=zip&token=testtoken123"
+	expectedURL := "https://github.com/testowner/testrepo/legacy.zip/refs/heads/main//testowner-testrepo-a1b2c3d?archive=zip&token=testtoken123"
 	testRoot := terraform.Root{
 		Path: "test/path",
 	}
@@ -28,7 +28,7 @@ func Test_BuildDownloadLinkFromArchive(t *testing.T) {
 }
 
 func Test_BuildDownloadLinkFromArchive_NoToken(t *testing.T) {
-	expectedURL := "https://github.com/testowner/testrepo/legacy.zip/refs/heads/main//testowner-testrepo-a1b2c3d/test/path?archive=zip"
+	expectedURL := "https://github.com/testowner/testrepo/legacy.zip/refs/heads/main//testowner-testrepo-a1b2c3d?archive=zip"
 	testRoot := terraform.Root{
 		Path: "/test/path",
 	}

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -52,7 +52,7 @@ func TestDeployWorkflow(t *testing.T) {
 
 	env.ExecuteWorkflow(workflows.Deploy, workflows.DeployRequest{
 		Root: workflows.DeployRequestRoot{
-			Name: "my test root",
+			Name: "mytestroot",
 		},
 		Repo: workflows.DeployRequestRepo{
 			FullName: "nish/repo",
@@ -77,7 +77,7 @@ func signalWorkflow(env *testsuite.TestWorkflowEnvironment) {
 	env.SignalWorkflow(workflows.DeployNewRevisionSignalID, workflows.DeployNewRevisionSignalRequest{
 		Revision: "12345",
 		Root: workflows.Root{
-			Name: "my test root",
+			Name: "mytestroot",
 			Plan: workflows.Job{
 				Steps: []workflows.Step{
 					{
@@ -244,6 +244,8 @@ var fileContents = ` resource "null_resource" "null" {}
 `
 
 func GetLocalTestRoot(ctx context.Context, dst, src string) error {
+	// dst will be the repo path here but we also need to create the root itself
+	dst = filepath.Join(dst, "terraform", "mytestroot")
 	err := os.MkdirAll(dst, os.ModePerm)
 
 	if err != nil {

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -30,7 +30,7 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func() 
 	return fetchRootResponse.LocalRoot, func() error {
 		var cleanupResponse activities.CleanupResponse
 		err = workflow.ExecuteActivity(ctx, r.Ta.Cleanup, activities.CleanupRequest{ //nolint:gosimple // unnecessary to add a method to convert reponses
-			LocalRoot: fetchRootResponse.LocalRoot,
+			DeployDirectory: fetchRootResponse.DeployDirectory,
 		}).Get(ctx, &cleanupResponse)
 		if err != nil {
 			return errors.Wrap(err, "cleaning up")

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -26,6 +26,7 @@ const (
 	testRootName     = "testroot"
 	testDeploymentID = "123"
 	testPath         = "rel/path"
+	DeployDir        = "deployments/123"
 )
 
 var testGithubRepo = github.Repo{
@@ -66,7 +67,8 @@ type githubActivities struct{}
 
 func (a *githubActivities) FetchRoot(_ context.Context, _ activities.FetchRootRequest) (activities.FetchRootResponse, error) {
 	return activities.FetchRootResponse{
-		LocalRoot: testLocalRoot,
+		LocalRoot:       testLocalRoot,
+		DeployDirectory: DeployDir,
 	}, nil
 }
 
@@ -227,10 +229,11 @@ func TestSuccess(t *testing.T) {
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
-		LocalRoot: testLocalRoot,
+		LocalRoot:       testLocalRoot,
+		DeployDirectory: DeployDir,
 	}, nil)
 	env.OnActivity(ta.Cleanup, mock.Anything, activities.CleanupRequest{
-		LocalRoot: testLocalRoot,
+		DeployDirectory: DeployDir,
 	}).Return(activities.CleanupResponse{}, nil)
 
 	// send approval of plan
@@ -337,7 +340,8 @@ func TestUpdateJobError(t *testing.T) {
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
-		LocalRoot: testLocalRoot,
+		DeployDirectory: DeployDir,
+		LocalRoot:       testLocalRoot,
 	}, nil)
 
 	// execute workflow
@@ -382,7 +386,8 @@ func TestPlanRejection(t *testing.T) {
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
-		LocalRoot: testLocalRoot,
+		DeployDirectory: DeployDir,
+		LocalRoot:       testLocalRoot,
 	}, nil)
 
 	// send rejection of plan
@@ -473,7 +478,8 @@ func TestFetchRootError(t *testing.T) {
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
 	}).Return(activities.FetchRootResponse{
-		LocalRoot: testLocalRoot,
+		DeployDirectory: DeployDir,
+		LocalRoot:       testLocalRoot,
 	}, assert.AnError)
 
 	// execute workflow
@@ -498,7 +504,7 @@ func TestCleanupErrorReturnsNoError(t *testing.T) {
 
 	// set activity expectations
 	env.OnActivity(ta.Cleanup, mock.Anything, activities.CleanupRequest{
-		LocalRoot: testLocalRoot,
+		DeployDirectory: DeployDir,
 	}).Return(activities.CleanupResponse{}, assert.AnError)
 
 	// send approval of plan


### PR DESCRIPTION
Local modules won't work if we do this sort of thing. This is what the folder structure looks like now:

```
/tmp/deployments/a22f0300-5bb4-11ed-8f30-0242ac140003
▶ ls -aslh
total 0
0 drwxr-xr-x 4 nishk wheel 128 Nov  3 13:18 .
0 drwxr-xr-x 4 nishk wheel 128 Nov  3 13:18 ..
0 drwxr-xr-x 5 nishk wheel 160 Nov  3 13:18 repo
0 lrwxr-xr-x 1 nishk wheel  78 Nov  3 13:18 root -> /tmp/deployments/a22f0300-5bb4-11ed-8f30-0242ac140003/repo/nish-test-workspace

/tmp/deployments/a22f0300-5bb4-11ed-8f30-0242ac140003
▶
```