### PR TITLE
Handle PRR event worker

### DIFF
--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -116,7 +116,6 @@ func NewVCSEventsController(
 	scope tally.Scope,
 	githubWebhookSecret []byte,
 	allowDraftPRs bool,
-	prReviewCommandRunner handlers.PRReviewCommandRunner,
 	commandRunner events.CommandRunner,
 	commentParser events.CommentParsing,
 	eventParser events.EventParsing,
@@ -149,7 +148,7 @@ func NewVCSEventsController(
 		logger,
 	)
 
-	pullRequestReviewHandler := handlers.NewPullRequestReviewEvent(prReviewCommandRunner, logger)
+	pullRequestReviewHandler := handlers.NewPullRequestReviewEvent(commandRunner, logger)
 
 	// we don't support push events in the atlantis worker and these should never make it in the queue
 	// in the first place, so if it happens, let's return an error and fail fast.

--- a/server/controllers/events/events_controller.go
+++ b/server/controllers/events/events_controller.go
@@ -116,6 +116,7 @@ func NewVCSEventsController(
 	scope tally.Scope,
 	githubWebhookSecret []byte,
 	allowDraftPRs bool,
+	prReviewCommandRunner handlers.PRReviewCommandRunner,
 	commandRunner events.CommandRunner,
 	commentParser events.CommentParsing,
 	eventParser events.EventParsing,
@@ -148,7 +149,7 @@ func NewVCSEventsController(
 		logger,
 	)
 
-	pullRequestReviewHandler := handlers.NewPullRequestReviewEvent()
+	pullRequestReviewHandler := handlers.NewPullRequestReviewEvent(prReviewCommandRunner, logger)
 
 	// we don't support push events in the atlantis worker and these should never make it in the queue
 	// in the first place, so if it happens, let's return an error and fail fast.

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1056,9 +1056,8 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		},
 	)
 
-	prReviewCommandRunner := handlers.PRReviewCommandRunner(commandRunner)
 	prrHandler := handlers.PullRequestReviewEventHandler{
-		PRReviewCommandRunner: prReviewCommandRunner,
+		PRReviewCommandRunner: commandRunner,
 	}
 
 	commentHandler := handlers.NewCommentEventWithCommandHandler(

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
-	httputil "github.com/runatlantis/atlantis/server/http"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -71,13 +70,6 @@ func (h noopCheckRunEventHandler) Handle(ctx context.Context, event event_types.
 type noopCheckSuiteEventHandler struct{}
 
 func (h noopCheckSuiteEventHandler) Handle(ctx context.Context, event event_types.CheckSuite) error {
-	return nil
-}
-
-type noopPullRequestReviewEventHandler struct {
-}
-
-func (n noopPullRequestReviewEventHandler) Handle(ctx context.Context, e event_types.PullRequestReview, r *httputil.BufferedRequest) error {
 	return nil
 }
 
@@ -456,6 +448,7 @@ policy-v2:
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply.txt"},
 				{"exp-output-merge.txt"},
 			},
@@ -469,6 +462,7 @@ policy-v2:
 			},
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply-failed.txt"},
 				{"exp-output-merge.txt"},
@@ -498,6 +492,7 @@ policy-v2:
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply-failed.txt"},
 				{"exp-output-merge.txt"},
 			},
@@ -507,13 +502,12 @@ policy-v2:
 			RepoDir:       "policy-checks-diff-owner",
 			ModifiedFiles: []string{"main.tf"},
 			Comments: []string{
-				"atlantis approve_policies",
 				"atlantis apply",
 			},
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
-				{"exp-output-approve-policies.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply-failed.txt"},
 				{"exp-output-merge.txt"},
 			},
@@ -543,6 +537,11 @@ policy-v2:
 			// First, send the open pull request event which triggers autoplan.
 			pullOpenedReq := GitHubPullRequestOpenedEvent(t, headSHA)
 			ctrl.Post(w, pullOpenedReq)
+			ResponseContains(t, w, 200, "Processing...")
+
+			pullReviewedReq := GitHubPullRequestReviewedEvent(t, headSHA)
+			w = httptest.NewRecorder()
+			ctrl.Post(w, pullReviewedReq)
 			ResponseContains(t, w, 200, "Processing...")
 
 			// Now send any other comments.
@@ -1012,6 +1011,10 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		command.Version:         versionCommandRunner,
 	}
 	staleCommandChecker := &testStaleCommandChecker{}
+	prrPolicyCommandRunner := &events.PRRPolicyCheckCommandRunner{
+		PrjCmdBuilder:            projectCommandBuilder,
+		PolicyCheckCommandRunner: policyCheckCommandRunner,
+	}
 	commandRunner := &events.DefaultCommandRunner{
 		VCSClient:                     vcsClient,
 		GlobalCfg:                     globalCfg,
@@ -1022,6 +1025,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		PullStatusFetcher:             boltdb,
 		StaleCommandChecker:           staleCommandChecker,
 		Logger:                        ctxLogger,
+		PolicyCommandRunner:           prrPolicyCommandRunner,
 	}
 
 	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")
@@ -1051,6 +1055,11 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 			Logger:      ctxLogger,
 		},
 	)
+
+	prReviewCommandRunner := handlers.PRReviewCommandRunner(commandRunner)
+	prrHandler := handlers.PullRequestReviewEventHandler{
+		PRReviewCommandRunner: prReviewCommandRunner,
+	}
 
 	commentHandler := handlers.NewCommentEventWithCommandHandler(
 		commentParser,
@@ -1082,7 +1091,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 				commentHandler,
 				prHandler,
 				noopPushEventHandler{},
-				noopPullRequestReviewEventHandler{},
+				prrHandler,
 				noopCheckRunEventHandler{},
 				noopCheckSuiteEventHandler{},
 				false,
@@ -1110,13 +1119,15 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 
 var (
 	// if not for these we'd be doing disk reads for each test
-	readCommentJSON           sync.Once
-	readPullRequestOpenedJSON sync.Once
-	readPullRequestClosedJSON sync.Once
+	readCommentJSON             sync.Once
+	readPullRequestOpenedJSON   sync.Once
+	readPullRequestClosedJSON   sync.Once
+	readPullRequestReviewedJSON sync.Once
 
-	commentJSON           string
-	pullRequestOpenedJSON string
-	pullRequestClosedJSON string
+	commentJSON             string
+	pullRequestOpenedJSON   string
+	pullRequestClosedJSON   string
+	pullRequestReviewedJSON string
 )
 
 func GitHubCommentEvent(t *testing.T, comment string) *http.Request {
@@ -1168,6 +1179,24 @@ func GitHubPullRequestClosedEvent(t *testing.T) *http.Request {
 	Ok(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(githubHeader, "pull_request")
+	return req
+}
+
+func GitHubPullRequestReviewedEvent(t *testing.T, headSHA string) *http.Request {
+	readPullRequestReviewedJSON.Do(
+		func() {
+			jsonBytes, err := os.ReadFile(filepath.Join("testfixtures", "githubPullRequestReviewedEvent.json"))
+			Ok(t, err)
+
+			pullRequestReviewedJSON = string(jsonBytes)
+		},
+	)
+	// Replace sha with expected sha.
+	requestJSONStr := strings.Replace(pullRequestReviewedJSON, "c31fd9ea6f557ad2ea659944c3844a059b83bc5d", headSHA, -1)
+	req, err := http.NewRequest("POST", "/events", bytes.NewBuffer([]byte(requestJSONStr)))
+	Ok(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(githubHeader, "pull_request_review")
 	return req
 }
 

--- a/server/controllers/events/handlers/pull_request_review.go
+++ b/server/controllers/events/handlers/pull_request_review.go
@@ -2,19 +2,14 @@ package handlers
 
 import (
 	"context"
-	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/http"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
-	"time"
 )
 
-type PRReviewCommandRunner interface {
-	RunPRReviewCommand(ctx context.Context, repo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64)
-}
-
 type PullRequestReviewEventHandler struct {
-	PRReviewCommandRunner PRReviewCommandRunner
+	PRReviewCommandRunner events.CommandRunner
 }
 
 func (p PullRequestReviewEventHandler) Handle(ctx context.Context, event event.PullRequestReview, _ *http.BufferedRequest) error {
@@ -34,7 +29,7 @@ type AsyncPullRequestReviewEvent struct {
 	logger  logging.Logger
 }
 
-func NewPullRequestReviewEvent(prReviewCommandRunner PRReviewCommandRunner, logger logging.Logger) *AsyncPullRequestReviewEvent {
+func NewPullRequestReviewEvent(prReviewCommandRunner events.CommandRunner, logger logging.Logger) *AsyncPullRequestReviewEvent {
 	return &AsyncPullRequestReviewEvent{
 		handler: &PullRequestReviewEventHandler{
 			PRReviewCommandRunner: prReviewCommandRunner,

--- a/server/controllers/events/handlers/pull_request_review.go
+++ b/server/controllers/events/handlers/pull_request_review.go
@@ -2,18 +2,54 @@ package handlers
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/http"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"time"
 )
 
-type PullRequestReviewEvent struct {
+type PRReviewCommandRunner interface {
+	RunPRReviewCommand(ctx context.Context, repo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64)
 }
 
-func (p PullRequestReviewEvent) Handle(ctx context.Context, e event.PullRequestReview, _ *http.BufferedRequest) error {
-	//TODO implement me to run a modified approve command runner
+type PullRequestReviewEventHandler struct {
+	PRReviewCommandRunner PRReviewCommandRunner
+}
+
+func (p PullRequestReviewEventHandler) Handle(ctx context.Context, event event.PullRequestReview, _ *http.BufferedRequest) error {
+	p.PRReviewCommandRunner.RunPRReviewCommand(
+		ctx,
+		event.Repo,
+		event.Pull,
+		event.User,
+		event.Timestamp,
+		event.InstallationToken,
+	)
 	return nil
 }
 
-func NewPullRequestReviewEvent() *PullRequestReviewEvent {
-	return &PullRequestReviewEvent{}
+type AsyncPullRequestReviewEvent struct {
+	handler *PullRequestReviewEventHandler
+	logger  logging.Logger
+}
+
+func NewPullRequestReviewEvent(prReviewCommandRunner PRReviewCommandRunner, logger logging.Logger) *AsyncPullRequestReviewEvent {
+	return &AsyncPullRequestReviewEvent{
+		handler: &PullRequestReviewEventHandler{
+			PRReviewCommandRunner: prReviewCommandRunner,
+		},
+		logger: logger,
+	}
+}
+
+func (a AsyncPullRequestReviewEvent) Handle(_ context.Context, event event.PullRequestReview, req *http.BufferedRequest) error {
+	go func() {
+		// Passing background context to avoid context cancellation since the parent goroutine does not wait for this goroutine to finish execution.
+		err := a.handler.Handle(context.Background(), event, req)
+		if err != nil {
+			a.logger.ErrorContext(context.Background(), err.Error())
+		}
+	}()
+	return nil
 }

--- a/server/controllers/events/testfixtures/githubPullRequestReviewedEvent.json
+++ b/server/controllers/events/testfixtures/githubPullRequestReviewedEvent.json
@@ -1,0 +1,96 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 1241209205,
+    "commit_id": "d1968d00316b3c3f189138dc0e1c7318b2111a87",
+    "submitted_at": "2020-01-09T21:10:40Z",
+    "state": "approved",
+    "html_url": "https://github.com/runatlantis/atlantis-tests/pull/2#pullrequestreview-1241209205",
+    "pull_request_url": "https://api.github.com/repos/runatlantis/atlantis-tests/pull/2",
+    "author_association": "NONE"
+  },
+  "pull_request": {
+    "url": "https://api.github.com/repos/runatlantis/atlantis-tests/pulls/2",
+    "html_url": "https://github.com/runatlantis/atlantis-tests/pull/2",
+    "id": 194034250,
+    "number": 2,
+    "state": "open",
+    "locked": false,
+    "title": "branch",
+    "user": {
+      "login": "runatlantis",
+      "id": 1034429
+    },
+    "body": "",
+    "created_at": "2018-06-11T16:22:16Z",
+    "updated_at": "2018-06-11T16:22:16Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignee": null,
+    "assignees": [
+
+    ],
+    "requested_reviewers": [
+
+    ],
+    "requested_teams": [
+
+    ],
+    "labels": [
+
+    ],
+    "head": {
+      "label": "runatlantis:branch",
+      "ref": "branch",
+      "sha": "c31fd9ea6f557ad2ea659944c3844a059b83bc5d",
+      "user": {
+        "login": "runatlantis"
+      },
+      "repo": {
+        "id": 136474117,
+        "node_id": "MDEwOlJlcG9zaXRvcnkxMzY0NzQxMTc=",
+        "clone_url": "https://github.com/runatlantis/atlantis-tests.git",
+        "name": "atlantis-tests",
+        "full_name": "runatlantis/atlantis-tests",
+        "owner": {
+          "login": "runatlantis"
+        }
+      }
+    },
+    "base": {
+      "label": "runatlantis:master",
+      "ref": "master",
+      "sha": "f59a822e83b3cd193142c7624ea635a5d7894388",
+      "user": {
+        "login": "runatlantis"
+      },
+      "repo": {
+        "id": 136474117,
+        "node_id": "MDEwOlJlcG9zaXRvcnkxMzY0NzQxMTc=",
+        "clone_url": "https://github.com/runatlantis/atlantis-tests.git",
+        "name": "atlantis-tests",
+        "full_name": "runatlantis/atlantis-tests",
+        "owner": {
+          "login": "runatlantis"
+        }
+      }
+    }
+  },
+  "repository": {
+    "id": 136474117,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMzY0NzQxMTc=",
+    "clone_url": "https://github.com/runatlantis/atlantis-tests.git",
+    "name": "atlantis-tests",
+    "full_name": "runatlantis/atlantis-tests",
+    "owner": {
+      "login": "runatlantis"
+    }
+  },
+  "user": {
+    "login": "runatlantis"
+  },
+  "installation": {
+    "id": 1
+  }
+}

--- a/server/controllers/events/testfixtures/githubPullRequestReviewedEvent.json
+++ b/server/controllers/events/testfixtures/githubPullRequestReviewedEvent.json
@@ -87,7 +87,7 @@
       "login": "runatlantis"
     }
   },
-  "user": {
+  "sender": {
     "login": "runatlantis"
   },
   "installation": {

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -18,9 +18,6 @@ const (
 
 	// Commands that are triggered by comments (ie. atlantis plan)
 	CommentTrigger
-
-	// Commands that are triggered by PR reviews (ie. approving a PR)
-	PRReviewTrigger
 )
 
 // Context represents the context of a command that should be executed

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -18,6 +18,9 @@ const (
 
 	// Commands that are triggered by comments (ie. atlantis plan)
 	CommentTrigger
+
+	// Commands that are triggered by PR reviews (ie. approving a PR)
+	PRReviewTrigger
 )
 
 // Context represents the context of a command that should be executed

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -42,6 +42,7 @@ type CommandRunner interface {
 	// and then calling the appropriate services to finish executing the command.
 	RunCommentCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, pullNum int, cmd *command.Comment, timestamp time.Time, installationToken int64)
 	RunAutoplanCommand(ctx context.Context, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64)
+	RunPRReviewCommand(ctx context.Context, repo models.Repo, pull models.PullRequest, user models.User, timestamp time.Time, installationToken int64)
 }
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_stale_command_checker.go StaleCommandChecker
@@ -237,8 +238,6 @@ func (c *DefaultCommandRunner) RunPRReviewCommand(ctx context.Context, repo mode
 		return
 	}
 	defer c.Drainer.OpDone()
-	defer c.logPanics(ctx)
-
 	scope := c.StatsScope.SubScope("pr_approval")
 	timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
 	defer timer.Stop()
@@ -255,7 +254,7 @@ func (c *DefaultCommandRunner) RunPRReviewCommand(ctx context.Context, repo mode
 		Pull:              pull,
 		PullStatus:        status,
 		HeadRepo:          repo,
-		Trigger:           command.PRReviewTrigger,
+		Trigger:           command.AutoTrigger,
 		Scope:             scope,
 		TriggerTimestamp:  timestamp,
 		RequestCtx:        ctx,

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -243,6 +243,7 @@ func (c *DefaultCommandRunner) RunPRReviewCommand(ctx context.Context, repo mode
 	timer := scope.Timer(metrics.ExecutionTimeMetric).Start()
 	defer timer.Stop()
 
+	// only log error here, like with Atlantis autoplans/commands
 	status, err := c.PullStatusFetcher.GetPullStatus(pull)
 	if err != nil {
 		c.Logger.ErrorContext(ctx, err.Error())

--- a/server/events/policy_check_prr_command_runner.go
+++ b/server/events/policy_check_prr_command_runner.go
@@ -1,0 +1,28 @@
+package events
+
+import (
+	"fmt"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type ProjectPolicyCheckCommandBuilder interface {
+	BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error)
+}
+
+type PRRPolicyCheckCommandRunner struct {
+	PrjCmdBuilder ProjectPolicyCheckCommandBuilder
+	*PolicyCheckCommandRunner
+}
+
+func (p *PRRPolicyCheckCommandRunner) Run(ctx *command.Context) {
+	projectCmds, err := p.PrjCmdBuilder.BuildPRRCommands(ctx)
+	if err != nil {
+		if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx.RequestCtx, ctx.Pull.BaseRepo, ctx.Pull, models.FailedVCSStatus, command.PolicyCheck, "", ""); statusErr != nil {
+			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", statusErr))
+		}
+		p.outputUpdater.UpdateOutput(ctx, PolicyCheckCommand{}, command.Result{Error: err})
+		return
+	}
+	p.PolicyCheckCommandRunner.Run(ctx, projectCmds)
+}

--- a/server/events/policy_check_prr_command_runner.go
+++ b/server/events/policy_check_prr_command_runner.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ProjectPolicyCheckCommandBuilder interface {
-	BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error)
+	BuildPolicyCheckCommands(ctx *command.Context) ([]command.ProjectContext, error)
 }
 
 type PRRPolicyCheckCommandRunner struct {
@@ -16,7 +16,7 @@ type PRRPolicyCheckCommandRunner struct {
 }
 
 func (p *PRRPolicyCheckCommandRunner) Run(ctx *command.Context) {
-	projectCmds, err := p.PrjCmdBuilder.BuildPRRCommands(ctx)
+	projectCmds, err := p.PrjCmdBuilder.BuildPolicyCheckCommands(ctx)
 	if err != nil {
 		if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx.RequestCtx, ctx.Pull.BaseRepo, ctx.Pull, models.FailedVCSStatus, command.PolicyCheck, "", ""); statusErr != nil {
 			ctx.Log.WarnContext(ctx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", statusErr))

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -101,6 +101,7 @@ type ProjectVersionCommandBuilder interface {
 // ProjectCommandBuilder builds commands that run on individual projects.
 type ProjectCommandBuilder interface {
 	ProjectPlanCommandBuilder
+	ProjectPolicyCheckCommandBuilder
 	ProjectApplyCommandBuilder
 	ProjectApprovePoliciesCommandBuilder
 	ProjectVersionCommandBuilder
@@ -146,6 +147,41 @@ func (p *DefaultProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, c
 	}
 	pcc, err := p.buildProjectPlanCommand(ctx, cmd)
 	return pcc, err
+}
+
+func (p *DefaultProjectCommandBuilder) BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error) {
+	unlockFn, err := p.WorkingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
+	if err != nil {
+		return nil, err
+	}
+	defer unlockFn()
+
+	pullDir, err := p.WorkingDir.GetPullDir(ctx.Pull.BaseRepo, ctx.Pull)
+	if err != nil {
+		return nil, err
+	}
+
+	plans, err := p.PendingPlanFinder.Find(pullDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// use the default repository workspace because it is the only one guaranteed to have an atlantis.yaml,
+	// other workspaces will not have the file if they are using pre_workflow_hooks to generate it dynamically
+	defaultRepoDir, err := p.WorkingDir.GetWorkingDir(ctx.Pull.BaseRepo, ctx.Pull, DefaultWorkspace)
+	if err != nil {
+		return nil, err
+	}
+
+	var cmds []command.ProjectContext
+	for _, plan := range plans {
+		commands, err := p.buildProjectCommandCtx(ctx, command.PolicyCheck, plan.ProjectName, []string{}, defaultRepoDir, plan.RepoRelDir, plan.Workspace, false, "")
+		if err != nil {
+			return nil, errors.Wrapf(err, "building command for dir %q", plan.RepoRelDir)
+		}
+		cmds = append(cmds, commands...)
+	}
+	return cmds, nil
 }
 
 // See ProjectCommandBuilder.BuildApplyCommands.

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -149,7 +149,7 @@ func (p *DefaultProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, c
 	return pcc, err
 }
 
-func (p *DefaultProjectCommandBuilder) BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error) {
+func (p *DefaultProjectCommandBuilder) BuildPolicyCheckCommands(ctx *command.Context) ([]command.ProjectContext, error) {
 	unlockFn, err := p.WorkingDirLocker.TryLockPull(ctx.Pull.BaseRepo.FullName, ctx.Pull.Num)
 	if err != nil {
 		return nil, err

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -3,6 +3,7 @@ package events_test
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1130,4 +1131,190 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 	Equals(t, "workspace2", ctxs[2].Workspace)
 	Equals(t, "project2", ctxs[3].RepoRelDir)
 	Equals(t, "workspace2", ctxs[3].Workspace)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPRRCommands(t *testing.T) {
+	testWorkingDirLocker := mockWorkingDirLocker{}
+	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+		"workspace1": map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf":          nil,
+				"workspace.tfplan": nil,
+			},
+		},
+	})
+	defer cleanup()
+	// Initialize git repos in each workspace so that the .tfplan files get
+	// picked up.
+	runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")
+	testWorkingDir := mockWorkingDir{
+		pullDir:    tmpDir,
+		workingDir: tmpDir,
+	}
+	expectedProjects := []command.ProjectContext{
+		{
+			CommandName: command.PolicyCheck,
+		},
+	}
+	testContextBuilder := mockContextBuilder{
+		projects: expectedProjects,
+	}
+	builder := events.DefaultProjectCommandBuilder{
+		ParserValidator:              &config.ParserValidator{},
+		WorkingDir:                   testWorkingDir,
+		WorkingDirLocker:             testWorkingDirLocker,
+		GlobalCfg:                    valid.NewGlobalCfg("somedir"),
+		PendingPlanFinder:            &events.DefaultPendingPlanFinder{},
+		ProjectCommandContextBuilder: testContextBuilder,
+	}
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
+		RequestCtx: context.Background(),
+	}
+	projects, err := builder.BuildPRRCommands(commandCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedProjects, projects)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPRRCommands_TryLockPullError(t *testing.T) {
+	testWorkingDirLocker := mockWorkingDirLocker{
+		error: assert.AnError,
+	}
+	builder := events.DefaultProjectCommandBuilder{
+		WorkingDirLocker: testWorkingDirLocker,
+	}
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
+		RequestCtx: context.Background(),
+	}
+	projects, err := builder.BuildPRRCommands(commandCtx)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Empty(t, projects)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetPullDirError(t *testing.T) {
+	testWorkingDir := mockWorkingDir{
+		pullErr: assert.AnError,
+	}
+	testWorkingDirLocker := mockWorkingDirLocker{}
+	builder := events.DefaultProjectCommandBuilder{
+		WorkingDir:       testWorkingDir,
+		WorkingDirLocker: testWorkingDirLocker,
+	}
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
+		RequestCtx: context.Background(),
+	}
+	projects, err := builder.BuildPRRCommands(commandCtx)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Empty(t, projects)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPRRCommands_FindError(t *testing.T) {
+	testWorkingDir := mockWorkingDir{}
+	testWorkingDirLocker := mockWorkingDirLocker{}
+	builder := events.DefaultProjectCommandBuilder{
+		WorkingDir:        testWorkingDir,
+		WorkingDirLocker:  testWorkingDirLocker,
+		PendingPlanFinder: &events.DefaultPendingPlanFinder{},
+	}
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
+		RequestCtx: context.Background(),
+	}
+	projects, err := builder.BuildPRRCommands(commandCtx)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.Empty(t, projects)
+}
+
+func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetWorkingDirErr(t *testing.T) {
+	testWorkingDirLocker := mockWorkingDirLocker{}
+	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
+		"workspace1": map[string]interface{}{
+			"project1": map[string]interface{}{
+				"main.tf":          nil,
+				"workspace.tfplan": nil,
+			},
+		},
+	})
+	defer cleanup()
+	// Initialize git repos in each workspace so that the .tfplan files get
+	// picked up.
+	runCmd(t, filepath.Join(tmpDir, "workspace1"), "git", "init")
+	testWorkingDir := mockWorkingDir{
+		pullDir:       tmpDir,
+		workingDirErr: assert.AnError,
+	}
+	builder := events.DefaultProjectCommandBuilder{
+		WorkingDir:        testWorkingDir,
+		WorkingDirLocker:  testWorkingDirLocker,
+		GlobalCfg:         valid.NewGlobalCfg("somedir"),
+		PendingPlanFinder: &events.DefaultPendingPlanFinder{},
+	}
+	commandCtx := &command.Context{
+		Log:        logging.NewNoopCtxLogger(t),
+		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
+		RequestCtx: context.Background(),
+	}
+	projects, err := builder.BuildPRRCommands(commandCtx)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Empty(t, projects)
+}
+
+type mockWorkingDirLocker struct {
+	error error
+}
+
+func (l mockWorkingDirLocker) TryLock(_ string, _ int, _ string) (func(), error) {
+	return func() {}, nil
+}
+
+func (l mockWorkingDirLocker) TryLockPull(_ string, _ int) (func(), error) {
+	if l.error != nil {
+		return func() {}, l.error
+	}
+	return func() {}, nil
+}
+
+type mockContextBuilder struct {
+	projects []command.ProjectContext
+}
+
+func (b mockContextBuilder) BuildProjectContext(_ *command.Context, _ command.Name, _ valid.MergedProjectCfg, _ []string, _ string, _ *command.ContextFlags) []command.ProjectContext {
+	return b.projects
+}
+
+type mockWorkingDir struct {
+	pullDir       string
+	workingDir    string
+	pullErr       error
+	workingDirErr error
+}
+
+func (w mockWorkingDir) GetPullDir(_ models.Repo, _ models.PullRequest) (string, error) {
+	return w.pullDir, w.pullErr
+}
+
+func (w mockWorkingDir) GetWorkingDir(models.Repo, models.PullRequest, string) (string, error) {
+	return w.workingDir, w.workingDirErr
+}
+
+func (w mockWorkingDir) HasDiverged(logging.Logger, string, models.Repo) bool {
+	return false
+}
+
+func (w mockWorkingDir) Delete(models.Repo, models.PullRequest) error {
+	return nil
+}
+
+func (w mockWorkingDir) DeleteForWorkspace(_ models.Repo, _ models.PullRequest, _ string) error {
+	return nil
+}
+
+func (w mockWorkingDir) Clone(_ logging.Logger, _ models.Repo, _ models.PullRequest, _ string) (string, bool, error) {
+	return "", false, nil
 }

--- a/server/events/project_command_builder_test.go
+++ b/server/events/project_command_builder_test.go
@@ -1133,7 +1133,7 @@ func TestDefaultProjectCommandBuilder_BuildVersionCommand(t *testing.T) {
 	Equals(t, "workspace2", ctxs[3].Workspace)
 }
 
-func TestDefaultProjectCommandBuilder_BuildPRRCommands(t *testing.T) {
+func TestDefaultProjectCommandBuilder_BuildPolicyCheckCommands(t *testing.T) {
 	testWorkingDirLocker := mockWorkingDirLocker{}
 	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
 		"workspace1": map[string]interface{}{
@@ -1172,12 +1172,12 @@ func TestDefaultProjectCommandBuilder_BuildPRRCommands(t *testing.T) {
 		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
-	projects, err := builder.BuildPRRCommands(commandCtx)
+	projects, err := builder.BuildPolicyCheckCommands(commandCtx)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedProjects, projects)
 }
 
-func TestDefaultProjectCommandBuilder_BuildPRRCommands_TryLockPullError(t *testing.T) {
+func TestDefaultProjectCommandBuilder_BuildPolicyCheckCommands_TryLockPullError(t *testing.T) {
 	testWorkingDirLocker := mockWorkingDirLocker{
 		error: assert.AnError,
 	}
@@ -1189,12 +1189,12 @@ func TestDefaultProjectCommandBuilder_BuildPRRCommands_TryLockPullError(t *testi
 		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
-	projects, err := builder.BuildPRRCommands(commandCtx)
+	projects, err := builder.BuildPolicyCheckCommands(commandCtx)
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Empty(t, projects)
 }
 
-func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetPullDirError(t *testing.T) {
+func TestDefaultProjectCommandBuilder_BuildPolicyCheckCommands_GetPullDirError(t *testing.T) {
 	testWorkingDir := mockWorkingDir{
 		pullErr: assert.AnError,
 	}
@@ -1208,12 +1208,12 @@ func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetPullDirError(t *testin
 		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
-	projects, err := builder.BuildPRRCommands(commandCtx)
+	projects, err := builder.BuildPolicyCheckCommands(commandCtx)
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Empty(t, projects)
 }
 
-func TestDefaultProjectCommandBuilder_BuildPRRCommands_FindError(t *testing.T) {
+func TestDefaultProjectCommandBuilder_BuildPolicyCheckCommands_FindError(t *testing.T) {
 	testWorkingDir := mockWorkingDir{}
 	testWorkingDirLocker := mockWorkingDirLocker{}
 	builder := events.DefaultProjectCommandBuilder{
@@ -1226,12 +1226,12 @@ func TestDefaultProjectCommandBuilder_BuildPRRCommands_FindError(t *testing.T) {
 		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
-	projects, err := builder.BuildPRRCommands(commandCtx)
+	projects, err := builder.BuildPolicyCheckCommands(commandCtx)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	assert.Empty(t, projects)
 }
 
-func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetWorkingDirErr(t *testing.T) {
+func TestDefaultProjectCommandBuilder_BuildPolicyCheckCommands_GetWorkingDirErr(t *testing.T) {
 	testWorkingDirLocker := mockWorkingDirLocker{}
 	tmpDir, cleanup := DirStructure(t, map[string]interface{}{
 		"workspace1": map[string]interface{}{
@@ -1260,7 +1260,7 @@ func TestDefaultProjectCommandBuilder_BuildPRRCommands_GetWorkingDirErr(t *testi
 		Scope:      tally.NewTestScope("atlantis", map[string]string{}),
 		RequestCtx: context.Background(),
 	}
-	projects, err := builder.BuildPRRCommands(commandCtx)
+	projects, err := builder.BuildPolicyCheckCommands(commandCtx)
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Empty(t, projects)
 }

--- a/server/events/size_limited_project_command_builder_test.go
+++ b/server/events/size_limited_project_command_builder_test.go
@@ -162,7 +162,7 @@ func (m mockProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, comme
 	return m.commands, m.error
 }
 
-func (m mockProjectCommandBuilder) BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error) {
+func (m mockProjectCommandBuilder) BuildPolicyCheckCommands(ctx *command.Context) ([]command.ProjectContext, error) {
 	return m.commands, m.error
 }
 

--- a/server/events/size_limited_project_command_builder_test.go
+++ b/server/events/size_limited_project_command_builder_test.go
@@ -6,14 +6,11 @@ import (
 	. "github.com/petergtz/pegomock"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
-	"github.com/runatlantis/atlantis/server/events/mocks"
 	. "github.com/runatlantis/atlantis/testing"
 )
 
 func TestSizeLimitedProjectCommandBuilder_autoplan(t *testing.T) {
 	RegisterMockTestingT(t)
-
-	delegate := mocks.NewMockProjectCommandBuilder()
 
 	ctx := &command.Context{}
 
@@ -33,15 +30,15 @@ func TestSizeLimitedProjectCommandBuilder_autoplan(t *testing.T) {
 	}
 
 	expectedResult := []command.ProjectContext{project1, project2}
+	delegate := mockProjectCommandBuilder{
+		commands: expectedResult,
+	}
 
 	t.Run("Limit Defined and Breached", func(t *testing.T) {
 		subject := &events.SizeLimitedProjectCommandBuilder{
 			Limit:                 1,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
-
 		_, err := subject.BuildAutoplanCommands(ctx)
 
 		ErrEquals(t, `Number of projects cannot exceed 1.  This can either be caused by:
@@ -56,9 +53,6 @@ Please break this pull request into smaller batches and try again.`, err)
 			Limit:                 2,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
-
 		result, err := subject.BuildAutoplanCommands(ctx)
 
 		Ok(t, err)
@@ -71,9 +65,6 @@ Please break this pull request into smaller batches and try again.`, err)
 			Limit:                 events.InfiniteProjectsPerPR,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(expectedResult, nil)
-
 		result, err := subject.BuildAutoplanCommands(ctx)
 
 		Ok(t, err)
@@ -82,15 +73,14 @@ Please break this pull request into smaller batches and try again.`, err)
 	})
 
 	t.Run("Only plan commands counted in limit", func(t *testing.T) {
+		resultWithPolicyCheckCommand := []command.ProjectContext{project1, project2, project3}
+		delegate = mockProjectCommandBuilder{
+			commands: resultWithPolicyCheckCommand,
+		}
 		subject := &events.SizeLimitedProjectCommandBuilder{
 			Limit:                 2,
 			ProjectCommandBuilder: delegate,
 		}
-
-		resultWithPolicyCheckCommand := []command.ProjectContext{project1, project2, project3}
-
-		When(delegate.BuildAutoplanCommands(ctx)).ThenReturn(resultWithPolicyCheckCommand, nil)
-
 		result, err := subject.BuildAutoplanCommands(ctx)
 
 		Ok(t, err)
@@ -101,9 +91,6 @@ Please break this pull request into smaller batches and try again.`, err)
 
 func TestSizeLimitedProjectCommandBuilder_planComment(t *testing.T) {
 	RegisterMockTestingT(t)
-
-	delegate := mocks.NewMockProjectCommandBuilder()
-
 	ctx := &command.Context{}
 
 	comment := &command.Comment{}
@@ -119,15 +106,15 @@ func TestSizeLimitedProjectCommandBuilder_planComment(t *testing.T) {
 	}
 
 	expectedResult := []command.ProjectContext{project1, project2}
+	delegate := mockProjectCommandBuilder{
+		commands: expectedResult,
+	}
 
 	t.Run("Limit Defined and Breached", func(t *testing.T) {
 		subject := &events.SizeLimitedProjectCommandBuilder{
 			Limit:                 1,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
-
 		_, err := subject.BuildPlanCommands(ctx, comment)
 
 		ErrEquals(t, `Number of projects cannot exceed 1.  This can either be caused by:
@@ -142,9 +129,6 @@ Please break this pull request into smaller batches and try again.`, err)
 			Limit:                 2,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
-
 		result, err := subject.BuildPlanCommands(ctx, comment)
 
 		Ok(t, err)
@@ -157,13 +141,39 @@ Please break this pull request into smaller batches and try again.`, err)
 			Limit:                 events.InfiniteProjectsPerPR,
 			ProjectCommandBuilder: delegate,
 		}
-
-		When(delegate.BuildPlanCommands(ctx, comment)).ThenReturn(expectedResult, nil)
-
 		result, err := subject.BuildPlanCommands(ctx, comment)
 
 		Ok(t, err)
 
 		Assert(t, len(result) == len(expectedResult), "size is expected")
 	})
+}
+
+type mockProjectCommandBuilder struct {
+	commands []command.ProjectContext
+	error    error
+}
+
+func (m mockProjectCommandBuilder) BuildAutoplanCommands(ctx *command.Context) ([]command.ProjectContext, error) {
+	return m.commands, m.error
+}
+
+func (m mockProjectCommandBuilder) BuildPlanCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	return m.commands, m.error
+}
+
+func (m mockProjectCommandBuilder) BuildPRRCommands(ctx *command.Context) ([]command.ProjectContext, error) {
+	return m.commands, m.error
+}
+
+func (m mockProjectCommandBuilder) BuildApplyCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	return m.commands, m.error
+}
+
+func (m mockProjectCommandBuilder) BuildApprovePoliciesCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	return m.commands, m.error
+}
+
+func (m mockProjectCommandBuilder) BuildVersionCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	return m.commands, m.error
 }

--- a/server/server.go
+++ b/server/server.go
@@ -795,6 +795,11 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	staleCommandChecker := &events.StaleCommandHandler{
 		StaleStatsScope: cmdStatsScope.SubScope("stale"),
 	}
+	prrPolicyCommandRunner := &events.PRRPolicyCheckCommandRunner{
+		PrjCmdBuilder:            projectCommandBuilder,
+		PolicyCheckCommandRunner: policyCheckCommandRunner,
+	}
+
 	commandRunner := &events.DefaultCommandRunner{
 		VCSClient:                     vcsClient,
 		CommentCommandRunnerByCmd:     commentCommandRunnerByCmd,
@@ -807,6 +812,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		StaleCommandChecker:           staleCommandChecker,
 		VCSStatusUpdater:              vcsStatusUpdater,
 		Logger:                        ctxLogger,
+		PolicyCommandRunner:           prrPolicyCommandRunner,
 	}
 
 	forceApplyCommandRunner := &events.ForceApplyCommandRunner{
@@ -914,6 +920,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		statsScope,
 		[]byte(userConfig.GithubWebhookSecret),
 		userConfig.PlanDrafts,
+		commandRunner,
 		forceApplyCommandRunner,
 		commentParser,
 		eventParser,

--- a/server/server.go
+++ b/server/server.go
@@ -920,7 +920,6 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		statsScope,
 		[]byte(userConfig.GithubWebhookSecret),
 		userConfig.PlanDrafts,
-		commandRunner,
 		forceApplyCommandRunner,
 		commentParser,
 		eventParser,

--- a/server/vcs/provider/github/converter/pr_review_event.go
+++ b/server/vcs/provider/github/converter/pr_review_event.go
@@ -34,7 +34,7 @@ func (p PullRequestReviewEvent) Convert(e *github.PullRequestReviewEvent) (event
 	}
 
 	if e.GetSender() == nil {
-		return event.PullRequestReview{}, errors.Wrap(err, "sender is nil")
+		return event.PullRequestReview{}, fmt.Errorf("sender is nil")
 	}
 	user := models.User{
 		Username: e.GetSender().GetLogin(),


### PR DESCRIPTION
Contains the following changes to be able to listen to pull request review events and rerun policy checks:

Worker fixes:

- Inject a special case policy check runner into the VCSEventsController
- When VCSEventsController receives a pull request review event, it will trigger the policy check runner
- This policy check runner is wrapped with a PRRPolicyCheckCommandRunner type that builds the project contexts needed to know where/what to run the policy checks on

^ note: The worker relies on our legacy code, which we plan on removing completely in favor of project neptune, phase 2. A lot of the code doesn't meet our standards and would require a full refactor to clean up. For now, I implemented the event handling this way to avoid messing with the legacy code/testing constructs as much as possible until we redesign everything on top of Temporal.