### PR TITLE
Gateway fixes for Pull Request Review Events

### DIFF
--- a/server/neptune/gateway/event/pull_request_review_handler_test.go
+++ b/server/neptune/gateway/event/pull_request_review_handler_test.go
@@ -48,8 +48,8 @@ func TestPullRequestReviewWorkerProxy_HandleSuccessWithFailedPolicies(t *testing
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.NoError(t, err)
@@ -77,8 +77,8 @@ func TestPullRequestReviewWorkerProxy_HandleSuccessNoFailedPolicies(t *testing.T
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.NoError(t, err)
@@ -106,8 +106,8 @@ func TestPullRequestReviewWorkerProxy_AllocationError(t *testing.T) {
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.Error(t, err)
@@ -134,8 +134,8 @@ func TestPullRequestReviewWorkerProxy_AllocationFalse(t *testing.T) {
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.NoError(t, err)
@@ -163,8 +163,8 @@ func TestPullRequestReviewWorkerProxy_NotApprovalEvent(t *testing.T) {
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: "something else",
-		Repo:   models.Repo{FullName: repoFullName},
+		State: "something else",
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.NoError(t, err)
@@ -194,8 +194,8 @@ func TestPullRequestReviewWorkerProxy_FetcherError(t *testing.T) {
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))
 	assert.Error(t, err)
@@ -225,8 +225,8 @@ func TestPullRequestReviewWorkerProxy_SNSError(t *testing.T) {
 		CheckRunFetcher: mockFetcher,
 	}
 	prrEvent := event.PullRequestReview{
-		Action: event.Approved,
-		Repo:   models.Repo{FullName: repoFullName},
+		State: event.Approved,
+		Repo:  models.Repo{FullName: repoFullName},
 	}
 
 	err := proxy.Handle(context.Background(), prrEvent, buildRequest(t))

--- a/server/vcs/provider/github/check_runs_fetcher.go
+++ b/server/vcs/provider/github/check_runs_fetcher.go
@@ -11,10 +11,10 @@ import (
 
 const (
 	CompletedStatus  = "completed"
-	FailedConclusion = "failed"
+	FailedConclusion = "failure"
 )
 
-var checkRunRegex = regexp.MustCompile("atlantis/policy_check: .*")
+var checkRunRegex = regexp.MustCompile("atlantis/policy_check.*")
 
 type CheckRunsFetcher struct {
 	ClientCreator githubapp.ClientCreator

--- a/server/vcs/provider/github/converter/pr_review_event.go
+++ b/server/vcs/provider/github/converter/pr_review_event.go
@@ -46,6 +46,7 @@ func (p PullRequestReviewEvent) Convert(e *github.PullRequestReviewEvent) (event
 	state := e.GetReview().GetState()
 	ref := e.GetReview().GetCommitID()
 	eventTimestamp := e.GetReview().GetSubmittedAt()
+	// if submitted_at is nil, API returns time.Time{}, so we use time.Now as a backup
 	if e.GetReview().GetSubmittedAt().Equal(time.Time{}) {
 		eventTimestamp = time.Now()
 	}

--- a/server/vcs/provider/github/converter/pr_review_event.go
+++ b/server/vcs/provider/github/converter/pr_review_event.go
@@ -1,36 +1,55 @@
 package converter
 
 import (
+	"fmt"
 	"github.com/google/go-github/v45/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"time"
 )
 
 type PullRequestReviewEvent struct {
 	RepoConverter RepoConverter
+	PullConverter PullConverter
 }
 
 func (p PullRequestReviewEvent) Convert(e *github.PullRequestReviewEvent) (event.PullRequestReview, error) {
 	installationToken := githubapp.GetInstallationIDFromEvent(e)
+	if e.GetRepo() == nil {
+		return event.PullRequestReview{}, fmt.Errorf("repo is nil")
+	}
 	repo, err := p.RepoConverter.Convert(e.GetRepo())
 	if err != nil {
 		return event.PullRequestReview{}, errors.Wrap(err, "converting repo")
 	}
+
+	if e.GetPullRequest() == nil {
+		return event.PullRequestReview{}, fmt.Errorf("pull request is nil")
+	}
+	pull, err := p.PullConverter.Convert(e.GetPullRequest())
+	if err != nil {
+		return event.PullRequestReview{}, errors.Wrap(err, "converting pull request")
+	}
 	user := models.User{
 		Username: e.GetSender().GetLogin(),
 	}
-	prNum := e.GetPullRequest().GetNumber()
-	action := e.GetAction()
+	state := e.GetReview().GetState()
 	ref := e.GetReview().GetCommitID()
+
+	eventTimestamp := e.GetReview().GetSubmittedAt()
+	if e.GetReview().GetSubmittedAt().Equal(time.Time{}) {
+		eventTimestamp = time.Now()
+	}
+
 	return event.PullRequestReview{
 		InstallationToken: installationToken,
 		Repo:              repo,
-		PRNum:             prNum,
 		User:              user,
-		Action:            action,
+		State:             state,
 		Ref:               ref,
+		Timestamp:         eventTimestamp,
+		Pull:              pull,
 	}, nil
-
 }

--- a/server/vcs/provider/github/converter/pr_review_event.go
+++ b/server/vcs/provider/github/converter/pr_review_event.go
@@ -32,12 +32,19 @@ func (p PullRequestReviewEvent) Convert(e *github.PullRequestReviewEvent) (event
 	if err != nil {
 		return event.PullRequestReview{}, errors.Wrap(err, "converting pull request")
 	}
+
+	if e.GetSender() == nil {
+		return event.PullRequestReview{}, errors.Wrap(err, "sender is nil")
+	}
 	user := models.User{
 		Username: e.GetSender().GetLogin(),
 	}
+
+	if e.GetReview() == nil {
+		return event.PullRequestReview{}, errors.Wrap(err, "review is nil")
+	}
 	state := e.GetReview().GetState()
 	ref := e.GetReview().GetCommitID()
-
 	eventTimestamp := e.GetReview().GetSubmittedAt()
 	if e.GetReview().GetSubmittedAt().Equal(time.Time{}) {
 		eventTimestamp = time.Now()

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -119,6 +119,7 @@ func NewHandler(
 		},
 		pullRequestReviewEventConverter: converter.PullRequestReviewEvent{
 			RepoConverter: repoConverter,
+			PullConverter: pullConverter,
 		},
 		checkRunEventConverter:   converter.CheckRunEvent{},
 		checkSuiteEventConverter: converter.CheckSuiteEvent{RepoConverter: repoConverter},
@@ -297,10 +298,11 @@ func (h *Handler) handleCheckSuiteEvent(ctx context.Context, e *github.CheckSuit
 func (h *Handler) handlePullRequestReviewEvent(ctx context.Context, e *github.PullRequestReviewEvent, r *http.BufferedRequest) error {
 	pullRequestReviewEvent, err := h.pullRequestReviewEventConverter.Convert(e)
 	if err != nil {
+		h.logger.ErrorContext(ctx, "error parsing prr event", map[string]interface{}{"err": err.Error()})
 		return &errors.EventParsingError{Err: err}
 	}
 	ctx = context.WithValue(ctx, contextInternal.RepositoryKey, pullRequestReviewEvent.Repo.FullName)
-	ctx = context.WithValue(ctx, contextInternal.PullNumKey, pullRequestReviewEvent.PRNum)
+	ctx = context.WithValue(ctx, contextInternal.PullNumKey, pullRequestReviewEvent.Pull.Num)
 	ctx = context.WithValue(ctx, contextInternal.SHAKey, pullRequestReviewEvent.Ref)
 	return h.pullRequestReviewHandler.Handle(ctx, pullRequestReviewEvent, r)
 }

--- a/server/vcs/provider/github/request/handler_test.go
+++ b/server/vcs/provider/github/request/handler_test.go
@@ -620,10 +620,10 @@ func TestHandlePullRequestReviewEvent(t *testing.T) {
 	internalEvent := event.PullRequestReview{
 		InstallationToken: 123,
 		Repo:              models.Repo{},
-		PRNum:             1,
 		User:              models.User{Username: "username"},
-		Action:            event.Approved,
+		State:             event.Approved,
 		Ref:               "abcd",
+		Pull:              models.PullRequest{Num: 1},
 	}
 
 	event := &github.PullRequestReviewEvent{


### PR DESCRIPTION
Few bugs in gateway discovered after testing

- check run fetcher should filter on: "failure" conclusion + checkRunRegex should skip the colon

- entire pull request metadata should be passed over to the worker for boltdb's state (PR number isn't enough)

- we don't need to know the review action, we need the state (state explains if PR is approved/rejected while action explains if the PR review was submitted/dismissed)

See: https://github.com/lyft/atlantis/pull/486 for how it all fits together