### PR TITLE
Add timeout to check run UI

### DIFF
--- a/server/neptune/workflows/activities/github/checks.go
+++ b/server/neptune/workflows/activities/github/checks.go
@@ -49,6 +49,7 @@ type PlanReviewActionType string
 const (
 	CheckRunSuccess CheckRunState = "success"
 	CheckRunFailure CheckRunState = "failure"
+	CheckRunTimeout CheckRunState = "timed_out"
 	CheckRunPending CheckRunState = "in_progress"
 	CheckRunQueued  CheckRunState = "queued"
 	CheckRunUnknown CheckRunState = ""

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -21,13 +21,17 @@ type checkrunTemplateData struct {
 	ApplyStatus   string
 	ApplyLogURL   string
 	InternalError bool
+	Timedout      bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	planStatus, planLogURL := getJobStatusAndOutput(workflowState.Plan)
 	applyStatus, applyLogURL := getJobStatusAndOutput(workflowState.Apply)
 
+	// we can probably pass in the completion reason but i like doing all the boolean
+	// checking here if we can instead of in the template.
 	internalError := workflowState.Result.Reason == state.InternalServiceError
+	timedOut := workflowState.Result.Reason == state.TimedOutError
 
 	return renderTemplate(checkrunTemplate, checkrunTemplateData{
 		PlanStatus:    planStatus,
@@ -35,6 +39,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 		ApplyStatus:   applyStatus,
 		ApplyLogURL:   applyLogURL,
 		InternalError: internalError,
+		Timedout:      timedOut,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -21,7 +21,7 @@ type checkrunTemplateData struct {
 	ApplyStatus   string
 	ApplyLogURL   string
 	InternalError bool
-	Timedout      bool
+	TimedOut      bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -39,7 +39,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 		ApplyStatus:   applyStatus,
 		ApplyLogURL:   applyLogURL,
 		InternalError: internalError,
-		Timedout:      timedOut,
+		TimedOut:      timedOut,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -17,6 +17,6 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 {{end}}
 {{if .TimedOut }}
 ## Timeout :clock1:
-:point_right: One more more operations has timed out. It's possible that a terraform operation is still making progress, this can be confirmed by checking the logs above. However,
+:point_right: One or more operations has timed out. It's possible that a terraform operation is still making progress, this can be confirmed by checking the logs above. However,
 this deployment will need to be retried for this check to go green.
 {{end}}

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -15,7 +15,7 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 
 **Note: If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.**
 {{end}}
-{{if .Timedout }}
+{{if .TimedOut }}
 ## Timeout :clock1:
 :point_right: One more more operations has timed out. It's possible that a terraform operation is still making progress, this can be confirmed by checking the logs above. However,
 this deployment will need to be retried for this check to go green.

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -15,3 +15,8 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 
 **Note: If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.**
 {{end}}
+{{if .Timedout }}
+## Timeout :clock1:
+:point_right: One more more operations has timed out. It's possible that a terraform operation is still making progress, this can be confirmed by checking the logs above. However,
+this deployment will need to be retried for this check to go green.
+{{end}}

--- a/server/neptune/workflows/activities/temporal/heartbeat.go
+++ b/server/neptune/workflows/activities/temporal/heartbeat.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const HeartbeatTimeout = 10 * time.Second
+const HeartbeatTimeout = 5 * time.Second
 
 // Adapted from dynajoe/temporal-terraform-demo:
 // https://github.com/dynajoe/temporal-terraform-demo/blob/b468ac13cd9400ec0ffeb1b96eb8135e4b36d8ee/heartbeat/heartbeat.go#L10

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -128,5 +128,9 @@ func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState 
 		return github.CheckRunSuccess
 	}
 
+	if workflowState.Result.Reason == state.TimedOutError {
+		return github.CheckRunTimeout
+	}
+
 	return github.CheckRunFailure
 }

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -225,6 +225,33 @@ func TestStateReceive(t *testing.T) {
 				},
 				Apply: &state.Job{
 					Output:    jobOutput,
+					Status:    state.FailedJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.TimedOutError,
+				},
+			},
+			ExpectedCheckRunState: github.CheckRunTimeout,
+			ExpectedAuditJobRequest: &activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
 					Status:    state.SuccessJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -18,7 +18,6 @@ type Request struct {
 const (
 	PlanRejectedErrorType    = "PlanRejectedError"
 	UpdateJobErrorType       = "UpdateJobError"
-	TerraformClientErrorType = "TerraformClientError"
 )
 
 type ExternalError struct {

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -16,8 +16,8 @@ type Request struct {
 }
 
 const (
-	PlanRejectedErrorType    = "PlanRejectedError"
-	UpdateJobErrorType       = "UpdateJobError"
+	PlanRejectedErrorType = "PlanRejectedError"
+	UpdateJobErrorType    = "UpdateJobError"
 )
 
 type ExternalError struct {

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -31,6 +31,7 @@ const (
 	UnknownCompletionReason WorkflowCompletionReason = iota
 	SuccessfulCompletionReason
 	InternalServiceError
+	TimedOutError
 )
 
 type JobOutput struct {


### PR DESCRIPTION
I'm doing a few other things here:
* Increase the heartbeat frequency so within the span of 1 minute we have 12 chances to not timeout, vs. 6.  
* Do not retry heartbeat timeouts on apply errors, we don't want two concurrent applies that result in some state lock error
* If we do timeout, at least we can update the UI with this info for users so it's a bit more informational.

TODO:

- [ ] testing