### PR TITLE
Support GH-team based policy ownership

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -835,7 +835,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		},
 		Exec: runtime_models.LocalExec{},
 		PolicyFilter: &events.ApprovedPolicyFilter{
-			GlobalCfg: globalCfg,
 			PRReviewsFetcher: &mockReviewFetcher{
 				approvers: []string{},
 			},

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -52,16 +52,16 @@ func (o PolicyOwners) ToValid() valid.PolicyOwners {
 }
 
 type PolicySet struct {
-	Path   string       `yaml:"path" json:"path"`
-	Source string       `yaml:"source" json:"source"`
-	Name   string       `yaml:"name" json:"name"`
-	Owners PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	Path   string `yaml:"path" json:"path"`
+	Source string `yaml:"source" json:"source"`
+	Name   string `yaml:"name" json:"name"`
+	Owner  string `yaml:"owner,omitempty" json:"owner,omitempty"`
 }
 
 func (p PolicySet) Validate() error {
 	return validation.ValidateStruct(&p,
 		validation.Field(&p.Name, validation.Required.Error("is required")),
-		validation.Field(&p.Owners),
+		validation.Field(&p.Owner, validation.Required.Error("is required")),
 		validation.Field(&p.Path, validation.Required.Error("is required")),
 		validation.Field(&p.Source, validation.In(valid.LocalPolicySet, valid.GithubPolicySet).Error("only 'local' and 'github' source types are supported")),
 	)
@@ -73,7 +73,7 @@ func (p PolicySet) ToValid() valid.PolicySet {
 	policySet.Name = p.Name
 	policySet.Path = p.Path
 	policySet.Source = p.Source
-	policySet.Owners = p.Owners.ToValid()
+	policySet.Owner = p.Owner
 
 	return policySet
 }

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -75,17 +75,13 @@ func TestPolicySets_Validate(t *testing.T) {
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name-1",
+						Owner:  "owner1",
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
 					},
 					{
-						Name: "policy-name-2",
-						Owners: raw.PolicyOwners{
-							Users: []string{
-								"john-doe",
-								"jane-doe",
-							},
-						},
+						Name:   "policy-name-2",
+						Owner:  "owner2",
 						Path:   "rel/path/to/source",
 						Source: valid.GithubPolicySet,
 					},
@@ -108,7 +104,7 @@ func TestPolicySets_Validate(t *testing.T) {
 					{},
 				},
 			},
-			expErr: "policy_sets: (0: (name: is required; path: is required.).).",
+			expErr: "policy_sets: (0: (name: is required; owner: is required; path: is required.).).",
 		},
 		{
 			description: "invalid source type",
@@ -116,6 +112,7 @@ func TestPolicySets_Validate(t *testing.T) {
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "good-policy",
+						Owner:  "owner1",
 						Source: "invalid-source-type",
 						Path:   "rel/path/to/source",
 					},
@@ -130,6 +127,7 @@ func TestPolicySets_Validate(t *testing.T) {
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name-1",
+						Owner:  "owner1",
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
 					},
@@ -144,6 +142,7 @@ func TestPolicySets_Validate(t *testing.T) {
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name-1",
+						Owner:  "owner1",
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
 					},
@@ -183,13 +182,7 @@ func TestPolicySets_ToValid(t *testing.T) {
 				},
 				PolicySets: []raw.PolicySet{
 					{
-						Name: "good-policy",
-						Owners: raw.PolicyOwners{
-							Users: []string{
-								"john-doe",
-								"jane-doe",
-							},
-						},
+						Name:   "good-policy",
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
 					},
@@ -202,13 +195,7 @@ func TestPolicySets_ToValid(t *testing.T) {
 				},
 				PolicySets: []valid.PolicySet{
 					{
-						Name: "good-policy",
-						Owners: valid.PolicyOwners{
-							Users: []string{
-								"john-doe",
-								"jane-doe",
-							},
-						},
+						Name:   "good-policy",
 						Path:   "rel/path/to/source",
 						Source: "local",
 					},
@@ -221,13 +208,7 @@ func TestPolicySets_ToValid(t *testing.T) {
 				Version: String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
-						Name: "good-policy",
-						Owners: raw.PolicyOwners{
-							Users: []string{
-								"john-doe",
-								"jane-doe",
-							},
-						},
+						Name:   "good-policy",
 						Path:   "rel/path/to/source",
 						Source: valid.LocalPolicySet,
 					},
@@ -237,13 +218,7 @@ func TestPolicySets_ToValid(t *testing.T) {
 				Version: version,
 				PolicySets: []valid.PolicySet{
 					{
-						Name: "good-policy",
-						Owners: valid.PolicyOwners{
-							Users: []string{
-								"john-doe",
-								"jane-doe",
-							},
-						},
+						Name:   "good-policy",
 						Path:   "rel/path/to/source",
 						Source: "local",
 					},

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -26,7 +26,7 @@ type PolicySet struct {
 	Source string
 	Path   string
 	Name   string
-	Owners PolicyOwners
+	Owner  string
 }
 
 func (p *PolicySets) HasPolicies() bool {

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -42,17 +42,20 @@ type ConfTestExecutor struct {
 	PolicyFilter   policyFilter
 }
 
-func NewConfTestExecutor(creator githubapp.ClientCreator) *ConfTestExecutor {
+func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestExecutor {
+	reviewsFetcher := &github.PRReviewerFetcher{
+		ClientCreator: creator,
+	}
+	teamMemberFetcher := &github.TeamMemberFetcher{
+		ClientCreator: creator,
+		Org:           org,
+	}
 	return &ConfTestExecutor{
 		SourceResolver: &SourceResolverProxy{
 			LocalSourceResolver: &LocalSourceResolver{},
 		},
-		Exec: runtime_models.LocalExec{},
-		PolicyFilter: &events.ApprovedPolicyFilter{
-			PRReviewsFetcher: &github.PRReviewerFetcher{
-				ClientCreator: creator,
-			},
-		},
+		Exec:         runtime_models.LocalExec{},
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, teamMemberFetcher),
 	}
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -42,14 +42,13 @@ type ConfTestExecutor struct {
 	PolicyFilter   policyFilter
 }
 
-func NewConfTestExecutor(cfg valid.GlobalCfg, creator githubapp.ClientCreator) *ConfTestExecutor {
+func NewConfTestExecutor(creator githubapp.ClientCreator) *ConfTestExecutor {
 	return &ConfTestExecutor{
 		SourceResolver: &SourceResolverProxy{
 			LocalSourceResolver: &LocalSourceResolver{},
 		},
 		Exec: runtime_models.LocalExec{},
 		PolicyFilter: &events.ApprovedPolicyFilter{
-			GlobalCfg: cfg,
 			PRReviewsFetcher: &github.PRReviewerFetcher{
 				ClientCreator: creator,
 			},

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -30,8 +30,7 @@ func NewApprovedPolicyFilter(prReviewsFetcher prReviewsFetcher, teamMemberFetche
 	}
 }
 
-// Filter performs an all-or-nothing filter against failed policies for now. If PR reviewer is a global policy owner,
-// all policies will pass.
+// Filter will remove failed policies if the underlying PR has been approved by a policy owner
 func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error) {
 	// Skip GH API calls if no policies failed
 	if len(failedPolicies) == 0 {

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -11,10 +11,15 @@ type prReviewsFetcher interface {
 	ListApprovalReviewers(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error)
 }
 
+type teamMemberFetcher interface {
+	ListTeamMembers(ctx context.Context, installationToken int64, teamSlug string) ([]string, error)
+}
+
 type ApprovedPolicyFilter struct {
-	//TODO: remove in favor of an in-memory cache of owners
-	GlobalCfg        valid.GlobalCfg
-	PRReviewsFetcher prReviewsFetcher
+	owners map[string][]string //cache
+
+	PRReviewsFetcher  prReviewsFetcher
+	TeamMemberFetcher teamMemberFetcher
 }
 
 // Filter performs an all-or-nothing filter against failed policies for now. If PR reviewer is a global policy owner,
@@ -31,11 +36,51 @@ func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int
 		return failedPolicies, errors.Wrap(err, "failed to fetch GH PR reviews")
 	}
 
-	// TODO: check each policy set separately when per-policy owners configuration is implemented
-	for _, reviewer := range approvedReviewers {
-		if p.GlobalCfg.PolicySets.IsOwner(reviewer) {
-			return nil, nil
+	// Filter out policies that already have been approved within GH
+	var filteredFailedPolicies []valid.PolicySet
+	for _, failedPolicy := range failedPolicies {
+		approved, err := p.policyApproved(ctx, installationToken, approvedReviewers, failedPolicy)
+		if err != nil {
+			return failedPolicies, errors.Wrap(err, "validating policy approval")
+		}
+		if !approved {
+			filteredFailedPolicies = append(filteredFailedPolicies, failedPolicy)
 		}
 	}
-	return failedPolicies, nil
+	return filteredFailedPolicies, nil
+}
+
+func (p *ApprovedPolicyFilter) policyApproved(ctx context.Context, installationToken int64, approvedReviewers []string, failedPolicy valid.PolicySet) (bool, error) {
+	// Check if any reviewer is an owner of the failed policy set
+	if p.ownersContainsPolicy(approvedReviewers, failedPolicy) {
+		return true, nil
+	}
+
+	// Cache miss, fetch and try again
+	err := p.getOwners(ctx, installationToken, failedPolicy)
+	if err != nil {
+		return false, errors.Wrap(err, "updating owners cache")
+	}
+	return p.ownersContainsPolicy(approvedReviewers, failedPolicy), nil
+}
+
+func (p *ApprovedPolicyFilter) ownersContainsPolicy(approvedReviewers []string, failedPolicy valid.PolicySet) bool {
+	// Check if any reviewer is an owner of the failed policy set
+	for _, owner := range p.owners[failedPolicy.Owner] {
+		for _, reviewer := range approvedReviewers {
+			if reviewer == owner {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *ApprovedPolicyFilter) getOwners(ctx context.Context, installationToken int64, policy valid.PolicySet) error {
+	members, err := p.TeamMemberFetcher.ListTeamMembers(ctx, installationToken, policy.Owner)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch GH team members")
+	}
+	p.owners[policy.Name] = members
+	return nil
 }

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -1,6 +1,6 @@
 package events
 
-// not using a separate test package to be able to test some fields in private struct approvedPolicyFilter
+// not using a separate test package to be able to test some private fields in struct ApprovedPolicyFilter
 
 import (
 	"context"

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -1,43 +1,61 @@
-package events_test
+package events
+
+// not using a separate test package to be able to test some fields in private struct approvedPolicyFilter
 
 import (
 	"context"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
-	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 const (
-	ownerA     = "A"
-	ownerB     = "B"
-	ownerC     = "C"
-	policyName = "some-policy"
+	ownerA      = "A"
+	ownerB      = "B"
+	ownerC      = "C"
+	policyName  = "some-policy"
+	policyOwner = "team"
 )
 
 func TestFilter_Approved(t *testing.T) {
 	reviewFetcher := &mockReviewFetcher{
 		approvers: []string{ownerB},
 	}
-	globalCfg := valid.GlobalCfg{
-		PolicySets: valid.PolicySets{
-			Owners: valid.PolicyOwners{
-				Users: []string{ownerA, ownerB, ownerC},
-			},
-		},
+	teamFetcher := &mockTeamMemberFetcher{
+		members: []string{ownerA, ownerB, ownerC},
 	}
-	policyFilter := events.ApprovedPolicyFilter{
-		GlobalCfg:        globalCfg,
-		PRReviewsFetcher: reviewFetcher,
-	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
 	failedPolicies := []valid.PolicySet{
-		{Name: policyName},
+		{Name: policyName, Owner: policyOwner},
 	}
 
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.isCalled)
+	assert.Empty(t, filteredPolicies)
+}
+
+func TestFilter_ApprovedCacheMiss(t *testing.T) {
+	team := []string{ownerA, ownerB, ownerC}
+	reviewFetcher := &mockReviewFetcher{
+		approvers: []string{ownerB},
+	}
+	teamFetcher := &mockTeamMemberFetcher{
+		members: team,
+	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
+	policyFilter.owners = map[string][]string{
+		policyOwner: team,
+	}
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName, Owner: policyOwner},
+	}
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.NoError(t, err)
+	assert.True(t, reviewFetcher.isCalled)
+	assert.False(t, teamFetcher.isCalled)
 	assert.Empty(t, filteredPolicies)
 }
 
@@ -45,24 +63,18 @@ func TestFilter_NotApproved(t *testing.T) {
 	reviewFetcher := &mockReviewFetcher{
 		approvers: []string{ownerB},
 	}
-	globalCfg := valid.GlobalCfg{
-		PolicySets: valid.PolicySets{
-			Owners: valid.PolicyOwners{
-				Users: []string{ownerA, ownerC},
-			},
-		},
+	teamFetcher := &mockTeamMemberFetcher{
+		members: []string{ownerA, ownerC},
 	}
-	policyFilter := events.ApprovedPolicyFilter{
-		GlobalCfg:        globalCfg,
-		PRReviewsFetcher: reviewFetcher,
-	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
 	failedPolicies := []valid.PolicySet{
-		{Name: policyName},
+		{Name: policyName, Owner: policyOwner},
 	}
 
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.isCalled)
+	assert.True(t, teamFetcher.isCalled)
 	assert.Equal(t, failedPolicies, filteredPolicies)
 }
 
@@ -70,22 +82,16 @@ func TestFilter_NoFailedPolicies(t *testing.T) {
 	reviewFetcher := &mockReviewFetcher{
 		approvers: []string{ownerB},
 	}
-	globalCfg := valid.GlobalCfg{
-		PolicySets: valid.PolicySets{
-			Owners: valid.PolicyOwners{
-				Users: []string{ownerA, ownerB, ownerC},
-			},
-		},
+	teamFetcher := &mockTeamMemberFetcher{
+		members: []string{ownerA, ownerB, ownerC},
 	}
-	policyFilter := events.ApprovedPolicyFilter{
-		GlobalCfg:        globalCfg,
-		PRReviewsFetcher: reviewFetcher,
-	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
 	var failedPolicies []valid.PolicySet
 
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.isCalled)
+	assert.False(t, teamFetcher.isCalled)
 	assert.Empty(t, filteredPolicies)
 }
 
@@ -93,24 +99,37 @@ func TestFilter_FailedPRReviewFetch(t *testing.T) {
 	reviewFetcher := &mockReviewFetcher{
 		error: assert.AnError,
 	}
-	globalCfg := valid.GlobalCfg{
-		PolicySets: valid.PolicySets{
-			Owners: valid.PolicyOwners{
-				Users: []string{ownerA, ownerB, ownerC},
-			},
-		},
+	teamFetcher := &mockTeamMemberFetcher{
+		members: []string{ownerA, ownerB, ownerC},
 	}
-	policyFilter := events.ApprovedPolicyFilter{
-		GlobalCfg:        globalCfg,
-		PRReviewsFetcher: reviewFetcher,
-	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
 	failedPolicies := []valid.PolicySet{
-		{Name: policyName},
+		{Name: policyName, Owner: policyOwner},
 	}
 
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.isCalled)
+	assert.False(t, teamFetcher.isCalled)
+	assert.Equal(t, failedPolicies, filteredPolicies)
+}
+
+func TestFilter_FailedTeamMemberFetch(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		approvers: []string{ownerB},
+	}
+	teamFetcher := &mockTeamMemberFetcher{
+		error: assert.AnError,
+	}
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName, Owner: policyOwner},
+	}
+
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
+	assert.Error(t, err)
+	assert.True(t, reviewFetcher.isCalled)
+	assert.True(t, teamFetcher.isCalled)
 	assert.Equal(t, failedPolicies, filteredPolicies)
 }
 
@@ -123,4 +142,15 @@ type mockReviewFetcher struct {
 func (f *mockReviewFetcher) ListApprovalReviewers(_ context.Context, _ int64, _ models.Repo, _ int) ([]string, error) {
 	f.isCalled = true
 	return f.approvers, f.error
+}
+
+type mockTeamMemberFetcher struct {
+	members  []string
+	error    error
+	isCalled bool
+}
+
+func (m *mockTeamMemberFetcher) ListTeamMembers(_ context.Context, _ int64, _ string) ([]string, error) {
+	m.isCalled = true
+	return m.members, m.error
 }

--- a/server/server.go
+++ b/server/server.go
@@ -588,7 +588,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator, "org")
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, userConfig.GithubOrg)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,

--- a/server/server.go
+++ b/server/server.go
@@ -585,7 +585,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, "org")
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,

--- a/server/server.go
+++ b/server/server.go
@@ -585,7 +585,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(globalCfg, clientCreator)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,

--- a/server/vcs/provider/github/team_fetcher.go
+++ b/server/vcs/provider/github/team_fetcher.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 )
 
-type TeamFetcher struct {
+type TeamMemberFetcher struct {
 	ClientCreator githubapp.ClientCreator
 	Org           string
 }
 
-func (t *TeamFetcher) ListTeamMembers(ctx context.Context, installationToken int64, teamSlug string) ([]string, error) {
+func (t *TeamMemberFetcher) ListTeamMembers(ctx context.Context, installationToken int64, teamSlug string) ([]string, error) {
 	client, err := t.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating installation client")

--- a/server/vcs/provider/github/team_fetcher.go
+++ b/server/vcs/provider/github/team_fetcher.go
@@ -19,11 +19,13 @@ func (t *TeamMemberFetcher) ListTeamMembers(ctx context.Context, installationTok
 	}
 	var usernames []string
 	run := func(ctx context.Context, nextPage int) ([]*gh.User, *gh.Response, error) {
-		listOptions := gh.ListOptions{
-			PerPage: 100,
+		listOptions := &gh.TeamListTeamMembersOptions{
+			ListOptions: gh.ListOptions{
+				PerPage: 100,
+			},
 		}
 		listOptions.Page = nextPage
-		return client.Teams.ListTeamMembersBySlug(ctx, t.Org, teamSlug, &gh.TeamListTeamMembersOptions{})
+		return client.Teams.ListTeamMembersBySlug(ctx, t.Org, teamSlug, listOptions)
 	}
 	users, err := Iterate(ctx, run)
 	if err != nil {

--- a/server/vcs/provider/github/team_fetcher.go
+++ b/server/vcs/provider/github/team_fetcher.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+type TeamFetcher struct {
+	ClientCreator githubapp.ClientCreator
+	Org           string
+}
+
+func (t *TeamFetcher) ListTeamMembers(ctx context.Context, installationToken int64, teamSlug string) ([]string, error) {
+	client, err := t.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating installation client")
+	}
+	users, resp, err := client.Teams.ListTeamMembersBySlug(ctx, t.Org, teamSlug, &gh.TeamListTeamMembersOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching team members")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("not ok status fetching team members: %s", resp.Status)
+	}
+	var usernames []string
+	for _, user := range users {
+		usernames = append(usernames, user.GetLogin())
+	}
+	return usernames, nil
+}


### PR DESCRIPTION
Current policy check ownership logic relies on validating owner exists in a global list field defined in the startup configuration. Instead, this allows for a more granular approach to policy approvals by allowing specific GH team members to approve a policy specifically owned by them.

Changes include:
* creating an atlantis config at the policy level that defines the team name that "owns" the policy
* relying on above config + GH teams api to identify the current set of team members that owns the policy
* within the policy filter logic, we use check if a failing policy in a PR is already approved by a policy owner and filter those out when determining of the atlantis policy check run should fail
* to avoid constantly calling the GH teams API, we keep an in-memory cache of policy owners