### PR TITLE
Fix hearbeating ctx.

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -211,7 +211,7 @@ type FetchRootResponse struct {
 // FetchRoot fetches a link to the archive URL using the GH client, processes that URL into a download URL that the
 // go-getter library can use, and then go-getter to download/extract files/subdirs within the root path to the destinationPath.
 func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootRequest) (FetchRootResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
+	cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 
 	deployBasePath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)

--- a/server/neptune/workflows/activities/temporal/heartbeat.go
+++ b/server/neptune/workflows/activities/temporal/heartbeat.go
@@ -10,17 +10,10 @@ const HeartbeatTimeout = 10 * time.Second
 
 // Adapted from dynajoe/temporal-terraform-demo:
 // https://github.com/dynajoe/temporal-terraform-demo/blob/b468ac13cd9400ec0ffeb1b96eb8135e4b36d8ee/heartbeat/heartbeat.go#L10
-func StartHeartbeat(ctx context.Context, frequency time.Duration) (context.Context, func()) {
+func StartHeartbeat(ctx context.Context, frequency time.Duration) func() {
 	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		select {
-		case <-activity.GetWorkerStopChannel(ctx):
-		case <-ctx.Done():
-		}
-		cancel()
-	}()
 	go startHeartbeatTicks(ctx, frequency)
-	return ctx, cancel
+	return cancel
 }
 
 func startHeartbeatTicks(ctx context.Context, duration time.Duration) {

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -106,7 +106,7 @@ type TerraformInitResponse struct {
 }
 
 func (t *terraformActivities) TerraformInit(ctx context.Context, request TerraformInitRequest) (TerraformInitResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
+	cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	// Resolve the tf version to be used for this operation
 	tfVersion, err := t.resolveVersion(request.TfVersion)
@@ -163,7 +163,7 @@ type TerraformPlanResponse struct {
 }
 
 func (t *terraformActivities) TerraformPlan(ctx context.Context, request TerraformPlanRequest) (TerraformPlanResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
+	cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {
@@ -250,7 +250,7 @@ type TerraformApplyResponse struct {
 }
 
 func (t *terraformActivities) TerraformApply(ctx context.Context, request TerraformApplyRequest) (TerraformApplyResponse, error) {
-	ctx, cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
+	cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 	tfVersion, err := t.resolveVersion(request.TfVersion)
 	if err != nil {


### PR DESCRIPTION
The original implementation seems wrong in a couple ways:
1. We shouldn't be listening to the worker stop channel directly since that bypasses the WorkerStopTimeout
2. The heartbeat ctx shouldn't be used for activity constructs since the hearbeat ctx has it's own cancellation terms.  Our tf activity in general should only be canceled by temporal itself.
3. The heartbeat function doesn't need to listen for ctx cancellation at all since it's created from the parent which allows it to inherit cancellation status