### PR TITLE
Support new conftest executor in policycheck runner

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -683,9 +683,14 @@ func (s *ServerCmd) run() error {
 	s.securityWarnings(&userConfig, logger)
 	s.trimAtSymbolFromUsers(&userConfig)
 
-	appConfig, err := createGHAppConfig(userConfig)
-	if err != nil {
-		return err
+	// Legacy code still partially supports other VCS configs
+	// so GithubAppKeyFile needs to exist to create the githubapp config
+	appConfig := githubapp.Config{}
+	if userConfig.GithubAppKeyFile != "" {
+		appConfig, err = createGHAppConfig(userConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Config looks good. Start the server.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -683,12 +683,18 @@ func (s *ServerCmd) run() error {
 	s.securityWarnings(&userConfig, logger)
 	s.trimAtSymbolFromUsers(&userConfig)
 
+	appConfig, err := createGHAppConfig(userConfig)
+	if err != nil {
+		return err
+	}
+
 	// Config looks good. Start the server.
 	server, err := s.ServerCreator.NewServer(userConfig, server.Config{
 		AtlantisURLFlag:      AtlantisURLFlag,
 		AtlantisVersion:      s.AtlantisVersion,
 		DefaultTFVersionFlag: DefaultTFVersionFlag,
 		RepoConfigJSONFlag:   RepoConfigJSONFlag,
+		AppCfg:               appConfig,
 	})
 	if err != nil {
 		return errors.Wrap(err, "initializing server")

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -156,6 +157,19 @@ func TestExecute_Flags(t *testing.T) {
 	for flag, exp := range testFlags {
 		Equals(t, exp, configVal(t, passedConfig, flag))
 	}
+}
+
+func TestExecute_GHAppKeyFile(t *testing.T) {
+	t.Log("Should use all the values from the config file.")
+	tmpFile := tempFile(t, "testdata")
+	defer os.Remove(tmpFile) // nolint: errcheck
+	c := setup(map[string]interface{}{
+		GHAppKeyFileFlag:  tmpFile,
+		GHAppIDFlag:       int64(1),
+		RepoAllowlistFlag: "*",
+	}, t)
+	err := c.Execute()
+	assert.NoError(t, err)
 }
 
 func TestExecute_ConfigFile(t *testing.T) {
@@ -458,14 +472,6 @@ func TestExecute_ValidateVCSConfig(t *testing.T) {
 			map[string]interface{}{
 				GHUserFlag:  "user",
 				GHTokenFlag: "token",
-			},
-			false,
-		},
-		{
-			"github app and key file set and should be successful",
-			map[string]interface{}{
-				GHAppIDFlag:      "1",
-				GHAppKeyFileFlag: "key.pem",
 			},
 			false,
 		},

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -806,6 +806,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 	// swapping out version cache to something that always returns local contest
 	// binary
 	conftextExec.VersionCache = conftestCache
+	// e2e test will be using legacy mode for now
 	policyCheckRunner, err := runtime.NewPolicyCheckStepRunner(
 		conftestVersion,
 		conftextExec,

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -837,7 +837,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		PolicyFilter: &events.ApprovedPolicyFilter{
 			GlobalCfg: globalCfg,
 			PRReviewsFetcher: &mockReviewFetcher{
-				approvers: []string{""},
+				approvers: []string{},
 			},
 		},
 	}

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -806,10 +806,11 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 	// swapping out version cache to something that always returns local contest
 	// binary
 	conftextExec.VersionCache = conftestCache
-
 	policyCheckRunner, err := runtime.NewPolicyCheckStepRunner(
 		conftestVersion,
 		conftextExec,
+		&mockExecutor{},
+		featureAllocator,
 	)
 	Ok(t, err)
 	initStepRunner := &runtime.InitStepRunner{
@@ -1349,6 +1350,13 @@ type testStaleCommandChecker struct{}
 
 func (t *testStaleCommandChecker) CommandIsStale(ctx *command.Context) bool {
 	return false
+}
+
+type mockExecutor struct {
+}
+
+func (e *mockExecutor) Run(prjCtx command.ProjectContext, executablePath, workdir string, envs map[string]string, extraArgs []string) (string, error) {
+	return "", nil
 }
 
 type testGithubClient struct {

--- a/server/controllers/events/testfixtures/githubIssueCommentEvent.json
+++ b/server/controllers/events/testfixtures/githubIssueCommentEvent.json
@@ -203,5 +203,8 @@
     "received_events_url": "https://api.github.com/users/runatlantis/received_events",
     "type": "User",
     "site_admin": false
+  },
+  "installation": {
+    "id": 12345
   }
 }

--- a/server/controllers/events/testfixtures/githubPullRequestOpenedEvent.json
+++ b/server/controllers/events/testfixtures/githubPullRequestOpenedEvent.json
@@ -464,5 +464,8 @@
     "received_events_url": "https://api.github.com/users/runatlantis/received_events",
     "type": "User",
     "site_admin": false
+  },
+  "installation": {
+    "id": 12345
   }
 }

--- a/server/core/runtime/executor.go
+++ b/server/core/runtime/executor.go
@@ -13,11 +13,11 @@ import (
 // VersionedExecutorWorkflow defines a versioned execution for a given project context
 type VersionedExecutorWorkflow interface {
 	ExecutorVersionEnsurer
-	LegacyExecutor
+	Executor
 }
 
 // Executor runs an executable with provided environment variables and arguments and returns stdout
-type LegacyExecutor interface {
+type Executor interface {
 	Run(ctx context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error)
 }
 

--- a/server/core/runtime/executor.go
+++ b/server/core/runtime/executor.go
@@ -13,11 +13,11 @@ import (
 // VersionedExecutorWorkflow defines a versioned execution for a given project context
 type VersionedExecutorWorkflow interface {
 	ExecutorVersionEnsurer
-	Executor
+	LegacyExecutor
 }
 
 // Executor runs an executable with provided environment variables and arguments and returns stdout
-type Executor interface {
+type LegacyExecutor interface {
 	Run(ctx context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error)
 }
 

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -90,13 +90,13 @@ func (p *LocalSourceResolver) Resolve(policySet valid.PolicySet) (string, error)
 
 // SourceResolverProxy proxies to underlying source resolvers dynamically
 type SourceResolverProxy struct {
-	localSourceResolver SourceResolver
+	LocalSourceResolver SourceResolver
 }
 
 func (p *SourceResolverProxy) Resolve(policySet valid.PolicySet) (string, error) {
 	switch source := policySet.Source; source {
 	case valid.LocalPolicySet:
-		return p.localSourceResolver.Resolve(policySet)
+		return p.LocalSourceResolver.Resolve(policySet)
 	default:
 		return "", fmt.Errorf("unable to resolve policy set source %s", source)
 	}
@@ -157,7 +157,7 @@ func NewConfTestExecutorWorkflow(log logging.Logger, versionRootDir string, conf
 		VersionCache:           versionCache,
 		DefaultConftestVersion: version,
 		SourceResolver: &SourceResolverProxy{
-			localSourceResolver: &LocalSourceResolver{},
+			LocalSourceResolver: &LocalSourceResolver{},
 		},
 		Exec: runtime_models.LocalExec{},
 	}

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -45,7 +45,7 @@ type ConfTestExecutor struct {
 func NewConfTestExecutor(cfg valid.GlobalCfg, creator githubapp.ClientCreator) *ConfTestExecutor {
 	return &ConfTestExecutor{
 		SourceResolver: &SourceResolverProxy{
-			localSourceResolver: &LocalSourceResolver{},
+			LocalSourceResolver: &LocalSourceResolver{},
 		},
 		Exec: runtime_models.LocalExec{},
 		PolicyFilter: &events.ApprovedPolicyFilter{

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -59,7 +59,7 @@ func NewConfTestExecutor(cfg valid.GlobalCfg, creator githubapp.ClientCreator) *
 
 // Run performs conftest policy tests against changes and fails if any policy does not pass. It also runs an all-or-nothing
 // filter that will filter out all policy failures based on the filter criteria.
-func (c *ConfTestExecutor) Run(prjCtx command.ProjectContext, executablePath, workdir string, envs map[string]string, extraArgs []string) (string, error) {
+func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error) {
 	var policyArgs []Arg
 	var policyNames []string
 	var failedPolicies []valid.PolicySet

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -65,7 +65,7 @@ func TestConfTestExecutor_PolicySuccess(t *testing.T) {
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.NoError(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)
@@ -93,7 +93,7 @@ func TestConfTestExecutor_PolicySuccess_FilteredFailures(t *testing.T) {
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.NoError(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)
@@ -122,7 +122,7 @@ func TestConfTestExecutor_PolicyFailure_NotFiltered(t *testing.T) {
 	}
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	expectedTitle := buildTestTitle(policySets)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
@@ -146,7 +146,7 @@ func TestConfTestExecutor_BuildArgError(t *testing.T) {
 	var args []string
 	var policySets []valid.PolicySet
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
 	assert.False(t, sourceResolver.isCalled)
 	assert.False(t, exec.isCalled)
@@ -170,7 +170,7 @@ func TestConfTestExecutor_SourceResolverError(t *testing.T) {
 		{Name: policyA},
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.False(t, exec.isCalled)
@@ -196,7 +196,7 @@ func TestConfTestExecutor_FilterFailure(t *testing.T) {
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)
@@ -232,7 +232,7 @@ func TestConfTestExecutor_MissingInstallationToken(t *testing.T) {
 		RequestCtx: context.Background(),
 	}
 	expectedTitle := buildTestTitle(policySets)
-	cmdOutput, err := executor.Run(prjCtx, executablePath, workDir, map[string]string{}, args)
+	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
 	assert.True(t, sourceResolver.isCalled)
 	assert.True(t, exec.isCalled)

--- a/server/core/runtime/policy_check_step_runner.go
+++ b/server/core/runtime/policy_check_step_runner.go
@@ -9,16 +9,12 @@ import (
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
-type executor interface {
-	Run(prjCtx command.ProjectContext, executablePath, workdir string, envs map[string]string, extraArgs []string) (string, error)
-}
-
 // PolicyCheckStepRunner runs a policy check command given a ctx
 type PolicyCheckStepRunner struct {
 	VersionEnsurer ExecutorVersionEnsurer
-	Executor       executor
+	Executor       Executor
 	// TODO: remove these
-	LegacyExecutor LegacyExecutor
+	LegacyExecutor Executor
 	Allocator      feature.Allocator
 }
 
@@ -26,7 +22,7 @@ type PolicyCheckStepRunner struct {
 func NewPolicyCheckStepRunner(
 	defaultTfVersion *version.Version,
 	versionEnsurer VersionedExecutorWorkflow,
-	executor executor,
+	executor Executor,
 	allocator feature.Allocator) (Runner, error) {
 	runner := &PlanTypeStepRunnerDelegate{
 		defaultRunner: &PolicyCheckStepRunner{
@@ -57,7 +53,7 @@ func (p *PolicyCheckStepRunner) Run(ctx context.Context, cmdCtx command.ProjectC
 		return p.LegacyExecutor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
 	}
 	if shouldAllocate {
-		return p.Executor.Run(cmdCtx, executable, path, envs, extraArgs)
+		return p.Executor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
 	}
 	return p.LegacyExecutor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
 }

--- a/server/core/runtime/policy_check_step_runner.go
+++ b/server/core/runtime/policy_check_step_runner.go
@@ -2,25 +2,38 @@ package runtime
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/command"
 )
 
+type executor interface {
+	Run(prjCtx command.ProjectContext, executablePath, workdir string, envs map[string]string, extraArgs []string) (string, error)
+}
+
 // PolicyCheckStepRunner runs a policy check command given a ctx
 type PolicyCheckStepRunner struct {
 	VersionEnsurer ExecutorVersionEnsurer
-	Executor       Executor
+	Executor       executor
+	// TODO: remove these
+	LegacyExecutor LegacyExecutor
+	Allocator      feature.Allocator
 }
 
 // NewPolicyCheckStepRunner creates a new step runner from an Executor workflow
-func NewPolicyCheckStepRunner(defaultTfVersion *version.Version, executorWorkflow VersionedExecutorWorkflow) (Runner, error) {
-
+func NewPolicyCheckStepRunner(
+	defaultTfVersion *version.Version,
+	versionEnsurer VersionedExecutorWorkflow,
+	executor executor,
+	allocator feature.Allocator) (Runner, error) {
 	runner := &PlanTypeStepRunnerDelegate{
 		defaultRunner: &PolicyCheckStepRunner{
-			VersionEnsurer: executorWorkflow,
-			Executor:       executorWorkflow,
+			VersionEnsurer: versionEnsurer,
+			LegacyExecutor: versionEnsurer,
+			Executor:       executor,
+			Allocator:      allocator,
 		},
 		remotePlanRunner: RemoteBackendUnsupportedRunner{},
 	}
@@ -31,10 +44,20 @@ func NewPolicyCheckStepRunner(defaultTfVersion *version.Version, executorWorkflo
 // Run ensures a given version for the executable, builds the args from the project context and then runs executable returning the result
 func (p *PolicyCheckStepRunner) Run(ctx context.Context, cmdCtx command.ProjectContext, extraArgs []string, path string, envs map[string]string) (string, error) {
 	executable, err := p.VersionEnsurer.EnsureExecutorVersion(cmdCtx.Log, cmdCtx.PolicySets.Version)
-
 	if err != nil {
 		return "", errors.Wrapf(err, "ensuring policy Executor version")
 	}
 
-	return p.Executor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
+	// TODO: remove feature allocator when the legacy executor is deprecated
+	shouldAllocate, err := p.Allocator.ShouldAllocate(feature.PolicyV2, feature.FeatureContext{
+		RepoName: cmdCtx.BaseRepo.FullName,
+	})
+	if err != nil {
+		cmdCtx.Log.ErrorContext(ctx, "unable to allocate policy v2, continuing with legacy mode")
+		return p.LegacyExecutor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
+	}
+	if shouldAllocate {
+		return p.Executor.Run(cmdCtx, executable, path, envs, extraArgs)
+	}
+	return p.LegacyExecutor.Run(ctx, cmdCtx, executable, envs, path, extraArgs)
 }

--- a/server/core/runtime/policy_check_step_runner_test.go
+++ b/server/core/runtime/policy_check_step_runner_test.go
@@ -182,7 +182,7 @@ type mockExecutor struct {
 	isCalled bool
 }
 
-func (t *mockExecutor) Run(_ command.ProjectContext, _, _ string, _ map[string]string, _ []string) (string, error) {
+func (t *mockExecutor) Run(_ context.Context, _ command.ProjectContext, _ string, _ map[string]string, _ string, _ []string) (string, error) {
 	t.isCalled = true
 	return t.output, t.err
 }

--- a/server/core/runtime/policy_check_step_runner_test.go
+++ b/server/core/runtime/policy_check_step_runner_test.go
@@ -2,95 +2,198 @@ package runtime_test
 
 import (
 	"context"
-	"errors"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
-	"github.com/runatlantis/atlantis/server/core/runtime/mocks"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
-	. "github.com/runatlantis/atlantis/testing"
 )
 
-var featureAllocator *testFeatureAllocator
+const (
+	expectedOutput = "output"
+	executablePath = "some/path/conftest"
+)
 
-type testFeatureAllocator struct {
-	Enabled bool
-	Err     error
-}
-
-func (t *testFeatureAllocator) ShouldAllocate(featureID feature.Name, featureCtx feature.FeatureContext) (bool, error) {
-	return t.Enabled, t.Err
-}
-
-func TestRun(t *testing.T) {
-	RegisterMockTestingT(t)
-	logger := logging.NewNoopCtxLogger(t)
-	workspace := "default"
-	v, _ := version.NewVersion("1.0")
-	workdir := "/path"
-	executablePath := "some/path/conftest"
-
-	ctx := context.Background()
-	prjCtx := command.ProjectContext{
-		Log:                logger,
-		EscapedCommentArgs: []string{"comment", "args"},
-		Workspace:          workspace,
-		RepoRelDir:         ".",
-		User:               models.User{Username: "username"},
-		Pull: models.PullRequest{
-			Num: 2,
-		},
+func buildTestPrjCtx(t *testing.T) command.ProjectContext {
+	v, err := version.NewVersion("1.0")
+	assert.NoError(t, err)
+	return command.ProjectContext{
+		Log: logging.NewNoopCtxLogger(t),
 		BaseRepo: models.Repo{
 			FullName: "owner/repo",
-			Owner:    "owner",
-			Name:     "repo",
 		},
 		PolicySets: valid.PolicySets{
 			Version:    v,
 			PolicySets: []valid.PolicySet{},
 		},
 	}
+}
 
-	executorWorkflow := mocks.NewMockVersionedExecutorWorkflow()
-	s := &runtime.PolicyCheckStepRunner{
-		VersionEnsurer: executorWorkflow,
-		LegacyExecutor: executorWorkflow,
-		Allocator:      &testFeatureAllocator{},
+func TestRun_Successful(t *testing.T) {
+	prjCtx := buildTestPrjCtx(t)
+	ensurer := &mockEnsurer{}
+	executor := &mockExecutor{
+		output: expectedOutput,
 	}
+	legacyExecutor := &mockLegacyExecutor{}
+	allocator := &mockFeatureAllocator{
+		enabled: true,
+	}
+	runner := &runtime.PolicyCheckStepRunner{
+		VersionEnsurer: ensurer,
+		Executor:       executor,
+		LegacyExecutor: legacyExecutor,
+		Allocator:      allocator,
+	}
+	output, err := runner.Run(context.Background(), prjCtx, []string{}, executablePath, map[string]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, output, expectedOutput)
+	assert.True(t, ensurer.isCalled)
+	assert.True(t, executor.isCalled)
+	assert.True(t, allocator.isCalled)
+	assert.False(t, legacyExecutor.isCalled)
+}
 
-	t.Run("success", func(t *testing.T) {
-		extraArgs := []string{"extra", "args"}
-		When(executorWorkflow.EnsureExecutorVersion(logger, v)).ThenReturn(executablePath, nil)
-		When(executorWorkflow.Run(ctx, prjCtx, executablePath, map[string]string(nil), workdir, extraArgs)).ThenReturn("Success!", nil)
+func TestRun_LegacySuccess(t *testing.T) {
+	prjCtx := buildTestPrjCtx(t)
+	ensurer := &mockEnsurer{}
+	executor := &mockExecutor{}
+	legacyExecutor := &mockLegacyExecutor{
+		output: expectedOutput,
+	}
+	allocator := &mockFeatureAllocator{}
+	runner := &runtime.PolicyCheckStepRunner{
+		VersionEnsurer: ensurer,
+		Executor:       executor,
+		LegacyExecutor: legacyExecutor,
+		Allocator:      allocator,
+	}
+	output, err := runner.Run(context.Background(), prjCtx, []string{}, executablePath, map[string]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, output, expectedOutput)
+	assert.True(t, ensurer.isCalled)
+	assert.False(t, executor.isCalled)
+	assert.True(t, allocator.isCalled)
+	assert.True(t, legacyExecutor.isCalled)
+}
 
-		output, err := s.Run(ctx, prjCtx, extraArgs, workdir, map[string]string(nil))
+func TestRun_LegacySuccess_AllocationError(t *testing.T) {
+	prjCtx := buildTestPrjCtx(t)
+	ensurer := &mockEnsurer{}
+	executor := &mockExecutor{}
+	legacyExecutor := &mockLegacyExecutor{
+		output: expectedOutput,
+	}
+	allocator := &mockFeatureAllocator{
+		err: assert.AnError,
+	}
+	runner := &runtime.PolicyCheckStepRunner{
+		VersionEnsurer: ensurer,
+		Executor:       executor,
+		LegacyExecutor: legacyExecutor,
+		Allocator:      allocator,
+	}
+	output, err := runner.Run(context.Background(), prjCtx, []string{}, executablePath, map[string]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, output, expectedOutput)
+	assert.True(t, ensurer.isCalled)
+	assert.False(t, executor.isCalled)
+	assert.True(t, allocator.isCalled)
+	assert.True(t, legacyExecutor.isCalled)
+}
 
-		Ok(t, err)
-		Equals(t, "Success!", output)
-	})
+func TestRun_LegacyFailure(t *testing.T) {
+	prjCtx := buildTestPrjCtx(t)
+	ensurer := &mockEnsurer{}
+	executor := &mockExecutor{}
+	legacyExecutor := &mockLegacyExecutor{
+		output: expectedOutput,
+		err:    assert.AnError,
+	}
+	allocator := &mockFeatureAllocator{}
+	runner := &runtime.PolicyCheckStepRunner{
+		VersionEnsurer: ensurer,
+		Executor:       executor,
+		LegacyExecutor: legacyExecutor,
+		Allocator:      allocator,
+	}
+	output, err := runner.Run(context.Background(), prjCtx, []string{}, executablePath, map[string]string{})
+	assert.Error(t, err)
+	assert.Equal(t, output, expectedOutput)
+	assert.True(t, ensurer.isCalled)
+	assert.False(t, executor.isCalled)
+	assert.True(t, allocator.isCalled)
+	assert.True(t, legacyExecutor.isCalled)
+}
 
-	t.Run("ensure version failure", func(t *testing.T) {
-		extraArgs := []string{"extra", "args"}
-		expectedErr := errors.New("error ensuring version")
-		When(executorWorkflow.EnsureExecutorVersion(logger, v)).ThenReturn("", expectedErr)
+func TestRun_EnsurerFailure(t *testing.T) {
+	prjCtx := buildTestPrjCtx(t)
+	ensurer := &mockEnsurer{
+		err: assert.AnError,
+	}
+	executor := &mockExecutor{}
+	legacyExecutor := &mockLegacyExecutor{}
+	allocator := &mockFeatureAllocator{}
+	runner := &runtime.PolicyCheckStepRunner{
+		VersionEnsurer: ensurer,
+		Executor:       executor,
+		LegacyExecutor: legacyExecutor,
+		Allocator:      allocator,
+	}
+	output, err := runner.Run(context.Background(), prjCtx, []string{}, executablePath, map[string]string{})
+	assert.Error(t, err)
+	assert.Empty(t, output)
+	assert.True(t, ensurer.isCalled)
+	assert.False(t, executor.isCalled)
+	assert.False(t, allocator.isCalled)
+	assert.False(t, legacyExecutor.isCalled)
+}
 
-		_, err := s.Run(ctx, prjCtx, extraArgs, workdir, map[string]string(nil))
+type mockFeatureAllocator struct {
+	enabled  bool
+	err      error
+	isCalled bool
+}
 
-		Assert(t, err != nil, "error is not nil")
-	})
-	t.Run("executor failure", func(t *testing.T) {
-		extraArgs := []string{"extra", "args"}
-		When(executorWorkflow.EnsureExecutorVersion(logger, v)).ThenReturn(executablePath, nil)
-		When(executorWorkflow.Run(ctx, prjCtx, executablePath, map[string]string(nil), workdir, extraArgs)).ThenReturn("", errors.New("error running executor"))
+func (t *mockFeatureAllocator) ShouldAllocate(_ feature.Name, _ feature.FeatureContext) (bool, error) {
+	t.isCalled = true
+	return t.enabled, t.err
+}
 
-		_, err := s.Run(ctx, prjCtx, extraArgs, workdir, map[string]string(nil))
+type mockLegacyExecutor struct {
+	output   string
+	err      error
+	isCalled bool
+}
 
-		Assert(t, err != nil, "error is not nil")
-	})
+func (t *mockLegacyExecutor) Run(_ context.Context, _ command.ProjectContext, _ string, _ map[string]string, _ string, _ []string) (string, error) {
+	t.isCalled = true
+	return t.output, t.err
+}
+
+type mockExecutor struct {
+	output   string
+	err      error
+	isCalled bool
+}
+
+func (t *mockExecutor) Run(_ command.ProjectContext, _, _ string, _ map[string]string, _ []string) (string, error) {
+	t.isCalled = true
+	return t.output, t.err
+}
+
+type mockEnsurer struct {
+	output   string
+	err      error
+	isCalled bool
+}
+
+func (t *mockEnsurer) EnsureExecutorVersion(_ logging.Logger, _ *version.Version) (string, error) {
+	t.isCalled = true
+	return t.output, t.err
 }

--- a/server/core/runtime/policy_check_step_runner_test.go
+++ b/server/core/runtime/policy_check_step_runner_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"context"
 	"errors"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -15,6 +16,17 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
 )
+
+var featureAllocator *testFeatureAllocator
+
+type testFeatureAllocator struct {
+	Enabled bool
+	Err     error
+}
+
+func (t *testFeatureAllocator) ShouldAllocate(featureID feature.Name, featureCtx feature.FeatureContext) (bool, error) {
+	return t.Enabled, t.Err
+}
 
 func TestRun(t *testing.T) {
 	RegisterMockTestingT(t)
@@ -48,7 +60,8 @@ func TestRun(t *testing.T) {
 	executorWorkflow := mocks.NewMockVersionedExecutorWorkflow()
 	s := &runtime.PolicyCheckStepRunner{
 		VersionEnsurer: executorWorkflow,
-		Executor:       executorWorkflow,
+		LegacyExecutor: executorWorkflow,
+		Allocator:      &testFeatureAllocator{},
 	}
 
 	t.Run("success", func(t *testing.T) {

--- a/server/lyft/feature/names.go
+++ b/server/lyft/feature/names.go
@@ -3,4 +3,7 @@ package feature
 type Name string
 
 // list of feature names used in the code base. These must be kept in sync with any external config.
-const PlatformMode Name = "platform-mode"
+const (
+	PlatformMode Name = "platform-mode"
+	PolicyV2     Name = "policy-v2"
+)


### PR DESCRIPTION
Modifies our policy check step command runner to use the new conftest executor if enabled by the feature allocator. It will continue to run legacy mode if not enabled/unable to determine if enabled.