### PR TITLE
Ensure state updater is notified on workflow completion.

### DIFF
--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -16,21 +16,25 @@ var checkrunTemplateStr string
 var checkrunTemplate = template.Must(template.New("").Parse(checkrunTemplateStr))
 
 type checkrunTemplateData struct {
-	PlanStatus  string
-	PlanLogURL  string
-	ApplyStatus string
-	ApplyLogURL string
+	PlanStatus    string
+	PlanLogURL    string
+	ApplyStatus   string
+	ApplyLogURL   string
+	InternalError bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	planStatus, planLogURL := getJobStatusAndOutput(workflowState.Plan)
 	applyStatus, applyLogURL := getJobStatusAndOutput(workflowState.Apply)
 
+	internalError := workflowState.Result.Reason == state.InternalServiceError
+
 	return renderTemplate(checkrunTemplate, checkrunTemplateData{
-		PlanStatus:  planStatus,
-		PlanLogURL:  planLogURL,
-		ApplyStatus: applyStatus,
-		ApplyLogURL: applyLogURL,
+		PlanStatus:    planStatus,
+		PlanLogURL:    planLogURL,
+		ApplyStatus:   applyStatus,
+		ApplyLogURL:   applyLogURL,
+		InternalError: internalError,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -4,6 +4,8 @@
 | Apply | {{ if .ApplyStatus }}`{{.ApplyStatus}}`{{else}}N/A{{end}} |{{ if .ApplyLogURL }}[Click Here]({{.ApplyLogURL}}){{else}}N/A{{end}} |
 
 {{if .InternalError }}
-## Internal Service Error :boom:
-:point_right: This is most likely a bug, please contact service owners to debug further
+## Deployment Error :boom:
+:point_right: If a specific terraform operation has failed, check the logs (linked above) to determine if this is a terraform error or not.  If it is, you'll likely need to make some configuration fixes and try again.
+
+If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.
 {{end}}

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -2,3 +2,8 @@
 | - | - | - |
 | Plan | {{ if .PlanStatus }}`{{.PlanStatus}}`{{else}}N/A{{end}} |{{ if .PlanLogURL }}[Click Here]({{.PlanLogURL}}){{else}}N/A{{end}} |
 | Apply | {{ if .ApplyStatus }}`{{.ApplyStatus}}`{{else}}N/A{{end}} |{{ if .ApplyLogURL }}[Click Here]({{.ApplyLogURL}}){{else}}N/A{{end}} |
+
+{{if .InternalError }}
+## Internal Service Error :boom:
+:point_right: This is most likely a bug, please contact service owners to debug further
+{{end}}

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -5,7 +5,12 @@
 
 {{if .InternalError }}
 ## Deployment Error :boom:
-:point_right: If a specific terraform operation has failed, check the logs (linked above) to determine if this is a terraform error or not.  If it is, you'll likely need to make some configuration fixes and try again.
+:point_right: An error has been encountered from either of the following:
+* A Terraform operation failed
+* A Terraform apply was rejected by a user
+* There was a platform issue
 
-If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.
+If a specific terraform operation has failed, check the logs (linked above) to determine if this is a terraform error or not.  If it is, you'll likely need to make some configuration fixes and try again.
+
+**Note: If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.**
 {{end}}

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -64,13 +64,14 @@ func TestDeployWorkflow(t *testing.T) {
 	// asserting the output itself is a bit overkill tbh.
 
 	// there should be 6 state changes that are reflected in our checks (3 state changes for plan and apply)
-	assert.Len(t, s.githubClient.Updates, 6)
+	assert.Len(t, s.githubClient.Updates, 7)
 
 	// we should have output for 2 different jobs
 	assert.Len(t, s.streamCloser.CapturedJobOutput, 2)
 
-	// we should emit 2 events: IN_PROGRESS and SUCCESS
-	assert.Len(t, s.snsWriter.writes, 2)
+	// we should emit 3 events: IN_PROGRESS, SUCCESS, SUCCESS
+	// two success events are emitted since one happens on completion of the workflow.
+	assert.Len(t, s.snsWriter.writes, 3)
 }
 
 func signalWorkflow(env *testsuite.TestWorkflowEnvironment) {

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -105,6 +105,19 @@ func TestStateReceive(t *testing.T) {
 					Status: state.FailedJobStatus,
 				},
 			},
+			ExpectedCheckRunState: github.CheckRunPending,
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.FailedJobStatus,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.InternalServiceError,
+				},
+			},
 			ExpectedCheckRunState: github.CheckRunFailure,
 		},
 		{
@@ -167,6 +180,33 @@ func TestStateReceive(t *testing.T) {
 					EndTime:   endTime,
 				},
 			},
+			ExpectedCheckRunState: github.CheckRunPending,
+			ExpectedAuditJobRequest: &activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.FailedJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.InternalServiceError,
+				},
+			},
 			ExpectedCheckRunState: github.CheckRunFailure,
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
@@ -188,6 +228,10 @@ func TestStateReceive(t *testing.T) {
 					Status:    state.SuccessJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.SuccessfulCompletionReason,
 				},
 			},
 			ExpectedCheckRunState: github.CheckRunSuccess,

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -101,6 +101,11 @@ func (s *WorkflowStore) UpdateApplyJobWithStatus(status JobStatus, options ...Up
 	return s.notifier(s.state)
 }
 
+func (s *WorkflowStore) UpdateCompletion(result WorkflowResult) error {
+	s.state.Result = result
+	return s.notifier(s.state)
+}
+
 func getStartTimeFromOpts(options ...UpdateOptions) time.Time {
 	for _, o := range options {
 		if !o.StartTime.IsZero() {

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -19,6 +19,20 @@ const (
 	SuccessJobStatus    JobStatus = "success"
 )
 
+type WorkflowStatus int
+type WorkflowCompletionReason int
+
+const (
+	InProgressWorkflowStatus WorkflowStatus = iota
+	CompleteWorkflowStatus
+)
+
+const (
+	UnknownCompletionReason WorkflowCompletionReason = iota
+	SuccessfulCompletionReason
+	InternalServiceError
+)
+
 type JobOutput struct {
 	URL *url.URL
 
@@ -34,7 +48,13 @@ type Job struct {
 	EndTime   time.Time
 }
 
+type WorkflowResult struct {
+	Status WorkflowStatus
+	Reason WorkflowCompletionReason
+}
+
 type Workflow struct {
-	Plan  *Job
-	Apply *Job
+	Plan   *Job
+	Apply  *Job
+	Result WorkflowResult
 }

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -266,7 +266,7 @@ func (r *Runner) run(ctx workflow.Context) error {
 		cleanupErr := cleanup()
 
 		if cleanupErr != nil {
-			logger.Warn(ctx, "error cleaning up local root", "err", err)
+			logger.Warn(ctx, "error cleaning up local root", "err", cleanupErr)
 		}
 	}()
 

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -211,6 +211,7 @@ func copy(s *state.Workflow) state.Workflow {
 			},
 		}
 	}
+	copy.Result = s.Result
 	return copy
 }
 
@@ -320,6 +321,24 @@ func TestSuccess(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: outputURL,
 				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Result: state.WorkflowResult{
+				Reason: state.SuccessfulCompletionReason,
+				Status: state.CompleteWorkflowStatus,
 			},
 		},
 	}, resp.States)
@@ -461,6 +480,24 @@ func TestPlanRejection(t *testing.T) {
 				Output: &state.JobOutput{
 					URL: outputURL,
 				},
+			},
+		},
+		{
+			Plan: &state.Job{
+				Status: state.SuccessJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Apply: &state.Job{
+				Status: state.RejectedJobStatus,
+				Output: &state.JobOutput{
+					URL: outputURL,
+				},
+			},
+			Result: state.WorkflowResult{
+				Reason: state.InternalServiceError,
+				Status: state.CompleteWorkflowStatus,
 			},
 		},
 	}, resp.States)


### PR DESCRIPTION
The following is how this looks when there is an error.  Eventually we can parse out Terraform specific errors but it's not necessary right now.

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/7416619/200426791-0d4e5092-1b19-4248-8705-8659ff518583.png">
