### PR TITLE
Modify timeout values.

### DIFF
--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -55,8 +55,8 @@ type QueueWorker interface {
 
 func Workflow(ctx workflow.Context, request Request, tfWorkflow terraform.Workflow) error {
 	options := workflow.ActivityOptions{
-		TaskQueue:              TaskQueue,
-		ScheduleToCloseTimeout: 5 * time.Second,
+		TaskQueue:           TaskQueue,
+		StartToCloseTimeout: 5 * time.Second,
 	}
 	ctx = workflow.WithActivityOptions(ctx, options)
 

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -38,8 +38,8 @@ type jobRunner interface {
 }
 
 const (
-	ScheduleToCloseTimeout = 24 * time.Hour
-	HeartBeatTimeout       = 1 * time.Minute
+	StartToCloseTimeout = 24 * time.Hour
+	HeartBeatTimeout    = 1 * time.Minute
 
 	// 1 week timeout for review gate
 	ReviewGateTimeout = 24 * time.Hour * 7
@@ -231,8 +231,8 @@ func (r *Runner) Run(ctx workflow.Context) error {
 
 func (r *Runner) run(ctx workflow.Context) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ScheduleToCloseTimeout: ScheduleToCloseTimeout,
-		HeartbeatTimeout:       HeartBeatTimeout,
+		StartToCloseTimeout: StartToCloseTimeout,
+		HeartbeatTimeout:    HeartBeatTimeout,
 	})
 	var response *activities.GetWorkerInfoResponse
 	err := workflow.ExecuteActivity(ctx, r.TerraformActivities.GetWorkerInfo).Get(ctx, &response)


### PR DESCRIPTION
Changing from ScheduleToClose because an activity should try to be scheduled for an unlimited amount of time. I don't think it makes sense to restrict that, but once it schedules, then we can enforce a StartToCloseTimeout.