### PR TITLE
Fix Command Template Message Formatting 

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -49,6 +49,7 @@ var commandTemplate = `
 | **Command Name**  |  **Status** |  
 | - | - |
 | %s  | {%s}  | 
+
 :information_source: Visit the checkrun for the root in the navigation panel on your left to view logs and details on the operation. 
 
 `
@@ -57,6 +58,9 @@ var commandTemplateWithCount = `
 | **Command Name** | **Num Total** | **Num Success** | **Status** |  
 | - | - | - | - |
 | %s | {%s} | {%s} | {%s} |  
+
+:information_source: Visit the checkrun for the root in the navigation panel on your left to view logs and details on the operation. 
+
 `
 
 // github checks conclusion


### PR DESCRIPTION
Github markdown populates the information text into the table without another newline character: https://github.com/lyft/orchestration-sandbox-neptune/pull/52/checks?check_run_id=10529446796