### PR TITLE
Remove workflow retries.

### DIFF
--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -40,11 +40,6 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 	id := deploymentInfo.ID
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID: id.String(),
-		// we shouldn't ever percolate failures up unless they are user errors (aka. Terraform specific)
-		// retrying indefinitely allows us to fix whatever issue that comes about without involving the user to redeploy
-		RetryPolicy: &temporal.RetryPolicy{
-			NonRetryableErrorTypes: []string{terraform.TerraformClientErrorType, terraform.PlanRejectedErrorType},
-		},
 	})
 	terraformWorkflowRequest := terraform.Request{
 		Root:         deploymentInfo.Root,

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	PlanReviewSignalName   = "planreview"
-	ScheduleToCloseTimeout = 30 * time.Minute
+	ScheduleToCloseTimeout = 24 * time.Hour
 	HeartBeatTimeout       = 1 * time.Minute
 
 	ActiveTerraformWorkflowStat  = "workflow.terraform.active"


### PR DESCRIPTION
Also increases `ScheduleStartToCloseTimeout` to 24 hours to give some time to fix any bugs that need fixing.