### PR TITLE
Filter out roots where the directory does not exist

### DIFF
--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -32,7 +32,7 @@ type fileFetcher interface {
 type rootFinder interface {
 	// FindRoots returns the list of roots that were modified
 	// based on modifiedFiles and the repo's config.
-	FindRoots(modifiedFiles []string, config valid.RepoCfg) ([]valid.Project, error)
+	FindRoots(ctx context.Context, config valid.RepoCfg, absRepoDir string, modifiedFiles []string) ([]valid.Project, error)
 }
 
 // parserValidator config builds repo specific configurations
@@ -96,7 +96,7 @@ func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch 
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", config.AtlantisYAMLFilename)
 	}
-	matchingRoots, err := b.RootFinder.FindRoots(modifiedFiles, repoCfg)
+	matchingRoots, err := b.RootFinder.FindRoots(ctx, repoCfg, repoDir, modifiedFiles)
 	if err != nil {
 		return nil, errors.Wrap(err, "determining roots")
 	}

--- a/server/neptune/gateway/event/root_config_builder_test.go
+++ b/server/neptune/gateway/event/root_config_builder_test.go
@@ -155,7 +155,7 @@ type mockRootFinder struct {
 	error          error
 }
 
-func (m *mockRootFinder) FindRoots(_ []string, _ valid.RepoCfg) ([]valid.Project, error) {
+func (m *mockRootFinder) FindRoots(_ context.Context, _ valid.RepoCfg, _ string, _ []string) ([]valid.Project, error) {
 	return m.ConfigProjects, m.error
 }
 

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -282,7 +282,7 @@ func NewServer(config Config) (*Server, error) {
 		RepoFetcher:     repoFetcher,
 		HooksRunner:     hooksRunner,
 		ParserValidator: &event.ParserValidator{GlobalCfg: globalCfg},
-		RootFinder:      &event.RepoRootFinder{},
+		RootFinder:      &event.RepoRootFinder{Logger: ctxLogger},
 		FileFetcher:     &github.RemoteFileFetcher{ClientCreator: clientCreator},
 		GlobalCfg:       globalCfg,
 		Logger:          ctxLogger,


### PR DESCRIPTION
Extra check to confirm that we don't attempt to use a root that was misconfigured to exist when there isn't a corresponding directory path.