### PR TITLE
Add instrumentation to Job Storage Backend in Neptune

### DIFF
--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/storage"
+	"github.com/uber-go/tally/v4"
 )
 
 type JobStatus int //nolint:revive // avoiding refactor while adding linter action
@@ -32,13 +33,13 @@ type Store interface {
 	Cleanup(ctx context.Context) error
 }
 
-func NewStorageBackedStore(jobStoreConfig valid.StoreConfig, logger logging.Logger) (*StorageBackendJobStore, error) {
+func NewStorageBackendStore(jobStoreConfig valid.StoreConfig, scope tally.Scope, logger logging.Logger) (*StorageBackendJobStore, error) {
 	stowClient, err := storage.NewClient(jobStoreConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing stow client")
 	}
 
-	storageBackend, err := NewStorageBackend(stowClient, logger)
+	storageBackend, err := NewStorageBackend(stowClient, scope, logger)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing storage backend")
 	}
@@ -178,7 +179,6 @@ func (s *StorageBackendJobStore) Close(ctx context.Context, jobID string, status
 	job, err := s.InMemoryStore.Get(ctx, jobID)
 	if err != nil || job == nil {
 		return errors.Wrapf(err, "retrieving job: %s from memory store", jobID)
-
 	}
 
 	ok, err := s.storageBackend.Write(ctx, jobID, job.Output)

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -74,7 +74,7 @@ func NewServer(config *config.Config) (*Server, error) {
 	}
 
 	// Build dependencies required for output handler and jobs controller
-	jobStore, err := job.NewStorageBackedStore(config.JobConfig, config.CtxLogger)
+	jobStore, err := job.NewStorageBackendStore(config.JobConfig, scope.SubScope("job.store"), config.CtxLogger)
 	if err != nil {
 		return nil, errors.Wrapf(err, "initializing job store")
 	}


### PR DESCRIPTION
This PR adds the following metrics to the jobs storage backend in Neptune. `JobReadExecutionFailure` metric will be used to create alarms when we can't find logs in s3.    


Reading from storage backend
```
production.app.atlantis.job.store.backend_storage.read.execution_failure
production.app.atlantis.job.store.backend_storage.read.execution_time
```

Writing to storage backend
```
production.app.atlantis.job.store.backend_storage.write.execution_failure
production.app.atlantis.job.store.backend_storage.write.execution_time
```