### PR TITLE
Use FileFetcherOptions to support PR/Commit type modified file fetches

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -3,6 +3,7 @@ package event
 import (
 	"bytes"
 	"context"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"time"
 
 	"github.com/runatlantis/atlantis/server/events/vcs"
@@ -100,7 +101,10 @@ func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *htt
 }
 
 func (p *CommentEventWorkerProxy) forceApply(ctx context.Context, event Comment) error {
-	rootCfgs, err := p.rootConfigBuilder.Build(ctx, event.HeadRepo, event.Pull.HeadBranch, event.Pull.HeadCommit, event.InstallationToken)
+	fileFetcherOptions := github.FileFetcherOptions{
+		PRNum: event.PullNum,
+	}
+	rootCfgs, err := p.rootConfigBuilder.Build(ctx, event.HeadRepo, event.Pull.HeadBranch, event.Pull.HeadCommit, fileFetcherOptions, event.InstallationToken)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -41,7 +42,7 @@ type deploySignaler interface {
 }
 
 type rootConfigBuilder interface {
-	Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error)
+	Build(ctx context.Context, repo models.Repo, branch string, sha string, fileFetcherOptions github.FileFetcherOptions, installationToken int64) ([]*valid.MergedProjectCfg, error)
 }
 
 type PushHandler struct {
@@ -83,7 +84,10 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 }
 
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
-	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Ref.Name, event.Sha, event.InstallationToken)
+	fileFetcherOptions := github.FileFetcherOptions{
+		Sha: event.Sha,
+	}
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, event.Repo, event.Ref.Name, event.Sha, fileFetcherOptions, event.InstallationToken)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -2,6 +2,7 @@ package event_test
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -366,6 +367,6 @@ type mockRootConfigBuilder struct {
 	error       error
 }
 
-func (r *mockRootConfigBuilder) Build(_ context.Context, _ models.Repo, _ string, _ string, _ int64) ([]*valid.MergedProjectCfg, error) {
+func (r *mockRootConfigBuilder) Build(_ context.Context, _ models.Repo, _ string, _ string, _ github.FileFetcherOptions, _ int64) ([]*valid.MergedProjectCfg, error) {
 	return r.rootConfigs, r.error
 }

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/metrics"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"github.com/uber-go/tally/v4"
 )
 
@@ -24,7 +25,7 @@ type hooksRunner interface {
 
 // fileFetcher handles being able to identify and fetch the changed files per individual commit
 type fileFetcher interface {
-	GetModifiedFilesFromCommit(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]string, error)
+	GetModifiedFiles(ctx context.Context, repo models.Repo, fileFetcherOptions github.FileFetcherOptions, installationToken int64) ([]string, error)
 }
 
 // rootFinder determines which roots were modified in a given event.
@@ -50,8 +51,8 @@ type RootConfigBuilder struct {
 	Scope           tally.Scope
 }
 
-func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
-	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, installationToken)
+func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, fileFetcherOptions github.FileFetcherOptions, installationToken int64) ([]*valid.MergedProjectCfg, error) {
+	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, fileFetcherOptions, installationToken)
 	if err != nil {
 		b.Scope.Counter(metrics.FilterErrorMetric).Inc(1)
 		return nil, err
@@ -64,7 +65,7 @@ func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch 
 	return mergedRootCfgs, nil
 }
 
-func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64) ([]*valid.MergedProjectCfg, error) {
+func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch string, sha string, fileFetcherOptions github.FileFetcherOptions, installationToken int64) ([]*valid.MergedProjectCfg, error) {
 	// Generate a new filepath location and clone repo into it
 	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, branch, sha)
 	if err != nil {
@@ -79,7 +80,7 @@ func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch 
 	}
 
 	// Fetch files modified in commit
-	modifiedFiles, err := b.FileFetcher.GetModifiedFilesFromCommit(ctx, repo, sha, installationToken)
+	modifiedFiles, err := b.FileFetcher.GetModifiedFiles(ctx, repo, fileFetcherOptions, installationToken)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding modified files: %s", modifiedFiles)
 	}

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -25,7 +25,7 @@ type hooksRunner interface {
 
 // fileFetcher handles being able to identify and fetch the changed files per individual commit
 type fileFetcher interface {
-	GetModifiedFiles(ctx context.Context, repo models.Repo, fileFetcherOptions github.FileFetcherOptions, installationToken int64) ([]string, error)
+	GetModifiedFiles(ctx context.Context, repo models.Repo, installationToken int64, fileFetcherOptions github.FileFetcherOptions) ([]string, error)
 }
 
 // rootFinder determines which roots were modified in a given event.
@@ -80,7 +80,7 @@ func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch 
 	}
 
 	// Fetch files modified in commit
-	modifiedFiles, err := b.FileFetcher.GetModifiedFiles(ctx, repo, fileFetcherOptions, installationToken)
+	modifiedFiles, err := b.FileFetcher.GetModifiedFiles(ctx, repo, installationToken, fileFetcherOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding modified files: %s", modifiedFiles)
 	}

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -146,7 +146,7 @@ type mockFileFetcher struct {
 	error error
 }
 
-func (f *mockFileFetcher) GetModifiedFiles(_ context.Context, _ models.Repo, _ github.FileFetcherOptions, _ int64) ([]string, error) {
+func (f *mockFileFetcher) GetModifiedFiles(_ context.Context, _ models.Repo, _ int64, _ github.FileFetcherOptions) ([]string, error) {
 	return nil, f.error
 }
 

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -3,6 +3,7 @@ package event_test
 import (
 	"context"
 	"errors"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"github.com/uber-go/tally/v4"
 	"testing"
 
@@ -55,7 +56,8 @@ func TestRootConfigBuilder_Success(t *testing.T) {
 	expProjectConfigs := []*valid.MergedProjectCfg{
 		&projCfg,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.NoError(t, err)
 	assert.Equal(t, expProjectConfigs, projectConfigs)
 }
@@ -66,7 +68,8 @@ func TestRootConfigBuilder_DetermineRootsError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.RootFinder = mockRootFinder
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -78,7 +81,8 @@ func TestRootConfigBuilder_ParserValidatorParseError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.ParserValidator = mockParserValidator
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -89,7 +93,8 @@ func TestRootConfigBuilder_GetModifiedFilesError(t *testing.T) {
 	rcb.FileFetcher = &mockFileFetcher{
 		error: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 }
@@ -99,7 +104,8 @@ func TestRootConfigBuilder_CloneError(t *testing.T) {
 	rcb.RepoFetcher = &mockRepoFetcher{
 		cloneError: expectedErr,
 	}
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -111,7 +117,8 @@ func TestRootConfigBuilder_HooksRunnerError(t *testing.T) {
 		error: expectedErr,
 	}
 	rcb.HooksRunner = mockHooksRunner
-	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, pushEvent.InstallationToken)
+	options := github.FileFetcherOptions{Sha: pushEvent.Sha}
+	projectConfigs, err := rcb.Build(context.Background(), pushEvent.Repo, pushEvent.Repo.DefaultBranch, pushEvent.Sha, options, pushEvent.InstallationToken)
 	assert.Error(t, err)
 	assert.Empty(t, projectConfigs)
 
@@ -139,7 +146,7 @@ type mockFileFetcher struct {
 	error error
 }
 
-func (f *mockFileFetcher) GetModifiedFilesFromCommit(_ context.Context, _ models.Repo, _ string, _ int64) ([]string, error) {
+func (f *mockFileFetcher) GetModifiedFiles(_ context.Context, _ models.Repo, _ github.FileFetcherOptions, _ int64) ([]string, error) {
 	return nil, f.error
 }
 

--- a/server/vcs/provider/github/file_fetcher.go
+++ b/server/vcs/provider/github/file_fetcher.go
@@ -78,9 +78,5 @@ func GetCommit(ctx context.Context, client *gh.Client, repo models.Repo, fileFet
 }
 
 func ListFiles(ctx context.Context, client *gh.Client, repo models.Repo, fileFetcherOptions FileFetcherOptions, listOptions gh.ListOptions) ([]*gh.CommitFile, *gh.Response, error) {
-	repositoryCommit, resp, err := client.Repositories.GetCommit(ctx, repo.Owner, repo.Name, fileFetcherOptions.Sha, &listOptions)
-	if repositoryCommit != nil {
-		return repositoryCommit.Files, resp, err
-	}
-	return nil, nil, errors.New("unable to retrieve commit files from GH commit")
+	return client.PullRequests.ListFiles(ctx, repo.Owner, repo.Name, fileFetcherOptions.PRNum, &listOptions)
 }

--- a/server/vcs/provider/github/file_fetcher.go
+++ b/server/vcs/provider/github/file_fetcher.go
@@ -35,7 +35,7 @@ func (r *RemoteFileFetcher) GetModifiedFiles(ctx context.Context, repo models.Re
 			listOptions.Page = nextPage
 		}
 
-		pageFiles, resp, err := r.getModifiedFiles(ctx, client, repo, fileFetcherOptions, listOptions)
+		pageFiles, resp, err := r.fetchFiles(ctx, client, repo, fileFetcherOptions, listOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "error fetching files")
 		}
@@ -59,7 +59,7 @@ func (r *RemoteFileFetcher) GetModifiedFiles(ctx context.Context, repo models.Re
 	return files, nil
 }
 
-func (r *RemoteFileFetcher) getModifiedFiles(ctx context.Context, client *gh.Client, repo models.Repo, fileFetcherOptions FileFetcherOptions, listOptions gh.ListOptions) ([]*gh.CommitFile, *gh.Response, error) {
+func (r *RemoteFileFetcher) fetchFiles(ctx context.Context, client *gh.Client, repo models.Repo, fileFetcherOptions FileFetcherOptions, listOptions gh.ListOptions) ([]*gh.CommitFile, *gh.Response, error) {
 	if fileFetcherOptions.Sha != "" {
 		repositoryCommit, resp, err := client.Repositories.GetCommit(ctx, repo.Owner, repo.Name, fileFetcherOptions.Sha, &listOptions)
 		if repositoryCommit != nil {

--- a/server/vcs/provider/github/file_fetcher.go
+++ b/server/vcs/provider/github/file_fetcher.go
@@ -15,7 +15,22 @@ type RemoteFileFetcher struct {
 	ClientCreator githubapp.ClientCreator
 }
 
-func (r *RemoteFileFetcher) GetModifiedFilesFromCommit(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]string, error) {
+type FileFetcherOptions struct {
+	Sha   string
+	PRNum int
+}
+
+func (r *RemoteFileFetcher) GetModifiedFiles(ctx context.Context, repo models.Repo, fileFetcherOptions FileFetcherOptions, installationToken int64) ([]string, error) {
+	if fileFetcherOptions.Sha != "" {
+		return r.getModifiedFilesFromCommit(ctx, repo, fileFetcherOptions.Sha, installationToken)
+	}
+	if fileFetcherOptions.PRNum != 0 {
+		return r.getModifiedFilesFromPR(ctx, repo, fileFetcherOptions.PRNum, installationToken)
+	}
+	return nil, errors.New("unable to process FileFetcherOptions")
+}
+
+func (r *RemoteFileFetcher) getModifiedFilesFromCommit(ctx context.Context, repo models.Repo, sha string, installationToken int64) ([]string, error) {
 	var files []string
 	nextPage := 0
 	for {
@@ -37,6 +52,43 @@ func (r *RemoteFileFetcher) GetModifiedFilesFromCommit(ctx context.Context, repo
 			return nil, fmt.Errorf("not ok status fetching repository commit: %s", resp.Status)
 		}
 		for _, f := range repositoryCommit.Files {
+			files = append(files, f.GetFilename())
+
+			// If the file was renamed, we'll want to run plan in the directory
+			// it was moved from as well.
+			if f.GetStatus() == "renamed" {
+				files = append(files, f.GetPreviousFilename())
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		nextPage = resp.NextPage
+	}
+	return files, nil
+}
+
+// GetModifiedFilesFromPR returns the names of files that were modified in the pull request
+// relative to the repo root, e.g. parent/child/file.txt.
+func (r *RemoteFileFetcher) getModifiedFilesFromPR(ctx context.Context, repo models.Repo, pullNum int, installationToken int64) ([]string, error) {
+	var files []string
+	nextPage := 0
+	for {
+		opts := gh.ListOptions{
+			PerPage: 300,
+		}
+		if nextPage != 0 {
+			opts.Page = nextPage
+		}
+		client, err := r.ClientCreator.NewInstallationClient(installationToken)
+		if err != nil {
+			return files, errors.Wrap(err, "creating installation client")
+		}
+		pageFiles, resp, err := client.PullRequests.ListFiles(ctx, repo.Owner, repo.Name, pullNum, &opts)
+		if err != nil {
+			return files, err
+		}
+		for _, f := range pageFiles {
 			files = append(files, f.GetFilename())
 
 			// If the file was renamed, we'll want to run plan in the directory


### PR DESCRIPTION
We can't just rely on the GetCommit GH api call for force applies since we need to take into account the entire PR history when determining the set of changes that may contain terraform files.