### PR TITLE
Initial Conftest executor

### DIFF
--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -77,11 +77,13 @@ func (c *ConfTestExecutor) Run(ctx context.Context, prjCtx command.ProjectContex
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "error filtering out approved policies", map[string]interface{}{
 			"err": err,
 		})
+		// use generic error message here as error output is what user sees
 		return output, errors.New("internal server error")
 	}
 	if len(failedPolicies) == 0 {
 		return output, nil
 	}
+	// use policyErr here as error output is what user sees
 	return output, policyErr
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -82,7 +82,7 @@ func (c *ConfTestExecutor) Run(prjCtx command.ProjectContext, executablePath, wo
 	output := c.sanitizeOutput(inputFile, title+cmdOutput)
 	installationToken, ok := prjCtx.RequestCtx.Value(contextInternal.InstallationIDKey).(int64)
 	if !ok {
-		prjCtx.Log.WarnContext(prjCtx.RequestCtx, "missing installation token")
+		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "missing installation token")
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
 		return output, errors.New(internalError)
 	}

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -1,0 +1,90 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"path/filepath"
+	"strings"
+
+	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
+	"github.com/runatlantis/atlantis/server/events/command"
+)
+
+type policyFilter interface {
+	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
+}
+
+// ConfTestExecutor runs a versioned conftest binary with the args built from the project context.
+// Project context defines whether conftest runs a local policy set or runs a test on a remote policy set.
+type ConfTestExecutor struct {
+	SourceResolver SourceResolver
+	Exec           runtime_models.Exec
+	policyFilter   policyFilter
+}
+
+func (c *ConfTestExecutor) Run(ctx context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error) {
+	var policyNames []string
+	var failedPolicies []valid.PolicySet
+	var results []string
+	var policyErr error
+
+	inputFile := filepath.Join(workdir, prjCtx.GetShowResultFileName())
+
+	for _, policySet := range prjCtx.PolicySets.PolicySets {
+		path, err := c.SourceResolver.Resolve(policySet)
+		// Let's not fail the whole step because of a single failure. Log and fail silently
+		if err != nil {
+			prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "Error resolving policyset", map[string]interface{}{
+				"policy": policySet.Name,
+				"err":    err.Error(),
+			})
+			continue
+		}
+		args := ConftestTestCommandArgs{
+			PolicyArgs: []Arg{NewPolicyArg(path)},
+			ExtraArgs:  extraArgs,
+			InputFile:  inputFile,
+			Command:    executablePath,
+		}
+		serializedArgs, err := args.build()
+		if err != nil {
+			prjCtx.Log.WarnContext(prjCtx.RequestCtx, "No policies have been configured")
+			return "", nil
+			// TODO: enable when we can pass policies in otherwise e2e tests with policy checks fail
+			// return "", errors.Wrap(err, "building args")
+		}
+		policyNames = append(policyNames, policySet.Name)
+		cmdOutput, err := c.Exec.CombinedOutput(serializedArgs, envs, workdir)
+		if err != nil {
+			failedPolicies = append(failedPolicies, policySet)
+			policyErr = err
+		}
+		results = append(results, cmdOutput)
+	}
+	title := c.buildTitle(policyNames)
+	results = append([]string{title}, results...)
+	output := c.sanitizeOutput(inputFile, strings.Join(results, "\n"))
+	// TODO: populate installation token into project context
+	failedPolicyNames, err := c.policyFilter.Filter(ctx, 0, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	if err != nil {
+		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "error filtering out approved policies", map[string]interface{}{
+			"err": err,
+		})
+		return output, errors.New("internal server error")
+	}
+	if len(failedPolicyNames) == 0 {
+		return output, nil
+	}
+	return output, policyErr
+}
+
+func (c *ConfTestExecutor) buildTitle(policySetNames []string) string {
+	return fmt.Sprintf("Checking plan against the following policies: \n  %s\n", strings.Join(policySetNames, "\n  "))
+}
+
+func (c *ConfTestExecutor) sanitizeOutput(inputFile string, output string) string {
+	return strings.Replace(output, inputFile, "<redacted plan file>", -1)
+}

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -3,79 +3,83 @@ package policy
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
-	"github.com/runatlantis/atlantis/server/events/models"
 	"path/filepath"
 	"strings"
 
-	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 )
+
+type sourceResolver interface {
+	Resolve(policySet valid.PolicySet) (string, error)
+}
 
 type policyFilter interface {
 	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
 }
 
+type exec interface {
+	CombinedOutput(args []string, envs map[string]string, workdir string) (string, error)
+}
+
 // ConfTestExecutor runs a versioned conftest binary with the args built from the project context.
 // Project context defines whether conftest runs a local policy set or runs a test on a remote policy set.
 type ConfTestExecutor struct {
-	SourceResolver SourceResolver
-	Exec           runtime_models.Exec
-	policyFilter   policyFilter
+	SourceResolver sourceResolver
+	Exec           exec
+	PolicyFilter   policyFilter
 }
 
+// Run performs conftest policy tests against changes and fails if any policy does not pass. It also runs an all-or-nothing
+// filter that will filter out all policy failures based on the filter criteria.
 func (c *ConfTestExecutor) Run(ctx context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error) {
+	var policyArgs []Arg
 	var policyNames []string
 	var failedPolicies []valid.PolicySet
-	var results []string
-	var policyErr error
-
 	inputFile := filepath.Join(workdir, prjCtx.GetShowResultFileName())
 
 	for _, policySet := range prjCtx.PolicySets.PolicySets {
 		path, err := c.SourceResolver.Resolve(policySet)
 		// Let's not fail the whole step because of a single failure. Log and fail silently
 		if err != nil {
-			prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "Error resolving policyset", map[string]interface{}{
-				"policy": policySet.Name,
-				"err":    err.Error(),
-			})
+			prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("Error resolving policyset %s. err: %s", policySet.Name, err.Error()))
 			continue
 		}
-		args := ConftestTestCommandArgs{
-			PolicyArgs: []Arg{NewPolicyArg(path)},
-			ExtraArgs:  extraArgs,
-			InputFile:  inputFile,
-			Command:    executablePath,
-		}
-		serializedArgs, err := args.build()
-		if err != nil {
-			prjCtx.Log.WarnContext(prjCtx.RequestCtx, "No policies have been configured")
-			return "", nil
-			// TODO: enable when we can pass policies in otherwise e2e tests with policy checks fail
-			// return "", errors.Wrap(err, "building args")
-		}
+		policyArgs = append(policyArgs, NewPolicyArg(path))
 		policyNames = append(policyNames, policySet.Name)
-		cmdOutput, err := c.Exec.CombinedOutput(serializedArgs, envs, workdir)
-		if err != nil {
-			failedPolicies = append(failedPolicies, policySet)
-			policyErr = err
-		}
-		results = append(results, cmdOutput)
 	}
+
+	args := ConftestTestCommandArgs{
+		PolicyArgs: policyArgs,
+		ExtraArgs:  extraArgs,
+		InputFile:  inputFile,
+		Command:    executablePath,
+	}
+	serializedArgs, err := args.build()
+	if err != nil {
+		prjCtx.Log.WarnContext(prjCtx.RequestCtx, "No policies have been configured")
+		return "", errors.Wrap(err, "building args")
+	}
+
+	// TODO: run each policy set separately and use each pass/failure decision to populate failedPolicies
+	cmdOutput, policyErr := c.Exec.CombinedOutput(serializedArgs, envs, workdir)
+	if policyErr != nil {
+		failedPolicies = prjCtx.PolicySets.PolicySets
+	}
+
 	title := c.buildTitle(policyNames)
-	results = append([]string{title}, results...)
-	output := c.sanitizeOutput(inputFile, strings.Join(results, "\n"))
+	output := c.sanitizeOutput(inputFile, title+cmdOutput)
 	// TODO: populate installation token into project context
-	failedPolicyNames, err := c.policyFilter.Filter(ctx, 0, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	failedPolicies, err = c.PolicyFilter.Filter(ctx, 0, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
 	if err != nil {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "error filtering out approved policies", map[string]interface{}{
 			"err": err,
 		})
 		return output, errors.New("internal server error")
 	}
-	if len(failedPolicyNames) == 0 {
+	if len(failedPolicies) == 0 {
 		return output, nil
 	}
 	return output, policyErr

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally/v4"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,7 @@ func buildTestProjectCtx(t *testing.T, policySets []valid.PolicySet) command.Pro
 			PolicySets: policySets,
 		},
 		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("test", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
 }
@@ -60,7 +62,7 @@ func TestConfTestExecutor_PolicySuccess(t *testing.T) {
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	assert.NoError(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)
@@ -88,7 +90,7 @@ func TestConfTestExecutor_PolicySuccess_FilteredFailures(t *testing.T) {
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	assert.NoError(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)
@@ -117,7 +119,7 @@ func TestConfTestExecutor_PolicyFailure_NotFiltered(t *testing.T) {
 	}
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	expectedTitle := buildTestTitle(policySets)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
@@ -141,7 +143,7 @@ func TestConfTestExecutor_BuildArgError(t *testing.T) {
 	var args []string
 	var policySets []valid.PolicySet
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	assert.Error(t, err)
 	assert.False(t, sourceResolver.isCalled)
 	assert.False(t, exec.isCalled)
@@ -165,7 +167,7 @@ func TestConfTestExecutor_SourceResolverError(t *testing.T) {
 		{Name: policyA},
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.False(t, exec.isCalled)
@@ -191,7 +193,7 @@ func TestConfTestExecutor_FilterFailure(t *testing.T) {
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, workDir, map[string]string{}, args)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -1,0 +1,234 @@
+package policy_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/core/runtime/policy"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+const (
+	path           = "/path/to/some/place"
+	output         = "test output"
+	workDir        = "workDir"
+	executablePath = "executablepath"
+	policyA        = "A"
+	policyB        = "B"
+)
+
+func buildTestProjectCtx(t *testing.T, policySets []valid.PolicySet) command.ProjectContext {
+	return command.ProjectContext{
+		PolicySets: valid.PolicySets{
+			Version:    nil,
+			Owners:     valid.PolicyOwners{},
+			PolicySets: policySets,
+		},
+		Log:        logging.NewNoopCtxLogger(t),
+		RequestCtx: context.Background(),
+	}
+}
+
+func buildTestTitle(policySets []valid.PolicySet) string {
+	var names []string
+	for _, policy := range policySets {
+		names = append(names, policy.Name)
+	}
+	return fmt.Sprintf("Checking plan against the following policies: \n  %s\n", strings.Join(names, "\n  "))
+}
+
+func TestConfTestExecutor_PolicySuccess(t *testing.T) {
+	sourceResolver := &mockSourceResolver{path: path}
+	exec := &mockExec{
+		output: output,
+	}
+	policyFilter := &mockPolicyFilter{}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	policySets := []valid.PolicySet{
+		{Name: policyA},
+		{Name: policyB},
+	}
+	prjCtx := buildTestProjectCtx(t, policySets)
+	expectedTitle := buildTestTitle(policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	assert.NoError(t, err)
+	assert.True(t, sourceResolver.isCalled)
+	assert.True(t, exec.isCalled)
+	assert.True(t, policyFilter.isCalled)
+	assert.Contains(t, cmdOutput, expectedTitle)
+	assert.Contains(t, cmdOutput, output)
+}
+
+func TestConfTestExecutor_PolicySuccess_FilteredFailures(t *testing.T) {
+	sourceResolver := &mockSourceResolver{path: path}
+	exec := &mockExec{
+		output: output,
+		error:  assert.AnError,
+	}
+	policyFilter := &mockPolicyFilter{}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	policySets := []valid.PolicySet{
+		{Name: policyA},
+		{Name: policyB},
+	}
+	prjCtx := buildTestProjectCtx(t, policySets)
+	expectedTitle := buildTestTitle(policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	assert.NoError(t, err)
+	assert.True(t, sourceResolver.isCalled)
+	assert.True(t, exec.isCalled)
+	assert.True(t, policyFilter.isCalled)
+	assert.Contains(t, cmdOutput, expectedTitle)
+	assert.Contains(t, cmdOutput, output)
+}
+
+func TestConfTestExecutor_PolicyFailure_NotFiltered(t *testing.T) {
+	sourceResolver := &mockSourceResolver{path: path}
+	exec := &mockExec{
+		output: output,
+		error:  assert.AnError,
+	}
+	policySets := []valid.PolicySet{
+		{Name: policyA},
+		{Name: policyB},
+	}
+	policyFilter := &mockPolicyFilter{
+		policies: policySets,
+	}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	prjCtx := buildTestProjectCtx(t, policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	expectedTitle := buildTestTitle(policySets)
+	assert.Error(t, err)
+	assert.True(t, sourceResolver.isCalled)
+	assert.True(t, exec.isCalled)
+	assert.True(t, policyFilter.isCalled)
+	assert.Contains(t, cmdOutput, expectedTitle)
+	assert.Contains(t, cmdOutput, output)
+}
+
+func TestConfTestExecutor_BuildArgError(t *testing.T) {
+	sourceResolver := &mockSourceResolver{path: path}
+	exec := &mockExec{
+		output: output,
+	}
+	policyFilter := &mockPolicyFilter{}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	var policySets []valid.PolicySet
+	prjCtx := buildTestProjectCtx(t, policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	assert.Error(t, err)
+	assert.False(t, sourceResolver.isCalled)
+	assert.False(t, exec.isCalled)
+	assert.False(t, policyFilter.isCalled)
+	assert.Empty(t, cmdOutput)
+}
+
+func TestConfTestExecutor_SourceResolverError(t *testing.T) {
+	sourceResolver := &mockSourceResolver{error: assert.AnError}
+	exec := &mockExec{
+		output: output,
+	}
+	policyFilter := &mockPolicyFilter{}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	policySets := []valid.PolicySet{
+		{Name: policyA},
+	}
+	prjCtx := buildTestProjectCtx(t, policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	assert.Error(t, err)
+	assert.True(t, sourceResolver.isCalled)
+	assert.False(t, exec.isCalled)
+	assert.False(t, policyFilter.isCalled)
+	assert.Empty(t, cmdOutput)
+}
+
+func TestConfTestExecutor_FilterFailure(t *testing.T) {
+	sourceResolver := &mockSourceResolver{path: path}
+	exec := &mockExec{
+		output: output,
+	}
+	policySets := []valid.PolicySet{
+		{Name: policyA},
+		{Name: policyB},
+	}
+	policyFilter := &mockPolicyFilter{error: assert.AnError}
+	executor := policy.ConfTestExecutor{
+		SourceResolver: sourceResolver,
+		Exec:           exec,
+		PolicyFilter:   policyFilter,
+	}
+	var args []string
+	prjCtx := buildTestProjectCtx(t, policySets)
+	expectedTitle := buildTestTitle(policySets)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
+	assert.Error(t, err)
+	assert.True(t, sourceResolver.isCalled)
+	assert.True(t, exec.isCalled)
+	assert.True(t, policyFilter.isCalled)
+	assert.Contains(t, cmdOutput, expectedTitle)
+	assert.Contains(t, cmdOutput, output)
+}
+
+type mockSourceResolver struct {
+	isCalled bool
+	path     string
+	error    error
+}
+
+func (r *mockSourceResolver) Resolve(_ valid.PolicySet) (string, error) {
+	r.isCalled = true
+	return r.path, r.error
+}
+
+type mockPolicyFilter struct {
+	isCalled bool
+	policies []valid.PolicySet
+	error    error
+}
+
+func (r *mockPolicyFilter) Filter(_ context.Context, _ int64, _ models.Repo, _ int, _ []valid.PolicySet) ([]valid.PolicySet, error) {
+	r.isCalled = true
+	return r.policies, r.error
+}
+
+type mockExec struct {
+	isCalled bool
+	output   string
+	error    error
+}
+
+func (r *mockExec) CombinedOutput(_ []string, _ map[string]string, _ string) (string, error) {
+	r.isCalled = true
+	return r.output, r.error
+}


### PR DESCRIPTION
This conftest executor will be run by the policy check command runner (similar to the [legacy method](https://github.com/lyft/atlantis/blob/release-v0.17.3-lyft.1/server/core/runtime/policy/conftest_client.go#L166)). Key difference here is that we will also run a filter remove failed policies that already received an owners approval using https://github.com/lyft/atlantis/pull/473.

For now, this executor will run all policies together. Later on, we will make this run each policy individually, so the filter logic will make more sense then.

Once project is complete, this will replace the existing conftest executor client within the PolicyCheckCommandRunner struct.

Next step: add conftest executor to policy check command runner