### PR TITLE
Set checkrun state to Queued when queuing up deployments 

### DIFF
--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -116,6 +116,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 		ExternalID: id,
 		Summary:    summary,
 		Actions:    actions,
+		State:      github.CheckRunQueued,
 	}).Get(ctx, &resp)
 
 	// don't block on error here, we'll just try again later when we have our result.

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -114,6 +114,7 @@ func TestEnqueue(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -169,6 +170,7 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -225,6 +227,7 @@ func TestEnqueue_ManualTrigger_queueAlreadyLocked(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -288,6 +291,7 @@ func TestEnqueue_MergeTrigger_queueAlreadyLocked(t *testing.T) {
 		ExternalID: id.String(),
 		Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
 		Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{


### PR DESCRIPTION
Currently when a deployment is queued, the checkrun UI has no information that suggests the deployment is queued. So, let's set the state to `CheckRunQueued` when we add a deployment to the queue. 