### PR TITLE
Create initial policy filter logic

### DIFF
--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -1,0 +1,41 @@
+package events
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type prReviewsFetcher interface {
+	ListApprovalReviewers(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error)
+}
+
+type ApprovedPolicyFilter struct {
+	//TODO: remove in favor of an in-memory cache of owners
+	GlobalCfg        valid.GlobalCfg
+	PRReviewsFetcher prReviewsFetcher
+}
+
+// Filter performs an all-or-nothing filter against failed policies for now. If PR reviewer is a global policy owner,
+// all policies will pass. TODO: This will change to make filter decisions for each failed policy individually.
+func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error) {
+	// Skip GH API calls if no policies failed
+	if len(failedPolicies) == 0 {
+		return failedPolicies, nil
+	}
+
+	// Fetch reviewers who approved the PR
+	approvedReviewers, err := p.PRReviewsFetcher.ListApprovalReviewers(ctx, installationToken, repo, prNum)
+	if err != nil {
+		return failedPolicies, errors.Wrap(err, "failed to fetch GH PR reviews")
+	}
+
+	// TODO: check each policy set separately when per-policy owners configuration is implemented
+	for _, reviewer := range approvedReviewers {
+		if p.GlobalCfg.PolicySets.IsOwner(reviewer) {
+			return nil, nil
+		}
+	}
+	return failedPolicies, nil
+}

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -1,0 +1,126 @@
+package events_test
+
+import (
+	"context"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	ownerA     = "A"
+	ownerB     = "B"
+	ownerC     = "C"
+	policyName = "some-policy"
+)
+
+func TestFilter_Approved(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		approvers: []string{ownerB},
+	}
+	globalCfg := valid.GlobalCfg{
+		PolicySets: valid.PolicySets{
+			Owners: valid.PolicyOwners{
+				Users: []string{ownerA, ownerB, ownerC},
+			},
+		},
+	}
+	policyFilter := events.ApprovedPolicyFilter{
+		GlobalCfg:        globalCfg,
+		PRReviewsFetcher: reviewFetcher,
+	}
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName},
+	}
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.NoError(t, err)
+	assert.True(t, reviewFetcher.isCalled)
+	assert.Empty(t, filteredPolicies)
+}
+
+func TestFilter_NotApproved(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		approvers: []string{ownerB},
+	}
+	globalCfg := valid.GlobalCfg{
+		PolicySets: valid.PolicySets{
+			Owners: valid.PolicyOwners{
+				Users: []string{ownerA, ownerC},
+			},
+		},
+	}
+	policyFilter := events.ApprovedPolicyFilter{
+		GlobalCfg:        globalCfg,
+		PRReviewsFetcher: reviewFetcher,
+	}
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName},
+	}
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.NoError(t, err)
+	assert.True(t, reviewFetcher.isCalled)
+	assert.Equal(t, failedPolicies, filteredPolicies)
+}
+
+func TestFilter_NoFailedPolicies(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		approvers: []string{ownerB},
+	}
+	globalCfg := valid.GlobalCfg{
+		PolicySets: valid.PolicySets{
+			Owners: valid.PolicyOwners{
+				Users: []string{ownerA, ownerB, ownerC},
+			},
+		},
+	}
+	policyFilter := events.ApprovedPolicyFilter{
+		GlobalCfg:        globalCfg,
+		PRReviewsFetcher: reviewFetcher,
+	}
+	var failedPolicies []valid.PolicySet
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.NoError(t, err)
+	assert.False(t, reviewFetcher.isCalled)
+	assert.Empty(t, filteredPolicies)
+}
+
+func TestFilter_FailedPRReviewFetch(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		error: assert.AnError,
+	}
+	globalCfg := valid.GlobalCfg{
+		PolicySets: valid.PolicySets{
+			Owners: valid.PolicyOwners{
+				Users: []string{ownerA, ownerB, ownerC},
+			},
+		},
+	}
+	policyFilter := events.ApprovedPolicyFilter{
+		GlobalCfg:        globalCfg,
+		PRReviewsFetcher: reviewFetcher,
+	}
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName},
+	}
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.Error(t, err)
+	assert.True(t, reviewFetcher.isCalled)
+	assert.Equal(t, failedPolicies, filteredPolicies)
+}
+
+type mockReviewFetcher struct {
+	approvers []string
+	error     error
+	isCalled  bool
+}
+
+func (f *mockReviewFetcher) ListApprovalReviewers(_ context.Context, _ int64, _ models.Repo, _ int) ([]string, error) {
+	f.isCalled = true
+	return f.approvers, f.error
+}

--- a/server/vcs/provider/github/reviewer_fetcher.go
+++ b/server/vcs/provider/github/reviewer_fetcher.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"net/http"
+)
+
+const ApprovalState = "APPROVED"
+
+type PRReviewerFetcher struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (r *PRReviewerFetcher) ListApprovalReviewers(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
+	client, err := r.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating installation client")
+	}
+
+	var approvalReviewers []string
+	nextPage := 0
+	for {
+		listOptions := gh.ListOptions{
+			PerPage: 300,
+		}
+		if nextPage != 0 {
+			listOptions.Page = nextPage
+		}
+
+		reviews, resp, err := client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
+		if err != nil {
+			return nil, errors.Wrap(err, "error fetching files")
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("not ok status fetching files: %s", resp.Status)
+		}
+		for _, review := range reviews {
+			if review.GetState() == ApprovalState && review.GetUser() != nil {
+				approvalReviewers = append(approvalReviewers, review.GetUser().GetLogin())
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		nextPage = resp.NextPage
+	}
+	return approvalReviewers, nil
+}

--- a/server/vcs/provider/github/reviewer_fetcher.go
+++ b/server/vcs/provider/github/reviewer_fetcher.go
@@ -26,18 +26,16 @@ func (r *PRReviewerFetcher) ListApprovalReviewers(ctx context.Context, installat
 	nextPage := 0
 	for {
 		listOptions := gh.ListOptions{
-			PerPage: 300,
+			PerPage: 100,
 		}
-		if nextPage != 0 {
-			listOptions.Page = nextPage
-		}
+		listOptions.Page = nextPage
 
 		reviews, resp, err := client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
 		if err != nil {
-			return nil, errors.Wrap(err, "error fetching files")
+			return nil, errors.Wrap(err, "error fetching pull request reviews")
 		}
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("not ok status fetching files: %s", resp.Status)
+			return nil, fmt.Errorf("not ok status fetching pull request reviews: %s", resp.Status)
 		}
 		for _, review := range reviews {
 			if review.GetState() == ApprovalState && review.GetUser() != nil {


### PR DESCRIPTION
Policy filter logic in the first iteration will check if a user who has approved a PR exists in the global owners list to determine if failing policies should be successes. This is a filter function that will eventually be changed to filter out specific policies if a PR reviewer owns that policy in particular. Code isn't used yet, so has no impact.

Also implements ListReviews api to fetch PR approvals.