### PR TITLE
Use sync.Map for owners cache

### DIFF
--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/stretchr/testify/assert"
-	"sync"
 	"testing"
 )
 
@@ -46,9 +45,7 @@ func TestFilter_ApprovedCacheMiss(t *testing.T) {
 		members: team,
 	}
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
-	owners := sync.Map{}
-	owners.Store(policyOwner, team)
-	policyFilter.owners = owners
+	policyFilter.owners.Store(policyOwner, team)
 	failedPolicies := []valid.PolicySet{
 		{Name: policyName, Owner: policyOwner},
 	}

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 )
 
@@ -45,9 +46,9 @@ func TestFilter_ApprovedCacheMiss(t *testing.T) {
 		members: team,
 	}
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, teamFetcher)
-	policyFilter.owners = map[string][]string{
-		policyOwner: team,
-	}
+	owners := sync.Map{}
+	owners.Store(policyOwner, team)
+	policyFilter.owners = owners
 	failedPolicies := []valid.PolicySet{
 		{Name: policyName, Owner: policyOwner},
 	}


### PR DESCRIPTION
Multiple concurrent policy check commands rely on the same cache so we should use a sync.Map