### PR TITLE
Filter out skipped check runs.

### DIFF
--- a/server/events/vcs/inject.go
+++ b/server/events/vcs/inject.go
@@ -23,7 +23,7 @@ func newValidChecksFilters(vcsStatusPrefix string) []ValidChecksFilter {
 		statusTitleMatcher: titleMatcher,
 	}
 	return []ValidChecksFilter{
-		SuccessConclusionFilter, applyChecksFilter,
+		SuccessConclusionFilter, SkippedConclusionFilter, applyChecksFilter,
 	}
 }
 

--- a/server/events/vcs/mergeability.go
+++ b/server/events/vcs/mergeability.go
@@ -85,6 +85,7 @@ func (c ConclusionFilter) Filter(checks []*github.CheckRun) []*github.CheckRun {
 }
 
 var SuccessConclusionFilter ConclusionFilter = "success"
+var SkippedConclusionFilter ConclusionFilter = "skipped"
 
 type MergeabilityChecker interface {
 	Check(pull *github.PullRequest, statuses []*github.RepoStatus, checks []*github.CheckRun) bool


### PR DESCRIPTION
If a check has been skipped, we shouldn't block on it for applies.