### PR TITLE
Fix working state init.

### DIFF
--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -153,6 +153,8 @@ func (w *Worker) Work(ctx workflow.Context) {
 	for {
 		if w.Queue.IsEmpty() {
 			w.state = WaitingWorkerState
+		} else {
+			w.state = WorkingWorkerState
 		}
 
 		selector.Select(ctx)
@@ -220,7 +222,6 @@ func (w *Worker) awaitWork(ctx workflow.Context) workflow.Future {
 }
 
 func (w *Worker) deploy(ctx workflow.Context, latestDeployment *deployment.Info) (*deployment.Info, error) {
-	w.state = WorkingWorkerState
 	msg, err := w.Queue.Pop()
 	if err != nil {
 		return nil, errors.Wrap(err, "popping off queue")


### PR DESCRIPTION
If a new workflow is started when the queue is locked, `WorkingWorkerState` will never be set since the item won't be popped.  This means that the workflow just stops after an hour and we drop whatever is in the queue.