### PR TITLE
Pass installation token through legacy workflow

### DIFF
--- a/server/controllers/events/handlers/comment.go
+++ b/server/controllers/events/handlers/comment.go
@@ -81,6 +81,7 @@ func (h *CommandHandler) Handle(ctx context.Context, _ *http.BufferedRequest, ev
 		event.PullNum,
 		command,
 		event.Timestamp,
+		event.InstallationToken,
 	)
 	return nil
 }

--- a/server/controllers/events/handlers/pull_request.go
+++ b/server/controllers/events/handlers/pull_request.go
@@ -28,6 +28,7 @@ func (p *Autoplanner) Handle(ctx context.Context, _ *http.BufferedRequest, event
 		event.Pull,
 		event.User,
 		event.Timestamp,
+		event.InstallationToken,
 	)
 
 	return nil

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -32,9 +32,10 @@ func buildTestProjectCtx(t *testing.T, policySets []valid.PolicySet) command.Pro
 			Owners:     valid.PolicyOwners{},
 			PolicySets: policySets,
 		},
-		Log:        logging.NewNoopCtxLogger(t),
-		Scope:      tally.NewTestScope("test", map[string]string{}),
-		RequestCtx: ctx,
+		Log:               logging.NewNoopCtxLogger(t),
+		Scope:             tally.NewTestScope("test", map[string]string{}),
+		RequestCtx:        ctx,
+		InstallationToken: 1,
 	}
 }
 

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -44,4 +44,6 @@ type Context struct {
 	// Time Atlantis received VCS event, triggering command to be executed
 	TriggerTimestamp time.Time
 	RequestCtx       context.Context
+
+	InstallationToken int64
 }

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -78,6 +78,7 @@ func NewProjectContext(
 		JobID:                uuid.New().String(),
 		RequestCtx:           ctx.RequestCtx,
 		WorkflowModeType:     projCfg.WorkflowMode,
+		InstallationToken:    ctx.InstallationToken,
 	}
 }
 
@@ -157,7 +158,8 @@ type ProjectContext struct {
 	// StatusID is used for consecutive status updates in the step runners
 	StatusID string
 
-	WorkflowModeType valid.WorkflowModeType
+	WorkflowModeType  valid.WorkflowModeType
+	InstallationToken int64
 }
 
 // ProjectCloneDir creates relative path to clone the repo to. If we are running

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -40,8 +40,8 @@ type CommandRunner interface {
 	// RunCommentCommand is the first step after a command request has been parsed.
 	// It handles gathering additional information needed to execute the command
 	// and then calling the appropriate services to finish executing the command.
-	RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time)
-	RunAutoplanCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time)
+	RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time, installationToken int64)
+	RunAutoplanCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_stale_command_checker.go StaleCommandChecker
@@ -93,7 +93,7 @@ type DefaultCommandRunner struct {
 }
 
 // RunAutoplanCommand runs plan and policy_checks when a pull request is opened or updated.
-func (c *DefaultCommandRunner) RunAutoplanCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time) {
+func (c *DefaultCommandRunner) RunAutoplanCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64) {
 	if opStarted := c.Drainer.StartOp(); !opStarted {
 		if commentErr := c.VCSClient.CreateComment(baseRepo, pull.Num, ShutdownComment, command.Plan.String()); commentErr != nil {
 			c.Logger.ErrorContext(ctx, commentErr.Error())
@@ -114,15 +114,16 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(ctx context.Context, baseRepo 
 	defer timer.Stop()
 
 	cmdCtx := &command.Context{
-		User:             user,
-		Log:              c.Logger,
-		Scope:            scope,
-		Pull:             pull,
-		HeadRepo:         headRepo,
-		PullStatus:       status,
-		Trigger:          command.AutoTrigger,
-		TriggerTimestamp: timestamp,
-		RequestCtx:       ctx,
+		User:              user,
+		Log:               c.Logger,
+		Scope:             scope,
+		Pull:              pull,
+		HeadRepo:          headRepo,
+		PullStatus:        status,
+		Trigger:           command.AutoTrigger,
+		TriggerTimestamp:  timestamp,
+		RequestCtx:        ctx,
+		InstallationToken: installationToken,
 	}
 	if !c.validateCtxAndComment(cmdCtx) {
 		return
@@ -154,7 +155,7 @@ func (c *DefaultCommandRunner) RunAutoplanCommand(ctx context.Context, baseRepo 
 // enough data to construct the Repo model and callers might want to wait until
 // the event is further validated before making an additional (potentially
 // wasteful) call to get the necessary data.
-func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time) {
+func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time, installationToken int64) {
 	if opStarted := c.Drainer.StartOp(); !opStarted {
 		if commentErr := c.VCSClient.CreateComment(baseRepo, pullNum, ShutdownComment, ""); commentErr != nil {
 			c.Logger.ErrorContext(ctx, commentErr.Error())
@@ -180,15 +181,16 @@ func (c *DefaultCommandRunner) RunCommentCommand(ctx context.Context, baseRepo m
 	}
 
 	cmdCtx := &command.Context{
-		User:             user,
-		Log:              c.Logger,
-		Pull:             pull,
-		PullStatus:       status,
-		HeadRepo:         headRepo,
-		Trigger:          command.CommentTrigger,
-		Scope:            scope,
-		TriggerTimestamp: timestamp,
-		RequestCtx:       ctx,
+		User:              user,
+		Log:               c.Logger,
+		Pull:              pull,
+		PullStatus:        status,
+		HeadRepo:          headRepo,
+		Trigger:           command.CommentTrigger,
+		Scope:             scope,
+		TriggerTimestamp:  timestamp,
+		RequestCtx:        ctx,
+		InstallationToken: installationToken,
 	}
 
 	if !c.validateCtxAndComment(cmdCtx) {
@@ -261,12 +263,12 @@ type ForceApplyCommandRunner struct {
 	Logger    logging.Logger
 }
 
-func (f *ForceApplyCommandRunner) RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time) {
+func (f *ForceApplyCommandRunner) RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time, installationToken int64) {
 	if cmd.ForceApply {
 		warningMessage := "⚠️ WARNING ⚠️\n\n You have bypassed all apply requirements for this PR 🚀 . This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘 .\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
 		if commentErr := f.VCSClient.CreateComment(baseRepo, pullNum, warningMessage, ""); commentErr != nil {
 			f.Logger.ErrorContext(ctx, commentErr.Error())
 		}
 	}
-	f.CommandRunner.RunCommentCommand(ctx, baseRepo, headRepo, pull, user, pullNum, cmd, timestamp)
+	f.CommandRunner.RunCommentCommand(ctx, baseRepo, headRepo, pull, user, pullNum, cmd, timestamp, installationToken)
 }

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -202,7 +202,7 @@ func TestRunCommentCommand_ForkPRDisabled(t *testing.T) {
 	headRepo := fixtures.GithubRepo
 	headRepo.FullName = "forkrepo/atlantis"
 	headRepo.Owner = "forkrepo"
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, headRepo, modelPull, fixtures.User, fixtures.Pull.Num, nil, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, headRepo, modelPull, fixtures.User, fixtures.Pull.Num, nil, time.Now(), 0)
 	commentMessage := "Atlantis commands can't be run on fork pull requests."
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, commentMessage, "")
 }
@@ -222,7 +222,7 @@ func TestRunCommentCommand_PreWorkflowHookError(t *testing.T) {
 
 			ch.PreWorkflowHooksCommandRunner = preWorkflowHooksCommandRunner
 
-			ch.RunCommentCommand(ctx, fixtures.GithubRepo, modelPull.BaseRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: cmd}, time.Now())
+			ch.RunCommentCommand(ctx, fixtures.GithubRepo, modelPull.BaseRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: cmd}, time.Now(), 0)
 			_, _, _, status, cmdName, _, _ := vcsUpdater.VerifyWasCalledOnce().UpdateCombined(matchers.AnyContextContext(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsVcsStatus(), matchers.AnyCommandName(), AnyString(), AnyString()).GetCapturedArguments()
 			Equals(t, models.FailedVCSStatus, status)
 			Equals(t, cmd, cmdName)
@@ -241,7 +241,7 @@ func TestRunCommentCommand_PreWorkflowHookError(t *testing.T) {
 
 		ch.PreWorkflowHooksCommandRunner = preWorkflowHooksCommandRunner
 
-		ch.RunCommentCommand(ctx, fixtures.GithubRepo, modelPull.BaseRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now())
+		ch.RunCommentCommand(ctx, fixtures.GithubRepo, modelPull.BaseRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now(), 0)
 		_, _, _, status, cmdName, _, _ := vcsUpdater.VerifyWasCalledOnce().UpdateCombined(matchers.AnyContextContext(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsVcsStatus(), matchers.AnyCommandName(), AnyString(), AnyString()).GetCapturedArguments()
 		Equals(t, models.FailedVCSStatus, status)
 		Equals(t, command.PolicyCheck, cmdName)
@@ -255,7 +255,7 @@ func TestRunCommentCommandApprovePolicy_NoProjects_SilenceEnabled(t *testing.T) 
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState}
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now(), 0)
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 	vcsUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
 		matchers.AnyContextContext(),
@@ -278,7 +278,7 @@ func TestRunCommentCommand_DisableApplyAllDisabled(t *testing.T) {
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState, Num: fixtures.Pull.Num}
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply}, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "**Error:** Running `atlantis apply` without flags is disabled. You must specify which project to apply via the `-d <dir>`, `-w <workspace>` or `-p <project name>` flags.", "apply")
 }
 
@@ -295,7 +295,7 @@ func TestForceApplyRunCommentCommandRunner_CommentWhenEnabled(t *testing.T) {
 
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState, Num: fixtures.Pull.Num}
 
-	fa.RunCommentCommand(ctx, fixtures.GithubRepo, models.Repo{}, models.PullRequest{}, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply, ForceApply: true}, time.Now())
+	fa.RunCommentCommand(ctx, fixtures.GithubRepo, models.Repo{}, models.PullRequest{}, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply, ForceApply: true}, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "⚠️ WARNING ⚠️\n\n You have bypassed all apply requirements for this PR 🚀 . This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘 .\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n", "")
 }
 
@@ -316,7 +316,7 @@ func TestRunCommentCommand_DisableDisableAutoplan(t *testing.T) {
 			},
 		}, nil)
 
-	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now())
+	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now(), 0)
 	projectCommandBuilder.VerifyWasCalled(Never()).BuildAutoplanCommands(matchers.AnyPtrToEventsCommandContext())
 }
 
@@ -327,7 +327,7 @@ func TestRunCommentCommand_ClosedPull(t *testing.T) {
 	ctx := context.Background()
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.ClosedPullState, Num: fixtures.Pull.Num}
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, nil, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, nil, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "Atlantis commands can't be run on closed pull requests", "")
 }
 
@@ -342,7 +342,7 @@ func TestRunCommentCommand_MatchedBranch(t *testing.T) {
 	})
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, BaseBranch: "main"}
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Plan}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Plan}, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, modelPull.Num, "Ran Plan for 0 projects:\n\n\n\n", "plan")
 }
 
@@ -357,7 +357,7 @@ func TestRunCommentCommand_UnmatchedBranch(t *testing.T) {
 	})
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, BaseBranch: "foo"}
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Plan}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Plan}, time.Now(), 0)
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 }
 
@@ -370,7 +370,7 @@ func TestRunUnlockCommand_VCSComment(t *testing.T) {
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState, Num: fixtures.Pull.Num}
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Unlock}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Unlock}, time.Now(), 0)
 
 	deleteLockCommand.VerifyWasCalledOnce().DeleteLocksByPull(fixtures.GithubRepo.FullName, fixtures.Pull.Num)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, fixtures.Pull.Num, "All Atlantis locks for this PR have been unlocked and plans discarded", "unlock")
@@ -386,7 +386,7 @@ func TestRunUnlockCommandFail_VCSComment(t *testing.T) {
 	When(deleteLockCommand.DeleteLocksByPull(fixtures.GithubRepo.FullName, fixtures.Pull.Num)).ThenReturn(0, errors.New("err"))
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Unlock}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Unlock}, time.Now(), 0)
 
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, fixtures.Pull.Num, "Failed to delete PR locks", "unlock")
 }
@@ -403,7 +403,7 @@ func TestRunAutoplanCommand_PreWorkflowHookError(t *testing.T) {
 
 	ch.PreWorkflowHooksCommandRunner = preWorkflowHooksCommandRunner
 
-	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now())
+	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now(), 0)
 	_, _, _, status, cmdName, _, _ := vcsUpdater.VerifyWasCalledOnce().UpdateCombined(matchers.AnyContextContext(), matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest(), matchers.AnyModelsVcsStatus(), matchers.AnyCommandName(), AnyString(), AnyString()).GetCapturedArguments()
 	Equals(t, models.FailedVCSStatus, status)
 	Equals(t, command.Plan, cmdName)
@@ -431,7 +431,7 @@ func TestFailedApprovalCreatesFailedStatusUpdate(t *testing.T) {
 
 	When(workingDir.GetPullDir(fixtures.GithubRepo, fixtures.Pull)).ThenReturn(tmp, nil)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.ApprovePolicies}, time.Now(), 0)
 	vcsUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
 		matchers.AnyContextContext(),
 		matchers.AnyModelsRepo(),
@@ -480,7 +480,7 @@ func TestApprovedPoliciesUpdateFailedPolicyStatus(t *testing.T) {
 
 	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, fixtures.Pull.Num, &command.Comment{
 		Name: command.ApprovePolicies,
-	}, time.Now())
+	}, time.Now(), 0)
 	vcsUpdater.VerifyWasCalledOnce().UpdateCombinedCount(
 		matchers.AnyContextContext(),
 		matchers.AnyModelsRepo(),
@@ -536,7 +536,7 @@ func TestApplyMergeablityWhenPolicyCheckFails(t *testing.T) {
 	})
 
 	When(workingDir.GetPullDir(fixtures.GithubRepo, modelPull)).ThenReturn(tmp, nil)
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Apply}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, modelPull, fixtures.User, fixtures.Pull.Num, &command.Comment{Name: command.Apply}, time.Now(), 0)
 }
 
 func TestRunCommentCommand_DrainOngoing(t *testing.T) {
@@ -544,7 +544,7 @@ func TestRunCommentCommand_DrainOngoing(t *testing.T) {
 	vcsClient := setup(t)
 	ctx := context.Background()
 	drainer.ShutdownBlocking()
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, models.PullRequest{}, fixtures.User, fixtures.Pull.Num, nil, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, models.PullRequest{}, fixtures.User, fixtures.Pull.Num, nil, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, fixtures.Pull.Num, "Atlantis server is shutting down, please try again later.", "")
 }
 
@@ -552,7 +552,7 @@ func TestRunCommentCommand_DrainNotOngoing(t *testing.T) {
 	t.Log("if drain is not ongoing then remove ongoing operation must be called even if panic occurred")
 	setup(t)
 	ctx := context.Background()
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, models.PullRequest{}, fixtures.User, fixtures.Pull.Num, nil, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, models.PullRequest{}, fixtures.User, fixtures.Pull.Num, nil, time.Now(), 0)
 	Equals(t, 0, drainer.GetStatus().InProgressOps)
 }
 
@@ -561,7 +561,7 @@ func TestRunAutoplanCommand_DrainOngoing(t *testing.T) {
 	vcsClient := setup(t)
 	ctx := context.Background()
 	drainer.ShutdownBlocking()
-	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now())
+	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now(), 0)
 	vcsClient.VerifyWasCalledOnce().CreateComment(fixtures.GithubRepo, fixtures.Pull.Num, "Atlantis server is shutting down, please try again later.", "plan")
 }
 
@@ -572,7 +572,7 @@ func TestRunAutoplanCommand_DrainNotOngoing(t *testing.T) {
 	fixtures.Pull.BaseRepo = fixtures.GithubRepo
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(false)
 	When(projectCommandBuilder.BuildAutoplanCommands(matchers.AnyPtrToEventsCommandContext())).ThenPanic("panic test - if you're seeing this in a test failure this isn't the failing test")
-	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now())
+	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now(), 0)
 	projectCommandBuilder.VerifyWasCalledOnce().BuildAutoplanCommands(matchers.AnyPtrToEventsCommandContext())
 	Equals(t, 0, drainer.GetStatus().InProgressOps)
 }
@@ -584,7 +584,7 @@ func TestRunCommentCommand_DropStaleRequest(t *testing.T) {
 	modelPull := models.PullRequest{BaseRepo: fixtures.GithubRepo, State: models.OpenPullState, Num: fixtures.Pull.Num}
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(true)
 
-	ch.RunCommentCommand(ctx, fixtures.GithubRepo, models.Repo{}, models.PullRequest{}, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply}, time.Now())
+	ch.RunCommentCommand(ctx, fixtures.GithubRepo, models.Repo{}, models.PullRequest{}, fixtures.User, modelPull.Num, &command.Comment{Name: command.Apply}, time.Now(), 0)
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 }
 
@@ -594,6 +594,6 @@ func TestRunAutoplanCommand_DropStaleRequest(t *testing.T) {
 	ctx := context.Background()
 	When(staleCommandChecker.CommandIsStale(matchers.AnyPtrToModelsCommandContext())).ThenReturn(true)
 
-	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now())
+	ch.RunAutoplanCommand(ctx, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User, time.Now(), 0)
 	vcsClient.VerifyWasCalled(Never()).CreateComment(matchers.AnyModelsRepo(), AnyInt(), AnyString(), AnyString())
 }

--- a/server/neptune/gateway/event/pull_request_handler.go
+++ b/server/neptune/gateway/event/pull_request_handler.go
@@ -13,10 +13,11 @@ import (
 
 // PullRequestEvent is our internal representation of a vcs based pr event
 type PullRequest struct {
-	Pull      models.PullRequest
-	User      models.User
-	EventType models.PullRequestEventType
-	Timestamp time.Time
+	Pull              models.PullRequest
+	User              models.User
+	EventType         models.PullRequestEventType
+	Timestamp         time.Time
+	InstallationToken int64
 }
 
 func NewAutoplannerValidatorProxy(

--- a/server/vcs/provider/github/converter/pull_event.go
+++ b/server/vcs/provider/github/converter/pull_event.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"github.com/palantir/go-githubapp/githubapp"
 	"time"
 
 	"github.com/google/go-github/v45/github"
@@ -63,10 +64,13 @@ func (e PullEventConverter) Convert(pullEvent *github.PullRequestEvent) (event.P
 		eventTimestamp = *pullEvent.PullRequest.UpdatedAt
 	}
 
+	installationToken := githubapp.GetInstallationIDFromEvent(pullEvent)
+
 	return event.PullRequest{
-		Pull:      pull,
-		EventType: pullEventType,
-		User:      models.User{Username: senderUsername},
-		Timestamp: eventTimestamp,
+		Pull:              pull,
+		EventType:         pullEventType,
+		User:              models.User{Username: senderUsername},
+		Timestamp:         eventTimestamp,
+		InstallationToken: installationToken,
 	}, nil
 }

--- a/server/vcs/provider/github/converter/pull_event_test.go
+++ b/server/vcs/provider/github/converter/pull_event_test.go
@@ -18,6 +18,9 @@ var PullEvent = github.PullRequestEvent{
 	Repo:        &Repo,
 	PullRequest: &Pull,
 	Action:      github.String("opened"),
+	Installation: &github.Installation{
+		ID: github.Int64(1),
+	},
 }
 
 func TestConvert_PullRequestEvent(t *testing.T) {
@@ -78,6 +81,7 @@ func TestConvert_PullRequestEvent(t *testing.T) {
 	}, actPull.Pull)
 	Equals(t, models.OpenedPullEvent, actPull.EventType)
 	Equals(t, models.User{Username: "user"}, actPull.User)
+	Equals(t, int64(1), actPull.InstallationToken)
 }
 
 func TestConvert_PullRequestEvent_Draft(t *testing.T) {
@@ -102,6 +106,7 @@ func TestConvert_PullRequestEvent_Draft(t *testing.T) {
 	pull, err = subject.Convert(&testEvent)
 	Ok(t, err)
 	Equals(t, models.OpenedPullEvent, pull.EventType)
+	Equals(t, int64(1), pull.InstallationToken)
 }
 
 func TestConvert_PullRequestEvent_EventType(t *testing.T) {
@@ -196,6 +201,7 @@ func TestConvert_PullRequestEvent_EventType(t *testing.T) {
 			subjectDraft.AllowDraftPRs = true
 			pull, err = subjectDraft.Convert(&event)
 			Ok(t, err)
+			Equals(t, int64(1), pull.InstallationToken)
 			Equals(t, c.exp, pull.EventType)
 		})
 	}


### PR DESCRIPTION
[Initially wanted to avoid](https://github.com/lyft/atlantis/pull/474#discussion_r1040632512) changing the legacy code to pass the installation token, but fetching it from the context won't work because we switch to using context.Backround() in the handlers [here](https://github.com/lyft/atlantis/blob/release-v0.17.3-lyft.1/server/controllers/events/handlers/comment.go#L96) and [here](https://github.com/lyft/atlantis/blob/release-v0.17.3-lyft.1/server/controllers/events/handlers/pull_request.go#L44). This will test building it into the command context itself.