### PR TITLE
Fix Close Job Activity Failures on worker restart

### DIFF
--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -111,9 +111,10 @@ func (m *InMemoryStore) Close(ctx context.Context, jobID string, status JobStatu
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	// Error out when job dne
+	// Job is only added to the in memory store when it is streamed throught the  log streaming UI,
+	// so no need to cleanup if not in memory
 	if m.jobs[jobID] == nil {
-		return fmt.Errorf("job: %s does not exist", jobID)
+		return nil
 	}
 
 	// Error when job is already set to complete

--- a/server/neptune/temporalworker/job/store_test.go
+++ b/server/neptune/temporalworker/job/store_test.go
@@ -270,14 +270,12 @@ func TestJobStore_Close(t *testing.T) {
 		assert.Empty(t, gotJob.Output)
 	})
 
-	t.Run("error when job does not exist", func(t *testing.T) {
+	t.Run("no error when job does not exist", func(t *testing.T) {
 		storageBackend := &testStorageBackend{}
 		jobStore := job.NewTestStorageBackedStore(logging.NewNoopCtxLogger(t), storageBackend, map[string]*job.Job{})
-		expectedErrString := fmt.Sprintf("job: %s does not exist", jobID)
 
 		err := jobStore.Close(context.TODO(), jobID, job.Complete)
-		assert.EqualError(t, err, expectedErrString)
-
+		assert.Nil(t, err)
 	})
 }
 

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 
 	"github.com/pkg/errors"
@@ -9,6 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	logger "github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -56,6 +58,7 @@ func (r *JobRunner) Plan(ctx workflow.Context, localRoot *terraform.LocalRoot, j
 		TfVersion: localRoot.Root.TfVersion,
 		JobID:     jobID,
 	}
+
 	defer r.closeTerraformJob(jobCtx)
 
 	var resp activities.TerraformPlanResponse
@@ -193,6 +196,14 @@ func (r *JobRunner) runOptionalSteps(ctx *ExecutionContext, localRoot *terraform
 }
 
 func (r *JobRunner) closeTerraformJob(ctx *ExecutionContext) {
+	// create a new disconnected ctx since we want this run even in the event of
+	// cancellation
+	if temporal.IsCanceledError(ctx.Err()) {
+		var cancel workflow.CancelFunc
+		ctx, cancel = workflow.NewDisconnectedContext(ctx)
+		defer cancel()
+	}
+
 	err := workflow.ExecuteActivity(ctx, r.Activity.CloseJob, activities.CloseJobRequest{
 		JobID: ctx.JobID,
 	}).Get(ctx, nil)


### PR DESCRIPTION
Since we run the `closeJob` function in it's own activity, it is possible that it tries to close a non existent job from memory on worker restart. So, we check if the job exists in memory before starting close job. If it does not exist, we can assume it was closed on server shutdown 

https://github.com/lyft/atlantis/blob/fd838f3d3b0c7092c5e515374cb4ffcf65aab1f4/server/neptune/temporalworker/server.go#L224-L231 