### PR TITLE
Use TerraformClientError for terraform errors to avoid retrying TF workflow executions

### DIFF
--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -43,7 +43,7 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 		// we shouldn't ever percolate failures up unless they are user errors (aka. Terraform specific)
 		// retrying indefinitely allows us to fix whatever issue that comes about without involving the user to redeploy
 		RetryPolicy: &temporal.RetryPolicy{
-			NonRetryableErrorTypes: []string{terraform.TerraformClientErrorType, terraform.PlanRejectedErrorType},
+			NonRetryableErrorTypes: []string{terraform.ClientErrorType, terraform.PlanRejectedErrorType},
 		},
 	})
 	terraformWorkflowRequest := terraform.Request{

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -16,9 +16,9 @@ type Request struct {
 }
 
 const (
-	PlanRejectedErrorType    = "PlanRejectedError"
-	UpdateJobErrorType       = "UpdateJobError"
-	TerraformClientErrorType = "TerraformClientError"
+	PlanRejectedErrorType = "PlanRejectedError"
+	UpdateJobErrorType    = "UpdateJobError"
+	ClientErrorType       = "TerraformClientError"
 )
 
 type ExternalError struct {
@@ -75,6 +75,6 @@ func (e TerraformClientError) Error() string {
 func newTerraformClientError(err error, msg string) TerraformClientError {
 	return TerraformClientError{
 		err:           errors.Wrap(err, msg),
-		ExternalError: ExternalError{ErrType: TerraformClientErrorType},
+		ExternalError: ExternalError{ErrType: ClientErrorType},
 	}
 }

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -63,17 +63,18 @@ func newUpdateJobError(err error, msg string) UpdateJobError {
 }
 
 type TerraformClientError struct {
-	Err error
+	err error
+	msg string
 	ExternalError
 }
 
 func (e TerraformClientError) Error() string {
-	return e.Err.Error()
+	return errors.Wrap(e.err, e.msg).Error()
 }
 
 func newTerraformClientError(err error, msg string) TerraformClientError {
 	return TerraformClientError{
-		Err:           errors.Wrap(err, msg),
+		err:           errors.Wrap(err, msg),
 		ExternalError: ExternalError{ErrType: TerraformClientErrorType},
 	}
 }

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -61,3 +61,19 @@ func newUpdateJobError(err error, msg string) UpdateJobError {
 		ExternalError: ExternalError{ErrType: UpdateJobErrorType},
 	}
 }
+
+type TerraformClientError struct {
+	Err error
+	ExternalError
+}
+
+func (e TerraformClientError) Error() string {
+	return e.Err.Error()
+}
+
+func newTerraformClientError(err error, msg string) TerraformClientError {
+	return TerraformClientError{
+		Err:           errors.Wrap(err, msg),
+		ExternalError: ExternalError{ErrType: TerraformClientErrorType},
+	}
+}

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -18,7 +18,7 @@ type Request struct {
 const (
 	PlanRejectedErrorType = "PlanRejectedError"
 	UpdateJobErrorType    = "UpdateJobError"
-	ClientErrorType       = "TerraformClientError"
+	ClientErrorType       = "ClientError"
 )
 
 type ExternalError struct {

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -18,7 +18,7 @@ type Request struct {
 const (
 	PlanRejectedErrorType = "PlanRejectedError"
 	UpdateJobErrorType    = "UpdateJobError"
-	ClientErrorType       = "ClientError"
+	ClientErrorType       = "TerraformClientError"
 )
 
 type ExternalError struct {
@@ -62,18 +62,18 @@ func newUpdateJobError(err error, msg string) UpdateJobError {
 	}
 }
 
-type TerraformClientError struct {
+type ClientError struct {
 	err error
 	msg string
 	ExternalError
 }
 
-func (e TerraformClientError) Error() string {
+func (e ClientError) Error() string {
 	return errors.Wrap(e.err, e.msg).Error()
 }
 
-func newTerraformClientError(err error, msg string) TerraformClientError {
-	return TerraformClientError{
+func newTerraformClientError(err error, msg string) ClientError {
+	return ClientError{
 		err:           errors.Wrap(err, msg),
 		ExternalError: ExternalError{ErrType: ClientErrorType},
 	}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -283,7 +283,7 @@ func toExternalError(err error, msg string) error {
 		return e.ToTemporalApplicationError()
 	}
 
-	var terraformClientErr TerraformClientError
+	var terraformClientErr ClientError
 	if errors.As(err, &terraformClientErr) {
 		e := ApplicationError{
 			ErrType: terraformClientErr.GetExternalType(),

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -224,7 +224,6 @@ func (r *Runner) Run(ctx workflow.Context) error {
 	}
 	defer func() {
 		err := cleanup()
-
 		if err != nil {
 			logger.Warn(ctx, "error cleaning up local root", "err", err)
 		}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -205,7 +205,7 @@ func (r *Runner) Run(ctx workflow.Context) error {
 		ScheduleToCloseTimeout: ScheduleToCloseTimeout,
 		HeartbeatTimeout:       HeartBeatTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
-			NonRetryableErrorTypes: []string{TerraformClientErrorType},
+			NonRetryableErrorTypes: []string{ClientErrorType},
 		},
 	})
 	var response *activities.GetWorkerInfoResponse


### PR DESCRIPTION
Using TerraformClientError wrapper prevents retries of the workflow. The linter was against the original name starting with the package name (Terraform), so I renamed the variable to ClientError.