### PR TITLE
Add review gate timeout.

### DIFF
--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -6,6 +6,7 @@
 {{if .InternalError }}
 ## Deployment Error :boom:
 :point_right: An error has been encountered from either of the following:
+* The Deploy timed out after 7 days without approval
 * A Terraform operation failed
 * A Terraform apply was rejected by a user
 * There was a platform issue

--- a/server/neptune/workflows/internal/terraform/gate/review.go
+++ b/server/neptune/workflows/internal/terraform/gate/review.go
@@ -1,0 +1,73 @@
+package gate
+
+import (
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	PlanReviewSignalName = "planreview"
+	PlanReviewTimerStat  = "workflow.terraform.planreview"
+)
+
+type PlanStatus int
+type PlanReviewSignalRequest struct {
+	Status PlanStatus
+
+	// TODO: Output this info to the checks UI
+	User string
+}
+
+const (
+	Approved PlanStatus = iota
+	Rejected
+)
+
+// Review waits for a plan review signal or a timeout to occur and returns an associated status.
+type Review struct {
+	MetricsHandler client.MetricsHandler
+	Timeout        time.Duration
+}
+
+func (r *Review) Await(ctx workflow.Context, root terraform.Root, planSummary terraform.PlanSummary) PlanStatus {
+	waitStartTime := time.Now()
+	defer func() {
+		r.MetricsHandler.Timer(PlanReviewTimerStat).Record(time.Since(waitStartTime))
+	}()
+
+	if root.Plan.Approval == terraform.AutoApproval || planSummary.IsEmpty() {
+		return Approved
+	}
+
+	ch := workflow.GetSignalChannel(ctx, PlanReviewSignalName)
+	selector := temporal.SelectorWithTimeout{
+		Selector: workflow.NewSelector(ctx),
+	}
+
+	var planReview PlanReviewSignalRequest
+	selector.AddReceive(ch, func(c workflow.ReceiveChannel, more bool) {
+		ch.Receive(ctx, &planReview)
+	})
+
+	var timedOut bool
+	selector.AddTimeout(ctx, r.Timeout, func(f workflow.Future) {
+		if err := f.Get(ctx, nil); err != nil {
+			logger.Warn(ctx, "Error timing out selector.  This is possibly due to a cancellation signal. ", context.ErrKey, err)
+		}
+		timedOut = true
+	})
+
+	selector.Select(ctx)
+
+	if timedOut {
+		return Rejected
+	}
+
+	return planReview.Status
+}

--- a/server/neptune/workflows/internal/terraform/gate/review_test.go
+++ b/server/neptune/workflows/internal/terraform/gate/review_test.go
@@ -1,0 +1,78 @@
+package gate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/gate"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type res struct {
+	Status gate.PlanStatus
+}
+
+type req struct {
+	PlanSummary terraform.PlanSummary
+}
+
+func testReviewWorkflow(ctx workflow.Context, r req) (res, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 30 * time.Second,
+	})
+	review := gate.Review{
+		Timeout:        10 * time.Second,
+		MetricsHandler: client.MetricsNopHandler,
+	}
+
+	status := review.Await(ctx, terraform.Root{
+		Plan: terraform.PlanJob{
+			Approval: terraform.ManualApproval,
+		},
+	}, r.PlanSummary)
+
+	return res{
+		Status: status,
+	}, nil
+}
+
+func TestAwait_timesOut(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(testReviewWorkflow, req{PlanSummary: terraform.PlanSummary{
+		Updates: []terraform.ResourceSummary{
+			{
+				Address: "addr",
+			},
+		},
+	}})
+
+	var r res
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r, res{
+		Status: gate.Rejected,
+	})
+}
+
+func TestAwait_approvesEmptyPlan(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(testReviewWorkflow, req{})
+
+	var r res
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r, res{
+		Status: gate.Approved,
+	})
+
+}

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/sdk/client"
 	"net/url"
 	"testing"
 	"time"
+
+	"go.temporal.io/sdk/client"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	terraformModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/gate"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -104,7 +106,6 @@ func (r *jobRunner) Plan(ctx workflow.Context, localRoot *terraformModel.LocalRo
 type request struct {
 	// bool since our errors are not serializable using json
 	ShouldErrorDuringJobUpdate bool
-	EmptyPlan                  bool
 }
 
 type response struct {
@@ -127,16 +128,6 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 		expectedError: expectedError,
 	}
 
-	if !req.EmptyPlan {
-		runner.planSummary = terraformModel.PlanSummary{
-			Creations: []terraformModel.ResourceSummary{
-				{
-					Address: "someaddress",
-				},
-			},
-		}
-	}
-
 	var s []state.Workflow
 
 	runnerReq := terraform.Request{
@@ -146,6 +137,10 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 	}
 
 	subject := &terraform.Runner{
+		ReviewGate: &gate.Review{
+			Timeout:        30 * time.Second,
+			MetricsHandler: client.MetricsNopHandler,
+		},
 		GithubActivities:    gAct,
 		TerraformActivities: tAct,
 		Request:             runnerReq,
@@ -255,8 +250,8 @@ func TestSuccess(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
-			Status: terraform.Approved,
+		env.SignalWorkflow("planreview", gate.PlanReviewSignalRequest{
+			Status: gate.Approved,
 		})
 	}, 5*time.Second)
 
@@ -358,39 +353,6 @@ func TestSuccess(t *testing.T) {
 	}, resp.States)
 }
 
-func TestSuccess_emptyPlan(t *testing.T) {
-	var suite testsuite.WorkflowTestSuite
-	env := suite.NewTestWorkflowEnvironment()
-	ga := &githubActivities{}
-	ta := &terraformActivities{}
-	env.RegisterActivity(ga)
-	env.RegisterActivity(ta)
-
-	// set activity expectations
-	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
-		Repo:         testGithubRepo,
-		Root:         testLocalRoot.Root,
-		DeploymentID: testDeploymentID,
-	}).Return(activities.FetchRootResponse{
-		LocalRoot:       testLocalRoot,
-		DeployDirectory: DeployDir,
-	}, nil)
-	env.OnActivity(ta.Cleanup, mock.Anything, activities.CleanupRequest{
-		DeployDirectory: DeployDir,
-	}).Return(activities.CleanupResponse{}, nil)
-
-	// execute workflow
-	env.ExecuteWorkflow(testTerraformWorkflow, request{EmptyPlan: true})
-	assert.True(t, env.IsWorkflowCompleted())
-
-	var resp response
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	// assert results are expected
-	env.AssertExpectations(t)
-}
-
 func TestUpdateJobError(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
@@ -460,8 +422,8 @@ func TestPlanRejection(t *testing.T) {
 
 	// send rejection of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
-			Status: terraform.Rejected,
+		env.SignalWorkflow("planreview", gate.PlanReviewSignalRequest{
+			Status: gate.Rejected,
 		})
 	}, 5*time.Second)
 
@@ -595,8 +557,8 @@ func TestCleanupErrorReturnsNoError(t *testing.T) {
 
 	// send approval of plan
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("planreview", terraform.PlanReviewSignalRequest{
-			Status: terraform.Approved,
+		env.SignalWorkflow("planreview", gate.PlanReviewSignalRequest{
+			Status: gate.Approved,
 		})
 	}, 5*time.Second)
 

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -90,7 +90,6 @@ func (a *terraformActivities) GetWorkerInfo(ctx context.Context) (*activities.Ge
 
 type jobRunner struct {
 	expectedError error
-	planSummary   terraformModel.PlanSummary
 }
 
 func (r *jobRunner) Apply(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, planFile string) error {
@@ -99,7 +98,13 @@ func (r *jobRunner) Apply(ctx workflow.Context, localRoot *terraformModel.LocalR
 
 func (r *jobRunner) Plan(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string) (activities.TerraformPlanResponse, error) {
 	return activities.TerraformPlanResponse{
-		Summary: r.planSummary,
+		Summary: terraformModel.PlanSummary{
+			Updates: []terraformModel.ResourceSummary{
+				{
+					Address: "addr",
+				},
+			},
+		},
 	}, r.expectedError
 }
 

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -2,20 +2,21 @@ package workflows
 
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/gate"
 	"go.temporal.io/sdk/workflow"
 )
 
 // Export anything that callers need such as requests, signals, etc.
 type TerraformRequest = terraform.Request
 
-type TerraformPlanReviewSignalRequest = terraform.PlanReviewSignalRequest
+type TerraformPlanReviewSignalRequest = gate.PlanReviewSignalRequest
 
-type TerraformPlanReviewStatus = terraform.PlanStatus
+type TerraformPlanReviewStatus = gate.PlanStatus
 
-const ApprovedPlanReviewStatus = terraform.Approved
-const RejectedPlanReviewStatus = terraform.Rejected
+const ApprovedPlanReviewStatus = gate.Approved
+const RejectedPlanReviewStatus = gate.Rejected
 
-const TerraformPlanReviewSignalName = terraform.PlanReviewSignalName
+const TerraformPlanReviewSignalName = gate.PlanReviewSignalName
 
 func Terraform(ctx workflow.Context, request TerraformRequest) error {
 	return terraform.Workflow(ctx, request)


### PR DESCRIPTION
By default, we will reject applies that don't have manual approval within a week.  For now this will ensure that some level of drain rate on in progress workflows, allowing us to roll out new versions of code.