### PR TITLE
Auto-approve empty plans for applying.

### DIFF
--- a/server/neptune/workflows/activities/terraform/summary.go
+++ b/server/neptune/workflows/activities/terraform/summary.go
@@ -18,7 +18,7 @@ type PlanSummary struct {
 }
 
 func (s PlanSummary) IsEmpty() bool {
-	return len(s.Creations) == 0 && len(s.Deletions) == 0 &&  len(s.Updates) == 0
+	return len(s.Creations) == 0 && len(s.Deletions) == 0 && len(s.Updates) == 0
 }
 
 // Generates a super simple plan summary with changes grouped by action

--- a/server/neptune/workflows/activities/terraform/summary.go
+++ b/server/neptune/workflows/activities/terraform/summary.go
@@ -17,6 +17,10 @@ type PlanSummary struct {
 	Updates   []ResourceSummary
 }
 
+func (s PlanSummary) IsEmpty() bool {
+	return len(s.Creations) == 0 && len(s.Deletions) == 0 &&  len(s.Updates) == 0
+}
+
 // Generates a super simple plan summary with changes grouped by action
 // creation, deletion, update.
 // changes are only represented using addresses for now.

--- a/server/neptune/workflows/activities/terraform/summary_test.go
+++ b/server/neptune/workflows/activities/terraform/summary_test.go
@@ -57,3 +57,13 @@ func TestSummary_replace(t *testing.T) {
 		},
 	}, summary)
 }
+
+func TestSummary_empty(t *testing.T) {
+	plan := "{\"format_version\": \"1.0\",\"resource_changes\":[{\"change\":{\"actions\":[\"noop\"]},\"address\":\"type.resource_replace\"}]}"
+
+	summary, err := terraform.NewPlanSummaryFromJSON([]byte(plan))
+	assert.NoError(t, err)
+
+	assert.Equal(t, terraform.PlanSummary{}, summary)
+	assert.True(t, summary.IsEmpty())
+}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -151,11 +151,11 @@ func (r *Runner) Plan(ctx workflow.Context, root *terraform.LocalRoot, serverURL
 	return response, nil
 }
 
-func (r *Runner) waitForPlanReview(ctx workflow.Context, root *terraform.LocalRoot) PlanStatus {
+func (r *Runner) waitForPlanReview(ctx workflow.Context, root *terraform.LocalRoot, planSummary terraform.PlanSummary) PlanStatus {
 	// Wait for plan review signal
 	var planReview PlanReviewSignalRequest
 
-	if root.Root.Plan.Approval == terraform.AutoApproval {
+	if root.Root.Plan.Approval == terraform.AutoApproval || planSummary.IsEmpty() {
 		return Approved
 	}
 
@@ -170,7 +170,7 @@ func (r *Runner) waitForPlanReview(ctx workflow.Context, root *terraform.LocalRo
 	return planReview.Status
 }
 
-func (r *Runner) Apply(ctx workflow.Context, root *terraform.LocalRoot, serverURL fmt.Stringer, planFile string) error {
+func (r *Runner) Apply(ctx workflow.Context, root *terraform.LocalRoot, serverURL fmt.Stringer, planResponse activities.TerraformPlanResponse) error {
 	jobID, err := sideeffect.GenerateUUID(ctx)
 
 	if err != nil {
@@ -182,7 +182,7 @@ func (r *Runner) Apply(ctx workflow.Context, root *terraform.LocalRoot, serverUR
 		return errors.Wrap(err, "initializing job")
 	}
 
-	planStatus := r.waitForPlanReview(ctx, root)
+	planStatus := r.waitForPlanReview(ctx, root, planResponse.Summary)
 
 	if planStatus == Rejected {
 		if err := r.Store.UpdateApplyJobWithStatus(state.RejectedJobStatus); err != nil {
@@ -197,7 +197,7 @@ func (r *Runner) Apply(ctx workflow.Context, root *terraform.LocalRoot, serverUR
 		return newUpdateJobError(err, "unable to update job with success status")
 	}
 
-	err = r.JobRunner.Apply(ctx, root, jobID.String(), planFile)
+	err = r.JobRunner.Apply(ctx, root, jobID.String(), planResponse.PlanFile)
 	if err != nil {
 
 		if err := r.Store.UpdateApplyJobWithStatus(state.FailedJobStatus, state.UpdateOptions{
@@ -275,7 +275,7 @@ func (r *Runner) run(ctx workflow.Context) error {
 		return r.toExternalError(err, "running plan job")
 	}
 
-	if err := r.Apply(ctx, root, response.ServerURL, planResponse.PlanFile); err != nil {
+	if err := r.Apply(ctx, root, response.ServerURL, planResponse); err != nil {
 		return r.toExternalError(err, "running apply job")
 	}
 	r.MetricsHandler.Counter(SuccessTerraformWorkflowStat).Inc(1)


### PR DESCRIPTION
Pretty self explanatory.  A user shouldn't have to approve an empty plan or be blocked by one.