### PR TITLE
Update command template to include pointer on how to view status/logs of an operation for a root

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -49,6 +49,8 @@ var commandTemplate = `
 | **Command Name**  |  **Status** |  
 | - | - |
 | %s  | {%s}  | 
+:information_source: Visit the checkrun for the root in the navigation panel on your left to view logs and details on the operation. 
+
 `
 
 var commandTemplateWithCount = `


### PR DESCRIPTION
Customer reported confusion around how to view the individual checkruns for a root when looking at the aggregate checkrun. https://lyft.slack.com/archives/C7HKA53FF/p1671030483361469 

So, we add an ℹ️ to the command template which instructs the user to navigate to the checkrun for the root to view logs and status of the operation. 