### PR TITLE
Separate conftest runs

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -422,7 +422,7 @@ policy-v2:
 	// Ensure we have >= TF 0.14 locally.
 	ensureRunning014(t)
 	// Ensure we have >= Conftest 0.21 locally.
-	ensureRunningConftest(t)
+	//ensureRunningConftest(t)
 
 	cases := []struct {
 		Description string
@@ -478,6 +478,7 @@ policy-v2:
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply-failed.txt"},
 				{"exp-output-merge.txt"},
 			},
@@ -516,8 +517,6 @@ policy-v2:
 
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
-			t.Parallel()
-
 			// reset userConfig
 			userConfig := &server.UserConfig{}
 			userConfig.EnablePolicyChecks = true
@@ -844,9 +843,6 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		members: []string{},
 	}
 	conftestExecutor := &policy.ConfTestExecutor{
-		SourceResolver: &policy.SourceResolverProxy{
-			LocalSourceResolver: &policy.LocalSourceResolver{},
-		},
 		Exec:         runtime_models.LocalExec{},
 		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, teamFetcher),
 	}

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -448,7 +448,6 @@ policy-v2:
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
-				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply.txt"},
 				{"exp-output-merge.txt"},
 			},
@@ -538,10 +537,12 @@ policy-v2:
 			ctrl.Post(w, pullOpenedReq)
 			ResponseContains(t, w, 200, "Processing...")
 
-			pullReviewedReq := GitHubPullRequestReviewedEvent(t, headSHA)
-			w = httptest.NewRecorder()
-			ctrl.Post(w, pullReviewedReq)
-			ResponseContains(t, w, 200, "Processing...")
+			if c.RepoDir != "policy-checks-multi-projects" {
+				pullReviewedReq := GitHubPullRequestReviewedEvent(t, headSHA)
+				w = httptest.NewRecorder()
+				ctrl.Post(w, pullReviewedReq)
+				ResponseContains(t, w, 200, "Processing...")
+			}
 
 			// Now send any other comments.
 			for _, comment := range c.Comments {
@@ -614,6 +615,7 @@ policy-v2:
 			},
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
+				{"exp-output-auto-policy-check.txt"},
 				{"exp-output-apply.txt"},
 			},
 		},
@@ -622,13 +624,11 @@ policy-v2:
 			RepoDir:       "platform-mode/policy-check-approval",
 			ModifiedFiles: []string{"main.tf"},
 			Comments: []string{
-				"atlantis approve_policies",
 				"atlantis apply",
 			},
 			ExpReplies: [][]string{
 				{"exp-output-autoplan.txt"},
 				{"exp-output-auto-policy-check.txt"},
-				{"exp-output-approve-policies.txt"},
 				{"exp-output-apply.txt"},
 			},
 		},
@@ -636,7 +636,6 @@ policy-v2:
 
 	for _, c := range cases {
 		t.Run(c.Description, func(t *testing.T) {
-			t.Parallel()
 			// Setup test dependencies.
 			w := httptest.NewRecorder()
 			// reset userConfig

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -422,7 +422,7 @@ policy-v2:
 	// Ensure we have >= TF 0.14 locally.
 	ensureRunning014(t)
 	// Ensure we have >= Conftest 0.21 locally.
-	//ensureRunningConftest(t)
+	ensureRunningConftest(t)
 
 	cases := []struct {
 		Description string

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-apply.txt
@@ -1,4 +1,4 @@
-Ran Apply for dir: `.` workspace: `default`
+Ran Apply for dir: `staging` workspace: `staging`
 
 ```diff
 atlantis apply is disabled for this project. Please track the deployment when the PR is merged. 

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
@@ -1,4 +1,4 @@
-Ran Policy Check for dir: `.` workspace: `default`
+Ran Policy Check for dir: `staging` workspace: `staging`
 
 **Policy Check Failed**
 ```

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `staging` workspace: `staging`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-autoplan.txt
@@ -1,4 +1,4 @@
-Ran Plan for dir: `.` workspace: `default`
+Ran Plan for dir: `staging` workspace: `staging`
 
 <details><summary>Show Output</summary>
 
@@ -10,25 +10,26 @@ plan. Resource actions are indicated with the following symbols:
 
 Terraform will perform the following actions:
 
-  # null_resource.simple[0] will be created
-+ resource "null_resource" "simple" {
+  # null_resource.this will be created
++ resource "null_resource" "this" {
       + id = (known after apply)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 Changes to Outputs:
-+ workspace = "default"
++ workspace = "staging"
 
 ```
 
 * :arrow_forward: To **apply** this plan, comment:
-    * `atlantis apply -d .`
+    * `atlantis apply -d staging -w staging`
 * :put_litter_in_its_place: To **delete** this plan click [here]()
 * :repeat: To **plan** this project again, comment:
-    * `atlantis plan -d .`
+    * `atlantis plan -d staging -w staging`
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
+
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/policies/policy.rego
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/policies/policy.rego
@@ -1,0 +1,28 @@
+package main
+
+import input as tfplan
+
+deny[reason] {
+	num_deletes.null_resource > 0
+	reason := "WARNING: Null Resource creation is prohibited."
+}
+
+resource_types = {"null_resource"}
+
+resources[resource_type] = all {
+	some resource_type
+	resource_types[resource_type]
+	all := [name |
+		name := tfplan.resource_changes[_]
+		name.type == resource_type
+	]
+}
+
+# number of deletions of resources of a given type
+num_deletes[resource_type] = num {
+	some resource_type
+	resource_types[resource_type]
+	all := resources[resource_type]
+	deletions := [res | res := all[_]; res.change.actions[_] == "create"]
+	num := count(deletions)
+}

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/repos.yaml
@@ -1,0 +1,8 @@
+repos:
+  - id: /.*/
+policies:
+  policy_sets:
+    - name: test_policy
+      owner: someoneelse
+      paths:
+        - ../policies/policy.rego

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/repos.yaml
@@ -2,11 +2,8 @@ repos:
 - id: /.*/
   apply_requirements: [approved]
 policies:
-  owners:
-    users:
-      - runatlantis
   policy_sets:
     - name: test_policy
-      path: policies/policy.rego
-      source: local
-        
+      owner: runatlantis
+      paths:
+        - policies/policy.rego

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-apply-failed.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-apply-failed.txt
@@ -1,4 +1,3 @@
 Ran Apply for dir: `.` workspace: `default`
 
 **Apply Failed**: All policies must pass for project before running apply
-

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
@@ -5,11 +5,11 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
 * :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
-
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-autoplan.txt
@@ -30,6 +30,7 @@ Changes to Outputs:
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 
+
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/repos.yaml
@@ -2,11 +2,9 @@ repos:
 - id: /.*/
   apply_requirements: [approved]
 policies:
-  owners:
-    users:
-      - runatlantis
   policy_sets:
     - name: test_policy
       path: policies/policy.rego
-      source: local
-        
+      owner: runatlantis
+      paths:
+        - policies/policy.rego

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
@@ -5,6 +5,7 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/repos.yaml
@@ -1,10 +1,9 @@
 repos:
   - id: /.*/
 policies:
-  owners:
-    users:
-      - someoneelse
   policy_sets:
     - name: test_policy
-      path: policies/policy.rego
+      owner: someoneelse
+      paths:
+        - policies/policy.rego
       source: local

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-apply-failed.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-apply-failed.txt
@@ -1,4 +1,3 @@
 Ran Apply for dir: `.` workspace: `default`
 
 **Apply Failed**: All policies must pass for project before running apply
-

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
@@ -5,11 +5,11 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
 FAIL - <redacted plan file> - null_resource_policy - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
 * :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
-
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - null_resource_policy - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-autoplan.txt
@@ -30,6 +30,7 @@ Changes to Outputs:
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 
+
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/repos.yaml
@@ -1,13 +1,12 @@
 repos:
   - id: /.*/
 policies:
-  owners:
-    users:
-      - runatlantis
   policy_sets:
     - name: test_policy
       path: policies/policy.rego
-      source: local
+      owner: runatlantis
+      paths:
+        - policies/policy.rego
 workflows:
   default:
     policy_check:

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/atlantis.yaml
@@ -1,4 +1,6 @@
 version: 3
 projects:
 - dir: dir1
+  name: dir1
 - dir: dir2
+  name: dir2

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-apply.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-apply.txt
@@ -1,9 +1,9 @@
 Ran Apply for 2 projects:
 
-1. dir: `dir1` workspace: `default`
-1. dir: `dir2` workspace: `default`
+1. project: `dir1` dir: `dir1` workspace: `default`
+1. project: `dir2` dir: `dir2` workspace: `default`
 
-### 1. dir: `dir1` workspace: `default`
+### 1. project: `dir1` dir: `dir1` workspace: `default`
 ```diff
 null_resource.simple:
 null_resource.simple:
@@ -17,7 +17,7 @@ workspace = "default"
 ```
 
 ---
-### 2. dir: `dir2` workspace: `default`
+### 2. project: `dir2` dir: `dir2` workspace: `default`
 **Apply Failed**: All policies must pass for project before running apply
 
 ---

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -19,7 +19,7 @@ Checking plan against the following policies:
 **Policy Check Failed**
 ```
 exit status 1
-Checking plan against the following policies:
+Checking plan against the following policies: 
   test_policy
 
 FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -8,7 +8,6 @@ Ran Policy Check for 2 projects:
 Checking plan against the following policies: 
   test_policy
 
-
 1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
 
 ```
@@ -21,7 +20,6 @@ Checking plan against the following policies:
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -5,26 +5,23 @@ Ran Policy Check for 2 projects:
 
 ### 1. dir: `dir1` workspace: `default`
 ```diff
-Checking plan against the following policies: 
+Checking plan against the following policies:
   test_policy
+
 
 1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
 
 ```
 
-* :arrow_forward: To **apply** this plan, comment:
-    * `atlantis apply -d dir1`
-* :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
-* :repeat: To re-run policies **plan** this project again by commenting:
-    * `atlantis plan -d dir1`
 
 ---
 ### 2. dir: `dir2` workspace: `default`
 **Policy Check Failed**
 ```
 exit status 1
-Checking plan against the following policies: 
+Checking plan against the following policies:
   test_policy
+
 FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -1,9 +1,9 @@
 Ran Policy Check for 2 projects:
 
-1. dir: `dir1` workspace: `default`
-1. dir: `dir2` workspace: `default`
+1. project: `dir1` dir: `dir1` workspace: `default`
+1. project: `dir2` dir: `dir2` workspace: `default`
 
-### 1. dir: `dir1` workspace: `default`
+### 1. project: `dir1` dir: `dir1` workspace: `default`
 ```diff
 Checking plan against the following policies: 
   test_policy
@@ -15,7 +15,7 @@ Checking plan against the following policies:
 
 
 ---
-### 2. dir: `dir2` workspace: `default`
+### 2. project: `dir2` dir: `dir2` workspace: `default`
 **Policy Check Failed**
 ```
 exit status 1

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -5,7 +5,7 @@ Ran Policy Check for 2 projects:
 
 ### 1. dir: `dir1` workspace: `default`
 ```diff
-Checking plan against the following policies:
+Checking plan against the following policies: 
   test_policy
 
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
@@ -34,6 +34,7 @@ Changes to Outputs:
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 
+
 ---
 ### 2. dir: `dir2` workspace: `default`
 <details><summary>Show Output</summary>
@@ -65,6 +66,7 @@ Changes to Outputs:
     * `atlantis plan -d dir2`
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
+
 
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-autoplan.txt
@@ -1,9 +1,9 @@
 Ran Plan for 2 projects:
 
-1. dir: `dir1` workspace: `default`
-1. dir: `dir2` workspace: `default`
+1. project: `dir1` dir: `dir1` workspace: `default`
+1. project: `dir2` dir: `dir2` workspace: `default`
 
-### 1. dir: `dir1` workspace: `default`
+### 1. project: `dir1` dir: `dir1` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
@@ -27,16 +27,16 @@ Changes to Outputs:
 ```
 
 * :arrow_forward: To **apply** this plan, comment:
-    * `atlantis apply -d dir1`
+    * `atlantis apply -p dir1`
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
-    * `atlantis plan -d dir1`
+    * `atlantis plan -p dir1`
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 
 
 ---
-### 2. dir: `dir2` workspace: `default`
+### 2. project: `dir2` dir: `dir2` workspace: `default`
 <details><summary>Show Output</summary>
 
 ```diff
@@ -60,10 +60,10 @@ Changes to Outputs:
 ```
 
 * :arrow_forward: To **apply** this plan, comment:
-    * `atlantis apply -d dir2`
+    * `atlantis apply -p dir2`
 * :put_litter_in_its_place: To **delete** this plan click [here](lock-url)
 * :repeat: To **plan** this project again, comment:
-    * `atlantis plan -d dir2`
+    * `atlantis plan -p dir2`
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/repos.yaml
@@ -1,10 +1,8 @@
 repos:
   - id: /.*/
 policies:
-  owners:
-    users:
-      - runatlantis
   policy_sets:
     - name: test_policy
-      path: ../policies/policy.rego
-      source: local
+      owner: runatlantis
+      paths:
+        - ../policies/policy.rego

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-apply-failed.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-apply-failed.txt
@@ -1,4 +1,3 @@
 Ran Apply for dir: `.` workspace: `default`
 
 **Apply Failed**: All policies must pass for project before running apply
-

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
@@ -5,11 +5,11 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
 
 ```
 * :heavy_check_mark: To **approve** failing policies either request an approval from approvers or address the failure by modifying the codebase.
-
 

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
@@ -5,7 +5,6 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
-
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-autoplan.txt
@@ -30,6 +30,7 @@ Changes to Outputs:
 </details>
 Plan: 1 to add, 0 to change, 0 to destroy.
 
+
 ---
 * :fast_forward: To **apply** all unapplied plans from this pull request, comment:
     * `atlantis apply`

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/repos.yaml
@@ -1,10 +1,8 @@
 repos:
   - id: /.*/
 policies:
-  owners:
-    users:
-      - runatlantis
   policy_sets:
     - name: test_policy
-      path: policies/policy.rego
-      source: local
+      owner: someoneelse
+      paths:
+        - policies/policy.rego

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -52,17 +52,19 @@ func (o PolicyOwners) ToValid() valid.PolicyOwners {
 }
 
 type PolicySet struct {
-	Path   string `yaml:"path" json:"path"`
-	Source string `yaml:"source" json:"source"`
-	Name   string `yaml:"name" json:"name"`
-	Owner  string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Path   string   `yaml:"path" json:"path"`
+	Source string   `yaml:"source" json:"source"`
+	Name   string   `yaml:"name" json:"name"`
+	Owner  string   `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Paths  []string `yaml:"paths" json:"paths"`
 }
 
 func (p PolicySet) Validate() error {
 	return validation.ValidateStruct(&p,
 		validation.Field(&p.Name, validation.Required.Error("is required")),
 		validation.Field(&p.Owner, validation.Required.Error("is required")),
-		validation.Field(&p.Path, validation.Required.Error("is required")),
+		validation.Field(&p.Path),
+		validation.Field(&p.Paths), // TODO: require when Path is deprecated
 		validation.Field(&p.Source, validation.In(valid.LocalPolicySet, valid.GithubPolicySet).Error("only 'local' and 'github' source types are supported")),
 	)
 }
@@ -72,6 +74,7 @@ func (p PolicySet) ToValid() valid.PolicySet {
 
 	policySet.Name = p.Name
 	policySet.Path = p.Path
+	policySet.Paths = p.Paths
 	policySet.Source = p.Source
 	policySet.Owner = p.Owner
 

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -37,6 +37,26 @@ policy_sets:
 				},
 			},
 		},
+		{
+			description: "valid yaml with multiple paths",
+			input: `
+conftest_version: v1.0.0
+policy_sets:
+- name: policy-name
+  source: "local"
+  paths: ["rel/path/to/policy-set", "rel/path/to/another/policy-set"]
+`,
+			exp: raw.PolicySets{
+				Version: String("v1.0.0"),
+				PolicySets: []raw.PolicySet{
+					{
+						Name:   "policy-name",
+						Source: valid.LocalPolicySet,
+						Paths:  []string{"rel/path/to/policy-set", "rel/path/to/another/policy-set"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -85,6 +105,12 @@ func TestPolicySets_Validate(t *testing.T) {
 						Path:   "rel/path/to/source",
 						Source: valid.GithubPolicySet,
 					},
+					{
+						Name:   "policy-name-3",
+						Owner:  "owner3",
+						Paths:  []string{"rel/path/to/source", "rel/diff/path/to/source"},
+						Source: valid.LocalPolicySet,
+					},
 				},
 			},
 			expErr: "",
@@ -98,13 +124,13 @@ func TestPolicySets_Validate(t *testing.T) {
 		},
 
 		{
-			description: "missing policy name and source path",
+			description: "missing policy name",
 			input: raw.PolicySets{
 				PolicySets: []raw.PolicySet{
 					{},
 				},
 			},
-			expErr: "policy_sets: (0: (name: is required; owner: is required; path: is required.).).",
+			expErr: "policy_sets: (0: (name: is required; owner: is required.).).",
 		},
 		{
 			description: "invalid source type",
@@ -220,6 +246,37 @@ func TestPolicySets_ToValid(t *testing.T) {
 					{
 						Name:   "good-policy",
 						Path:   "rel/path/to/source",
+						Source: "local",
+					},
+				},
+			},
+		},
+		{
+			description: "valid policies with multiple paths",
+			input: raw.PolicySets{
+				Version: String("v1.0.0"),
+				Owners: raw.PolicyOwners{
+					Users: []string{
+						"test",
+					},
+				},
+				PolicySets: []raw.PolicySet{
+					{
+						Name:   "good-policy",
+						Paths:  []string{"rel/path/to/source", "rel/path/to/source2"},
+						Source: valid.LocalPolicySet,
+					},
+				},
+			},
+			exp: valid.PolicySets{
+				Version: version,
+				Owners: valid.PolicyOwners{
+					Users: []string{"test"},
+				},
+				PolicySets: []valid.PolicySet{
+					{
+						Name:   "good-policy",
+						Paths:  []string{"rel/path/to/source", "rel/path/to/source2"},
 						Source: "local",
 					},
 				},

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -23,10 +23,11 @@ type PolicyOwners struct {
 }
 
 type PolicySet struct {
-	Source string
-	Path   string
+	Source string // TODO: seems unused, remove when legacy policy checks are deprecated
+	Path   string // TODO: replaced by Paths, remove when legacy policy checks are deprecated
 	Name   string
 	Owner  string
+	Paths  []string
 }
 
 func (p *PolicySets) HasPolicies() bool {

--- a/server/core/runtime/policy/conftest_client.go
+++ b/server/core/runtime/policy/conftest_client.go
@@ -51,7 +51,7 @@ type ConftestTestCommandArgs struct {
 }
 
 func (c ConftestTestCommandArgs) build() ([]string, error) {
-
+	// TODO: remove check when legacy contest client is depreccated
 	if len(c.PolicyArgs) == 0 {
 		return []string{}, errors.New("no policies specified")
 	}

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -17,10 +17,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-type sourceResolver interface {
-	Resolve(policySet valid.PolicySet) (string, error)
-}
-
 type policyFilter interface {
 	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
 }
@@ -31,15 +27,15 @@ type exec interface {
 
 const (
 	conftestScope = "conftest.policies"
+	// use internal server error message for user to understand error is from atlantis
 	internalError = "internal server error"
 )
 
 // ConfTestExecutor runs a versioned conftest binary with the args built from the project context.
 // Project context defines whether conftest runs a local policy set or runs a test on a remote policy set.
 type ConfTestExecutor struct {
-	SourceResolver sourceResolver
-	Exec           exec
-	PolicyFilter   policyFilter
+	Exec         exec
+	PolicyFilter policyFilter
 }
 
 func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestExecutor {
@@ -51,9 +47,6 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 		Org:           org,
 	}
 	return &ConfTestExecutor{
-		SourceResolver: &SourceResolverProxy{
-			LocalSourceResolver: &LocalSourceResolver{},
-		},
 		Exec:         runtime_models.LocalExec{},
 		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, teamMemberFetcher),
 	}
@@ -62,54 +55,53 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 // Run performs conftest policy tests against changes and fails if any policy does not pass. It also runs an all-or-nothing
 // filter that will filter out all policy failures based on the filter criteria.
 func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error) {
-	var policyArgs []Arg
 	var policyNames []string
 	var failedPolicies []valid.PolicySet
+	var totalCmdOutput string
+	var policyErr error
+
 	inputFile := filepath.Join(workdir, prjCtx.GetShowResultFileName())
 	scope := prjCtx.Scope.SubScope(conftestScope)
 
 	for _, policySet := range prjCtx.PolicySets.PolicySets {
-		path, err := c.SourceResolver.Resolve(policySet)
-		// Let's not fail the whole step because of a single failure. Log and fail silently
-		if err != nil {
-			prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("Error resolving policyset %s. err: %s", policySet.Name, err.Error()))
-			continue
+		var policyArgs []Arg
+		for _, path := range policySet.Paths {
+			policyArgs = append(policyArgs, NewPolicyArg(path))
 		}
-		policyArgs = append(policyArgs, NewPolicyArg(path))
 		policyNames = append(policyNames, policySet.Name)
-	}
+		args := ConftestTestCommandArgs{
+			PolicyArgs: policyArgs,
+			ExtraArgs:  extraArgs,
+			InputFile:  inputFile,
+			Command:    executablePath,
+		}
+		serializedArgs, err := args.build()
+		if err != nil {
+			prjCtx.Log.WarnContext(prjCtx.RequestCtx, "No policies have been configured")
+			scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
+			return "", errors.Wrap(err, "building args")
+		}
 
-	args := ConftestTestCommandArgs{
-		PolicyArgs: policyArgs,
-		ExtraArgs:  extraArgs,
-		InputFile:  inputFile,
-		Command:    executablePath,
-	}
-	serializedArgs, err := args.build()
-	if err != nil {
-		prjCtx.Log.WarnContext(prjCtx.RequestCtx, "No policies have been configured")
-		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
-		return "", errors.Wrap(err, "building args")
-	}
-
-	// TODO: run each policy set separately and use each pass/failure decision to populate failedPolicies
-	cmdOutput, policyErr := c.Exec.CombinedOutput(serializedArgs, envs, workdir)
-	if policyErr != nil {
-		failedPolicies = prjCtx.PolicySets.PolicySets
+		cmdOutput, cmdErr := c.Exec.CombinedOutput(serializedArgs, envs, workdir)
+		// Continue running other policies if one fails since it might not be the only failing one
+		if cmdErr != nil {
+			policyErr = cmdErr
+			failedPolicies = append(failedPolicies, policySet)
+		}
+		totalCmdOutput = fmt.Sprintf("%s\n%s", totalCmdOutput, cmdOutput)
 	}
 
 	title := c.buildTitle(policyNames)
-	output := c.sanitizeOutput(inputFile, title+cmdOutput)
+	output := c.sanitizeOutput(inputFile, title+totalCmdOutput)
 	if prjCtx.InstallationToken == 0 {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "missing installation token")
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
 		return output, errors.New(internalError)
 	}
 
-	failedPolicies, err = c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
 	if err != nil {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("error filtering out approved policies: %s", err.Error()))
-		// use generic error message here as error output is what user sees
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
 		return output, errors.New(internalError)
 	}
@@ -117,7 +109,7 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 		scope.Counter(metrics.ExecutionSuccessMetric).Inc(1)
 		return output, nil
 	}
-	// use policyErr here as error output is what user sees
+	// use policyErr here as policy error output is what the user should see
 	scope.Counter(metrics.ExecutionFailureMetric).Inc(1)
 	return output, policyErr
 }

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -57,7 +57,7 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext, executablePath string, envs map[string]string, workdir string, extraArgs []string) (string, error) {
 	var policyNames []string
 	var failedPolicies []valid.PolicySet
-	var totalCmdOutput string
+	var totalCmdOutput []string
 	var policyErr error
 
 	inputFile := filepath.Join(workdir, prjCtx.GetShowResultFileName())
@@ -88,11 +88,11 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 			policyErr = cmdErr
 			failedPolicies = append(failedPolicies, policySet)
 		}
-		totalCmdOutput = fmt.Sprintf("%s\n%s", totalCmdOutput, cmdOutput)
+		totalCmdOutput = append(totalCmdOutput, cmdOutput)
 	}
 
 	title := c.buildTitle(policyNames)
-	output := c.sanitizeOutput(inputFile, title+totalCmdOutput)
+	output := c.sanitizeOutput(inputFile, title+strings.Join(totalCmdOutput, "\n"))
 	if prjCtx.InstallationToken == 0 {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, "missing installation token")
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	path           = "/path/to/some/place"
+	path2          = "/path/to/another/place"
 	output         = "test output"
 	workDir        = "workDir"
 	executablePath = "executablepath"
@@ -48,178 +49,118 @@ func buildTestTitle(policySets []valid.PolicySet) string {
 }
 
 func TestConfTestExecutor_PolicySuccess(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
 	exec := &mockExec{
 		output: output,
 	}
 	policyFilter := &mockPolicyFilter{}
 	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
+		Exec:         exec,
+		PolicyFilter: policyFilter,
 	}
 	var args []string
 	policySets := []valid.PolicySet{
-		{Name: policyA},
-		{Name: policyB},
+		{Name: policyA, Paths: []string{path, path2}},
+		{Name: policyB, Paths: []string{path, path2}},
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
 	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.NoError(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.True(t, exec.isCalled)
+	assert.Equal(t, exec.numCalls, 2)
 	assert.True(t, policyFilter.isCalled)
 	assert.Contains(t, cmdOutput, expectedTitle)
 	assert.Contains(t, cmdOutput, output)
 }
 
 func TestConfTestExecutor_PolicySuccess_FilteredFailures(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
 	exec := &mockExec{
 		output: output,
 		error:  assert.AnError,
 	}
 	policyFilter := &mockPolicyFilter{}
 	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
+		Exec:         exec,
+		PolicyFilter: policyFilter,
 	}
 	var args []string
 	policySets := []valid.PolicySet{
-		{Name: policyA},
-		{Name: policyB},
+		{Name: policyA, Paths: []string{path}},
+		{Name: policyB, Paths: []string{path2}},
 	}
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
 	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.NoError(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.True(t, exec.isCalled)
+	assert.Equal(t, exec.numCalls, 2)
 	assert.True(t, policyFilter.isCalled)
 	assert.Contains(t, cmdOutput, expectedTitle)
 	assert.Contains(t, cmdOutput, output)
 }
 
 func TestConfTestExecutor_PolicyFailure_NotFiltered(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
 	exec := &mockExec{
 		output: output,
 		error:  assert.AnError,
 	}
 	policySets := []valid.PolicySet{
-		{Name: policyA},
-		{Name: policyB},
+		{Name: policyA, Paths: []string{path}},
+		{Name: policyB, Paths: []string{path2}},
 	}
 	policyFilter := &mockPolicyFilter{
 		policies: policySets,
 	}
 	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
+		Exec:         exec,
+		PolicyFilter: policyFilter,
 	}
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
 	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	expectedTitle := buildTestTitle(policySets)
 	assert.Error(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.True(t, exec.isCalled)
+	assert.Equal(t, exec.numCalls, 2)
 	assert.True(t, policyFilter.isCalled)
 	assert.Contains(t, cmdOutput, expectedTitle)
 	assert.Contains(t, cmdOutput, output)
 }
 
-func TestConfTestExecutor_BuildArgError(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
-	exec := &mockExec{
-		output: output,
-	}
-	policyFilter := &mockPolicyFilter{}
-	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
-	}
-	var args []string
-	var policySets []valid.PolicySet
-	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
-	assert.Error(t, err)
-	assert.False(t, sourceResolver.isCalled)
-	assert.False(t, exec.isCalled)
-	assert.False(t, policyFilter.isCalled)
-	assert.Empty(t, cmdOutput)
-}
-
-func TestConfTestExecutor_SourceResolverError(t *testing.T) {
-	sourceResolver := &mockSourceResolver{error: assert.AnError}
-	exec := &mockExec{
-		output: output,
-	}
-	policyFilter := &mockPolicyFilter{}
-	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
-	}
-	var args []string
-	policySets := []valid.PolicySet{
-		{Name: policyA},
-	}
-	prjCtx := buildTestProjectCtx(t, policySets)
-	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
-	assert.Error(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.False(t, exec.isCalled)
-	assert.False(t, policyFilter.isCalled)
-	assert.Empty(t, cmdOutput)
-}
-
 func TestConfTestExecutor_FilterFailure(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
 	exec := &mockExec{
 		output: output,
 	}
 	policySets := []valid.PolicySet{
-		{Name: policyA},
-		{Name: policyB},
+		{Name: policyA, Paths: []string{path}},
+		{Name: policyB, Paths: []string{path2}},
 	}
 	policyFilter := &mockPolicyFilter{error: assert.AnError}
 	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
+		Exec:         exec,
+		PolicyFilter: policyFilter,
 	}
 	var args []string
 	prjCtx := buildTestProjectCtx(t, policySets)
 	expectedTitle := buildTestTitle(policySets)
 	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.True(t, exec.isCalled)
+	assert.Equal(t, exec.numCalls, 2)
 	assert.True(t, policyFilter.isCalled)
 	assert.Contains(t, cmdOutput, expectedTitle)
 	assert.Contains(t, cmdOutput, output)
 }
 
 func TestConfTestExecutor_MissingInstallationToken(t *testing.T) {
-	sourceResolver := &mockSourceResolver{path: path}
 	exec := &mockExec{
 		output: output,
 	}
 	policyFilter := &mockPolicyFilter{}
 	executor := policy.ConfTestExecutor{
-		SourceResolver: sourceResolver,
-		Exec:           exec,
-		PolicyFilter:   policyFilter,
+		Exec:         exec,
+		PolicyFilter: policyFilter,
 	}
 	var args []string
 	policySets := []valid.PolicySet{
-		{Name: policyA},
-		{Name: policyB},
+		{Name: policyA, Paths: []string{path}},
+		{Name: policyB, Paths: []string{path2}},
 	}
 	prjCtx := command.ProjectContext{
 		PolicySets: valid.PolicySets{
@@ -234,22 +175,10 @@ func TestConfTestExecutor_MissingInstallationToken(t *testing.T) {
 	expectedTitle := buildTestTitle(policySets)
 	cmdOutput, err := executor.Run(context.Background(), prjCtx, executablePath, map[string]string{}, workDir, args)
 	assert.Error(t, err)
-	assert.True(t, sourceResolver.isCalled)
-	assert.True(t, exec.isCalled)
+	assert.Equal(t, exec.numCalls, 2)
 	assert.False(t, policyFilter.isCalled)
 	assert.Contains(t, cmdOutput, expectedTitle)
 	assert.Contains(t, cmdOutput, output)
-}
-
-type mockSourceResolver struct {
-	isCalled bool
-	path     string
-	error    error
-}
-
-func (r *mockSourceResolver) Resolve(_ valid.PolicySet) (string, error) {
-	r.isCalled = true
-	return r.path, r.error
 }
 
 type mockPolicyFilter struct {
@@ -264,12 +193,12 @@ func (r *mockPolicyFilter) Filter(_ context.Context, _ int64, _ models.Repo, _ i
 }
 
 type mockExec struct {
-	isCalled bool
+	numCalls int
 	output   string
 	error    error
 }
 
 func (r *mockExec) CombinedOutput(_ []string, _ map[string]string, _ string) (string, error) {
-	r.isCalled = true
+	r.numCalls += 1
 	return r.output, r.error
 }

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -199,6 +199,6 @@ type mockExec struct {
 }
 
 func (r *mockExec) CombinedOutput(_ []string, _ map[string]string, _ string) (string, error) {
-	r.numCalls += 1
+	r.numCalls++
 	return r.output, r.error
 }


### PR DESCRIPTION
Companion to https://github.com/lyft/atlantis/commit/741702d429ff0f7433822d647bfc4ede212a1615. Now that policy check happens at a per team level, we need to update the new ConftestExecutor to separately run each policy set. PR contains the following:

- PolicySet config introduces a `Paths` field to allow for conftest to multiple paths for a single policy (will deprecate `Path` field once project is rolled out)
- ConftestExecutor will run conftest command separately for each PolicySet
- Discovered a lot of our E2E tests weren't properly running in parallel, removing that call showed a lot of test file bugs that I fixed in this PR
