### PR TITLE
Fix PrjCmdOutputHandler Test

### DIFF
--- a/server/jobs/project_command_output_handler_test.go
+++ b/server/jobs/project_command_output_handler_test.go
@@ -1,7 +1,6 @@
 package jobs_test
 
 import (
-	"fmt"
 	"regexp"
 	"sync"
 	"testing"
@@ -187,9 +186,7 @@ func TestProjectCommandOutputHandler(t *testing.T) {
 		// read from channel
 		func() {
 			for msg := range ch {
-				fmt.Println("Reading msg:", msg)
 				if msg == "Complete" {
-					fmt.Println("Complete")
 					return
 				}
 			}


### PR DESCRIPTION
The `clean up all jobs when PR is closed` test races between receiving the msg from the registered channel and it being removed by the handler if it's blocking: https://github.com/lyft/atlantis/blob/f49481668c0ba456e86390f77e8b7723734b882c/server/jobs/project_command_output_handler.go#L128-L129

We can choose to be conservative and add a `5` second timer before closing the receiver channel but since we're only testing if the job store is cleaned up, we only need to send 1 msg and check if it was cleaned up, instead of sending consecutive messages which complicates the tests. 