### PR TITLE
Default to auto-apply except for diverging cases.

### DIFF
--- a/server/neptune/workflows/activities/terraform/job.go
+++ b/server/neptune/workflows/activities/terraform/job.go
@@ -4,11 +4,16 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
 )
 
-type PlanApprovalType string
+type PlanApproval struct {
+	Type   PlanApprovalType
+	Reason string
+}
+
+type PlanApprovalType int
 
 const (
-	ManualApproval PlanApprovalType = "manual"
-	AutoApproval   PlanApprovalType = "auto"
+	AutoApproval PlanApprovalType = iota
+	ManualApproval
 )
 
 type PlanMode string
@@ -20,7 +25,7 @@ func NewDestroyPlanMode() *PlanMode {
 
 type PlanJob struct {
 	Mode     *PlanMode
-	Approval PlanApprovalType
+	Approval PlanApproval
 	execute.Job
 }
 

--- a/server/neptune/workflows/activities/terraform/root.go
+++ b/server/neptune/workflows/activities/terraform/root.go
@@ -18,6 +18,11 @@ type Root struct {
 	Rerun     bool
 }
 
+func (r Root) WithPlanApprovalOverride(a PlanApproval) Root {
+	r.Plan.Approval = a
+	return r
+}
+
 type Trigger string
 
 const (

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -98,10 +98,7 @@ func signalWorkflow(env *testsuite.TestWorkflowEnvironment) {
 			},
 			RepoRelPath: "terraform/mytestroot",
 			PlanMode:    workflows.NormalPlanMode,
-
-			// auto approve since we are testing
-			PlanApprovalType: "auto",
-			Trigger:          workflows.MergeTrigger,
+			Trigger:     workflows.MergeTrigger,
 		},
 		Repo: workflows.Repo{
 			FullName: "nish/repo",

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -15,8 +15,10 @@ func Root(external request.Root) terraform.Root {
 		Plan: terraform.PlanJob{
 			Job: execute.Job{
 				Steps: steps(external.Plan.Steps)},
-			Mode:     mode(external.PlanMode),
-			Approval: terraform.PlanApprovalType(external.PlanApprovalType),
+			Mode: mode(external.PlanMode),
+			Approval: terraform.PlanApproval{
+				Type: terraform.PlanApprovalType(external.PlanApproval.Type),
+			},
 		},
 		Path:      external.RepoRelPath,
 		TfVersion: external.TfVersion,

--- a/server/neptune/workflows/internal/deploy/request/root.go
+++ b/server/neptune/workflows/internal/deploy/request/root.go
@@ -14,18 +14,27 @@ const (
 	ManualTrigger Trigger = "manual"
 )
 
-type PlanApprovalType string
+type PlanApproval struct {
+	Type PlanApprovalType
+}
+
+type PlanApprovalType int64
+
+const (
+	AutoApproval PlanApprovalType = iota
+	ManualApproval
+)
 
 type Root struct {
-	Name             string
-	Apply            Job
-	Plan             Job
-	RepoRelPath      string
-	TfVersion        string
-	PlanMode         PlanMode
-	PlanApprovalType string
-	Trigger          Trigger
-	Rerun            bool
+	Name         string
+	Apply        Job
+	Plan         Job
+	RepoRelPath  string
+	TfVersion    string
+	PlanMode     PlanMode
+	PlanApproval PlanApproval
+	Trigger      Trigger
+	Rerun        bool
 }
 
 type Job struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -25,7 +25,7 @@ func NewValidationError(msg string, format ...interface{}) *ValidationError {
 }
 
 type terraformWorkflowRunner interface {
-	Run(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo) error
+	Run(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo, diffDirection activities.DiffDirection) error
 }
 
 type dbActivities interface {
@@ -71,7 +71,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWor
 	}
 
 	// don't wrap this err as it's not necessary and will mess with any err type assertions we might need to do
-	err = p.TerraformWorkflowRunner.Run(ctx, requestedDeployment)
+	err = p.TerraformWorkflowRunner.Run(ctx, requestedDeployment, commitDirection)
 
 	// No need to persist deployment if it's a PlanRejectionError
 	if _, ok := err.(*terraformWorkflow.PlanRejectionError); ok {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -33,7 +33,7 @@ type testTerraformWorkflowRunner struct {
 	expectedErrorType  ErrorType
 }
 
-func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo) error {
+func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, diffDirection activities.DiffDirection) error {
 	if r.expectedErrorType == PlanRejectionError {
 		return terraform.NewPlanRejectionError("plan rejected")
 	} else if r.expectedErrorType == TerraformClientError {

--- a/server/neptune/workflows/internal/terraform/gate/review.go
+++ b/server/neptune/workflows/internal/terraform/gate/review.go
@@ -41,7 +41,7 @@ func (r *Review) Await(ctx workflow.Context, root terraform.Root, planSummary te
 		r.MetricsHandler.Timer(PlanReviewTimerStat).Record(time.Since(waitStartTime))
 	}()
 
-	if root.Plan.Approval == terraform.AutoApproval || planSummary.IsEmpty() {
+	if root.Plan.Approval.Type == terraform.AutoApproval || planSummary.IsEmpty() {
 		return Approved
 	}
 

--- a/server/neptune/workflows/internal/terraform/gate/review_test.go
+++ b/server/neptune/workflows/internal/terraform/gate/review_test.go
@@ -31,7 +31,9 @@ func testReviewWorkflow(ctx workflow.Context, r req) (res, error) {
 
 	status := review.Await(ctx, terraform.Root{
 		Plan: terraform.PlanJob{
-			Approval: terraform.ManualApproval,
+			Approval: terraform.PlanApproval{
+				Type: terraform.ManualApproval,
+			},
 		},
 	}, r.PlanSummary)
 

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -47,6 +47,9 @@ var testLocalRoot = &terraformModel.LocalRoot{
 					},
 				},
 			},
+			Approval: terraformModel.PlanApproval{
+				Type: terraformModel.ManualApproval,
+			},
 		},
 		Apply: execute.Job{
 			Steps: []execute.Step{


### PR DESCRIPTION
Based on recent discussions, let's default to auto-apply to satisfy the 90% case of changes that are going out.  For now, we will go back to manual confirmation in the event that we deem it not safe.  For now this is only for the diverged commit direction case.

A followup PR will actually displaying the manual approval reason in the check run, I didn't add that here to limit the scope of changes in one PR.