### PR TITLE
Gate approve policies command 

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -965,17 +965,10 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		parallelPoolSize,
 	)
 
-	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(
-		e2eStatusUpdater,
-		projectCommandBuilder,
-		prjCmdRunner,
-		pullUpdater,
-		dbUpdater,
-		&policies.CommandOutputGenerator{
-			PrjCommandRunner:  prjCmdRunner,
-			PrjCommandBuilder: projectCommandBuilder,
-		},
-	)
+	approvePoliciesCommandRunner := events.NewApprovePoliciesCommandRunner(e2eStatusUpdater, projectCommandBuilder, prjCmdRunner, pullUpdater, dbUpdater, &policies.CommandOutputGenerator{
+		PrjCommandRunner:  prjCmdRunner,
+		PrjCommandBuilder: projectCommandBuilder,
+	}, featureAllocator)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(
 		deleteLockCommand,

--- a/server/events/approve_policies_command_runner.go
+++ b/server/events/approve_policies_command_runner.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"fmt"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -11,6 +12,7 @@ type commandOutputGenerator interface {
 	GeneratePolicyCheckOutputStore(ctx *command.Context, cmd *command.Comment) (command.PolicyCheckOutputStore, error)
 }
 
+// TODO: delete approve policies command runner when policy v2 rollout is complete
 func NewApprovePoliciesCommandRunner(
 	vcsStatusUpdater VCSStatusUpdater,
 	prjCommandBuilder ProjectApprovePoliciesCommandBuilder,
@@ -18,7 +20,7 @@ func NewApprovePoliciesCommandRunner(
 	outputUpdater OutputUpdater,
 	dbUpdater *DBUpdater,
 	policyCheckOutputGenerator commandOutputGenerator,
-) *ApprovePoliciesCommandRunner {
+	allocator feature.Allocator) *ApprovePoliciesCommandRunner {
 	return &ApprovePoliciesCommandRunner{
 		vcsStatusUpdater:           vcsStatusUpdater,
 		prjCmdBuilder:              prjCommandBuilder,
@@ -26,6 +28,7 @@ func NewApprovePoliciesCommandRunner(
 		outputUpdater:              outputUpdater,
 		dbUpdater:                  dbUpdater,
 		policyCheckOutputGenerator: policyCheckOutputGenerator,
+		allocator:                  allocator,
 	}
 }
 
@@ -36,11 +39,22 @@ type ApprovePoliciesCommandRunner struct {
 	prjCmdBuilder              ProjectApprovePoliciesCommandBuilder
 	prjCmdRunner               ProjectApprovePoliciesCommandRunner
 	policyCheckOutputGenerator commandOutputGenerator
+	allocator                  feature.Allocator
 }
 
 func (a *ApprovePoliciesCommandRunner) Run(ctx *command.Context, cmd *command.Comment) {
 	baseRepo := ctx.Pull.BaseRepo
 	pull := ctx.Pull
+	shouldAllocate, err := a.allocator.ShouldAllocate(feature.PolicyV2, feature.FeatureContext{
+		RepoName: baseRepo.FullName,
+	})
+	if err != nil {
+		ctx.Log.ErrorContext(ctx.RequestCtx, "unable to allocate policy v2, continuing with legacy mode")
+	}
+	if shouldAllocate {
+		ctx.Log.ErrorContext(ctx.RequestCtx, "policy v2 mode doesn't support atlantis approve_policies command")
+		return
+	}
 
 	statusID, err := a.vcsStatusUpdater.UpdateCombined(ctx.RequestCtx, baseRepo, pull, models.PendingVCSStatus, command.PolicyCheck, "", "")
 	if err != nil {

--- a/server/events/command/name.go
+++ b/server/events/command/name.go
@@ -20,6 +20,7 @@ const (
 	// PolicyCheck is a command to run conftest test.
 	PolicyCheck
 	// ApprovePolicies is a command to approve policies with owner check
+	// TODO: remove ApprovePolicies with policy v2
 	ApprovePolicies
 	// Autoplan is a command to run terrafor plan on PR open/update if autoplan is enabled
 	Autoplan

--- a/server/events/command_runner_test.go
+++ b/server/events/command_runner_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally/v4"
 	"regexp"
@@ -134,18 +135,13 @@ func setup(t *testing.T) *vcsmocks.MockClient {
 		parallelPoolSize,
 		pullReqStatusFetcher,
 	)
+	featureAllocator, featureAllocatorErr := feature.NewStringSourcedAllocator(logger)
+	assert.NoError(t, featureAllocatorErr)
 
-	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(
-		vcsUpdater,
-		projectCommandBuilder,
-		projectCommandRunner,
-		pullUpdater,
-		dbUpdater,
-		&policies.CommandOutputGenerator{
-			PrjCommandRunner:  projectCommandRunner,
-			PrjCommandBuilder: projectCommandBuilder,
-		},
-	)
+	approvePoliciesCommandRunner = events.NewApprovePoliciesCommandRunner(vcsUpdater, projectCommandBuilder, projectCommandRunner, pullUpdater, dbUpdater, &policies.CommandOutputGenerator{
+		PrjCommandRunner:  projectCommandRunner,
+		PrjCommandBuilder: projectCommandBuilder,
+	}, featureAllocator)
 
 	unlockCommandRunner = events.NewUnlockCommandRunner(
 		deleteLockCommand,

--- a/server/server.go
+++ b/server/server.go
@@ -763,6 +763,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		checksOutputUpdater,
 		dbUpdater,
 		&policyCheckOutputGenerator,
+		featureAllocator,
 	)
 
 	unlockCommandRunner := events.NewUnlockCommandRunner(


### PR DESCRIPTION
We are going to remove the approve policies command in favor of GH approvals, so let's use the feature allocator to gate its run. Eventually the entire command runner will be removed.

TODO: fix e2e tests + add apply command runner unit test for feature allocator