### PR TITLE
Add local persistence as the default.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -490,7 +490,7 @@ func (t *TemporalWorker) NewServer(userConfig server.UserConfig, config server.C
 		return nil, errors.Wrap(err, "failed to build context logger")
 	}
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg(userConfig.DataDir)
 	validator := &cfgParser.ParserValidator{}
 	if userConfig.RepoConfig != "" {
 		globalCfg, err = validator.ParseGlobalCfg(userConfig.RepoConfig, globalCfg)
@@ -548,6 +548,10 @@ type ServerCreatorProxy struct {
 }
 
 func (d *ServerCreatorProxy) NewServer(userConfig server.UserConfig, config server.Config) (ServerStarter, error) {
+	// maybe there's somewhere better to do this
+	if err := os.MkdirAll(userConfig.DataDir, 0700); err != nil {
+		return nil, err
+	}
 	if userConfig.ToLyftMode() == server.Gateway {
 		return d.GatewayCreator.NewServer(userConfig, config)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         volumes:
             - ~/.ssh:/.ssh
             - ./:/atlantis/src
+            - /tmp:/tmp
         # Contains the flags that atlantis uses in env var form
         env_file:
             - ~/.atlantis-gateway.env
@@ -31,6 +32,7 @@ services:
         volumes:
             - ~/.ssh:/.ssh
             - ./:/atlantis/src
+            - /tmp:/tmp
         # Contains the flags that atlantis uses in env var form
         env_file:
             - ~/.atlantis-temporalworker.env

--- a/repo-config-dev-template.yaml
+++ b/repo-config-dev-template.yaml
@@ -11,3 +11,7 @@ metrics:
 temporal:
   host: temporalite
   port: 7233
+
+persistence:
+  job_store_prefix: jobs
+  deployment_store_prefix: deployments

--- a/repo-config-dev-template.yaml
+++ b/repo-config-dev-template.yaml
@@ -11,7 +11,3 @@ metrics:
 temporal:
   host: temporalite
   port: 7233
-
-persistence:
-  job_store_prefix: jobs
-  deployment_store_prefix: deployments

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -729,7 +729,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		VCSClient: vcsClient,
 	}
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg(dataDir)
 
 	workingDir := &events.FileWorkspace{
 		DataDir:                     dataDir,

--- a/server/core/config/raw/global_cfg.go
+++ b/server/core/config/raw/global_cfg.go
@@ -158,7 +158,7 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 		DeploymentWorkflows:  validDeploymentWorkflows,
 		PolicySets:           policySets,
 		Metrics:              g.Metrics.ToValid(),
-		PersistenceConfig:    g.Persistence.ToValid(),
+		PersistenceConfig:    g.Persistence.ToValid(defaultCfg),
 		TerraformLogFilter:   g.TerraformLogFilters.ToValid(),
 		Temporal:             g.Temporal.ToValid(),
 	}

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -5,9 +5,16 @@ import (
 	"regexp"
 
 	"github.com/graymeta/stow"
+	"github.com/graymeta/stow/local"
 	stow_s3 "github.com/graymeta/stow/s3"
 	version "github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/logging"
+)
+
+const (
+	LocalStore               = "artifact-store"
+	DefaultJobsPrefix        = "jobs"
+	DefaultDeploymentsPrefix = "deployments"
 )
 
 const MergeableApplyReq = "mergeable"
@@ -200,7 +207,7 @@ var DefaultLocklessPlanStage = Stage{
 	},
 }
 
-func NewGlobalCfg() GlobalCfg {
+func NewGlobalCfg(dataDir string) GlobalCfg {
 	defaultWorkflow := Workflow{
 		Name:        DefaultWorkflowName,
 		Apply:       DefaultApplyStage,
@@ -245,6 +252,25 @@ func NewGlobalCfg() GlobalCfg {
 		},
 		PullRequestWorkflows: map[string]Workflow{
 			DefaultWorkflowName: pullRequestWorkflow,
+		},
+	}
+
+	globalCfg.PersistenceConfig = PersistenceConfig{
+		Deployments: StoreConfig{
+			BackendType: LocalBackend,
+			Prefix:      DefaultDeploymentsPrefix,
+			Config: stow.ConfigMap{
+				local.ConfigKeyPath: dataDir,
+			},
+			ContainerName: LocalStore,
+		},
+		Jobs: StoreConfig{
+			BackendType: LocalBackend,
+			Prefix:      DefaultJobsPrefix,
+			Config: stow.ConfigMap{
+				local.ConfigKeyPath: dataDir,
+			},
+			ContainerName: LocalStore,
 		},
 	}
 

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -169,7 +169,7 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 
 	When(preWorkflowHooksCommandRunner.RunPreHooks(matchers.AnyContextContext(), matchers.AnyPtrToEventsCommandContext())).ThenReturn(nil)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 
 	staleCommandChecker = mocks.NewMockStaleCommandChecker()

--- a/server/events/github_app_working_dir_test.go
+++ b/server/events/github_app_working_dir_test.go
@@ -28,7 +28,7 @@ func TestClone_GithubAppNoneExisting(t *testing.T) {
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
-		GlobalCfg:                   valid.NewGlobalCfg(),
+		GlobalCfg:                   valid.NewGlobalCfg("somedir"),
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 

--- a/server/events/project_command_builder_internal_test.go
+++ b/server/events/project_command_builder_internal_test.go
@@ -574,7 +574,7 @@ projects:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg())
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg("somedir"))
 			Ok(t, err)
 
 			if c.repoCfg != "" {
@@ -743,7 +743,7 @@ workflows:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg())
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg("somedir"))
 			Ok(t, err)
 
 			if c.repoCfg != "" {
@@ -944,7 +944,7 @@ projects:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, ioutil.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg())
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg("somedir"))
 			Ok(t, err)
 
 			if c.repoCfg != "" {
@@ -1158,7 +1158,7 @@ workflows:
 			globalCfgPath := filepath.Join(tmp, "global.yaml")
 			Ok(t, os.WriteFile(globalCfgPath, []byte(c.globalCfg), 0600))
 			parser := &config.ParserValidator{}
-			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg())
+			globalCfg, err := parser.ParseGlobalCfg(globalCfgPath, valid.NewGlobalCfg("somedir"))
 			Ok(t, err)
 
 			if c.repoCfg != "" {

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -149,7 +149,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(),
+				valid.NewGlobalCfg("somedir"),
 				&events.DefaultPendingPlanFinder{},
 				false,
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -402,7 +402,7 @@ projects:
 					Ok(t, err)
 				}
 
-				globalCfg := valid.NewGlobalCfg()
+				globalCfg := valid.NewGlobalCfg("somedir")
 				globalCfg.Repos[0].AllowedOverrides = []string{"apply_requirements"}
 
 				builder := events.NewProjectCommandBuilder(
@@ -559,7 +559,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(),
+				valid.NewGlobalCfg("somedir"),
 				&events.DefaultPendingPlanFinder{},
 				false,
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -642,7 +642,7 @@ func TestDefaultProjectCommandBuilder_BuildMultiApply(t *testing.T) {
 		nil,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(),
+		valid.NewGlobalCfg("somedir"),
 		&events.DefaultPendingPlanFinder{},
 		false,
 		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -719,7 +719,7 @@ projects:
 		nil,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(),
+		valid.NewGlobalCfg("somedir"),
 		&events.DefaultPendingPlanFinder{},
 		false,
 		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -789,7 +789,7 @@ func TestDefaultProjectCommandBuilder_EscapeArgs(t *testing.T) {
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(),
+				valid.NewGlobalCfg("somedir"),
 				&events.DefaultPendingPlanFinder{},
 				false,
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -963,7 +963,7 @@ projects:
 				vcsClient,
 				workingDir,
 				events.NewDefaultWorkingDirLocker(),
-				valid.NewGlobalCfg(),
+				valid.NewGlobalCfg("somedir"),
 				&events.DefaultPendingPlanFinder{},
 				false,
 				"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",
@@ -1012,7 +1012,7 @@ func TestDefaultProjectCommandBuilder_WithPolicyCheckEnabled_BuildAutoplanComman
 	vcsClient := vcsmocks.NewMockClient()
 	When(vcsClient.GetModifiedFiles(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())).ThenReturn([]string{"main.tf"}, nil)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	commentParser := &events.CommentParser{}
 	contextBuilder := wrappers.
 		WrapProjectContext(events.NewProjectCommandContextBuilder(commentParser)).
@@ -1099,7 +1099,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 		nil,
 		workingDir,
 		events.NewDefaultWorkingDirLocker(),
-		valid.NewGlobalCfg(),
+		valid.NewGlobalCfg("somedir"),
 		&events.DefaultPendingPlanFinder{},
 		false,
 		"**/*.tf,**/*.tfvars,**/*.tfvars.json,**/terragrunt.hcl",

--- a/server/events/working_dir_test.go
+++ b/server/events/working_dir_test.go
@@ -38,7 +38,7 @@ func TestClone_NoneExisting(t *testing.T) {
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
-		GlobalCfg:                   valid.NewGlobalCfg(),
+		GlobalCfg:                   valid.NewGlobalCfg("somedir"),
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 
@@ -86,7 +86,7 @@ func TestClone_CheckoutMergeNoneExisting(t *testing.T) {
 
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	wd := &events.FileWorkspace{
@@ -139,7 +139,7 @@ func TestClone_CheckoutMergeNoReclone(t *testing.T) {
 	defer cleanup2()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	baseRepo := NewBaseRepo()
@@ -195,7 +195,7 @@ func TestClone_CheckoutMergeNoRecloneFastForward(t *testing.T) {
 	defer cleanup2()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	wd := &events.FileWorkspace{
@@ -256,7 +256,7 @@ func TestClone_CheckoutMergeConflict(t *testing.T) {
 	defer cleanup2()
 	overrideURL := fmt.Sprintf("file://%s", repoDir)
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	wd := &events.FileWorkspace{
@@ -300,7 +300,7 @@ func TestClone_NoReclone(t *testing.T) {
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
-		GlobalCfg:                   valid.NewGlobalCfg(),
+		GlobalCfg:                   valid.NewGlobalCfg("somedir"),
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 
@@ -337,7 +337,7 @@ func TestClone_RecloneWrongCommit(t *testing.T) {
 
 	wd := &events.FileWorkspace{
 		DataDir:                     dataDir,
-		GlobalCfg:                   valid.NewGlobalCfg(),
+		GlobalCfg:                   valid.NewGlobalCfg("somedir"),
 		TestingOverrideHeadCloneURL: fmt.Sprintf("file://%s", repoDir),
 	}
 	cloneDir, hasDiverged, err := wd.Clone(logging.NewNoopCtxLogger(t), models.Repo{}, models.PullRequest{
@@ -404,7 +404,7 @@ func TestClone_MasterHasDiverged(t *testing.T) {
 	runCmd(t, repoDir, "mkdir", "-p", repoPath)
 	runCmd(t, repoDir, "cp", "-R", secondPRDir, repoPath+"default")
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	// Run the clone.
@@ -483,7 +483,7 @@ func TestHasDiverged_MasterHasDiverged(t *testing.T) {
 	// "git", "remote", "set-url", "origin", p.BaseRepo.CloneURL,
 	runCmd(t, repoDir+"/repos/0/default", "git", "remote", "update")
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	globalCfg.Repos[0].CheckoutStrategy = "merge"
 
 	// Run the clone.

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -55,7 +55,7 @@ func setupAutoplan(t *testing.T) *vcsmocks.MockClient {
 	}
 	preWorkflowHooksCommandRunner = mocks.NewMockPreWorkflowHooksCommandRunner()
 	When(preWorkflowHooksCommandRunner.RunPreHooks(matchers.AnyContextContext(), matchers.AnyPtrToEventsCommandContext())).ThenReturn(nil)
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg("somedir")
 	logger := logging.NewNoopCtxLogger(t)
 	scope, _, _ := metrics.NewLoggingScope(logger, "atlantis")
 	autoplanValidator = gateway.AutoplanValidator{

--- a/server/neptune/gateway/event/parser_validator_test.go
+++ b/server/neptune/gateway/event/parser_validator_test.go
@@ -1059,7 +1059,7 @@ workflows:
 	assert.NoError(t, err)
 
 	r := event.ParserValidator{
-		GlobalCfg: valid.NewGlobalCfg(),
+		GlobalCfg: valid.NewGlobalCfg("somedir"),
 	}
 
 	_, err = r.ParseRepoCfg(tmpDir, "repo_id")

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -18,7 +18,7 @@ var globalCfg valid.GlobalCfg
 var expectedErr = errors.New("some error") //nolint:revive // error name is fine for testing purposes
 
 func setupTesting(t *testing.T) {
-	globalCfg = valid.NewGlobalCfg()
+	globalCfg = valid.NewGlobalCfg("somedir")
 	repo := models.Repo{
 		FullName:      "nish/repo",
 		DefaultBranch: "",

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -98,7 +98,7 @@ func NewServer(config Config) (*Server, error) {
 		return nil, err
 	}
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg(config.DataDir)
 	validator := &cfgParser.ParserValidator{}
 	if config.RepoConfig != "" {
 		globalCfg, err = validator.ParseGlobalCfg(config.RepoConfig, globalCfg)

--- a/server/neptune/storage/client_test.go
+++ b/server/neptune/storage/client_test.go
@@ -2,7 +2,6 @@ package storage_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -61,30 +60,7 @@ func (t *testContainerResolver) Container(name string) (stow.Container, error) {
 
 func TestClient_Get(t *testing.T) {
 	id := "1234"
-	containerName := "container"
 	prefix := "prefix"
-	expErr := errors.New("error")
-
-	t.Run("should throw container not found error when Container not found", func(t *testing.T) {
-		location := &testContainerResolver{
-			t:    t,
-			name: containerName,
-			err:  expErr,
-		}
-
-		client := storage.Client{
-			Location:      location,
-			ContainerName: containerName,
-			Prefix:        prefix,
-		}
-
-		readCloser, err := client.Get(context.Background(), id)
-		assert.Nil(t, readCloser)
-		assert.Equal(t, &storage.ContainerNotFoundError{
-			Err: expErr,
-		}, err)
-
-	})
 
 	t.Run("should throw item not found error when Item not found", func(t *testing.T) {
 		container := &testContainer{
@@ -99,16 +75,9 @@ func TestClient_Get(t *testing.T) {
 			},
 		}
 
-		location := &testContainerResolver{
-			t:         t,
-			name:      containerName,
-			container: container,
-		}
-
 		client := storage.Client{
-			Location:      location,
-			ContainerName: containerName,
-			Prefix:        prefix,
+			Container: container,
+			Prefix:    prefix,
 		}
 
 		readCloser, err := client.Get(context.Background(), id)

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	validator := &cfgParser.ParserValidator{}
 
-	globalCfg := valid.NewGlobalCfg()
+	globalCfg := valid.NewGlobalCfg(userConfig.DataDir)
 
 	if userConfig.RepoConfig != "" {
 		globalCfg, err = validator.ParseGlobalCfg(userConfig.RepoConfig, globalCfg)


### PR DESCRIPTION
This unblocks local testing as we default to just persisting on disk if the config is missing.  Note: I've mounted tmp as a volume in the docker-compose.yaml this allows you to use that as your ATLANTIS_DATA_DIR AND see what's going on there without needing to exec into the pod.  Also preserves any logging you have across restarts of your temporal worker which is nice as well.