### PR TITLE
Enable Auto deploys from refactorator bots

### DIFF
--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -51,10 +51,11 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 		},
 	})
 	terraformWorkflowRequest := terraform.Request{
-		Root:         deploymentInfo.Root,
-		Repo:         deploymentInfo.Repo,
-		DeploymentID: id.String(),
-		Revision:     deploymentInfo.Revision,
+		Root:           deploymentInfo.Root,
+		Repo:           deploymentInfo.Repo,
+		DeploymentID:   id.String(),
+		Revision:       deploymentInfo.Revision,
+		InitiatingUser: deploymentInfo.InitiatingUser,
 	}
 
 	future := workflow.ExecuteChildWorkflow(ctx, r.Workflow, terraformWorkflowRequest)

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Request struct {
-	Root         terraform.Root
-	Repo         github.Repo
-	DeploymentID string
-	Revision     string
+	Root           terraform.Root
+	Repo           github.Repo
+	InitiatingUser github.User
+	DeploymentID   string
+	Revision       string
 }
 
 const (


### PR DESCRIPTION
Refactorator currently uses 3 different github bots according to their source code: 
https://github.com/lyft/refactorator/blob/6ee892217b5068d5212c6ed585620c5130960569/refactorator/github.py#L55-L58

In order to auto deploy requests from a refactorator bot, we need to propagate the initiating user information to the terraform workflow which matches the name against the `refactoratorBots` list to allow auto-deploys for a refactorator bot. 