### PR TITLE
Use sha as ref instead of ref value.

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -220,7 +220,7 @@ func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootReque
 	deployBasePath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)
 	repositoryPath := filepath.Join(deployBasePath, "repo")
 	opts := &github.RepositoryContentGetOptions{
-		Ref: ref,
+		Ref: request.Revision,
 	}
 	// note: this link exists for 5 minutes when fetching a private repository archive
 	archiveLink, resp, err := a.Client.GetArchiveLink(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, github.Zipball, opts, true)

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -213,10 +213,7 @@ type FetchRootResponse struct {
 func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootRequest) (FetchRootResponse, error) {
 	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
-	ref, err := request.Repo.Ref.String()
-	if err != nil {
-		return FetchRootResponse{}, errors.Wrap(err, "processing request ref")
-	}
+
 	deployBasePath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)
 	repositoryPath := filepath.Join(deployBasePath, "repo")
 	opts := &github.RepositoryContentGetOptions{


### PR DESCRIPTION
we want to stick to cloning the revision we are processing:

```
▶ cd /tmp/deployments/36b51e0b-5bd0-11ed-ad4e-0242ac140002

/tmp/deployments/36b51e0b-5bd0-11ed-ad4e-0242ac140002
▶ ls
repo  root

/tmp/deployments/36b51e0b-5bd0-11ed-ad4e-0242ac140002
▶ ls repo/
README.md  atlantis.yaml  nish-test-workspace
```
