### PR TITLE
Improve policy check output

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/disabled-apply/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `staging` workspace: `staging`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/platform-mode/policy-check-approval/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - null_resource_policy - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -8,6 +8,7 @@ Ran Policy Check for 2 projects:
 Checking plan against the following policies: 
   test_policy
 
+test_policy:
 1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
 
 ```
@@ -20,6 +21,8 @@ Checking plan against the following policies:
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/exp-output-auto-policy-check.txt
@@ -5,6 +5,8 @@ Ran Policy Check for dir: `.` workspace: `default`
 exit status 1
 Checking plan against the following policies: 
   test_policy
+
+test_policy:
 FAIL - <redacted plan file> - main - WARNING: Null Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -92,7 +92,7 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 			policyErr = cmdErr
 			failedPolicies = append(failedPolicies, policySet)
 		}
-		totalCmdOutput = append(totalCmdOutput, cmdOutput)
+		totalCmdOutput = append(totalCmdOutput, c.processOutput(cmdOutput, policySet, cmdErr))
 	}
 
 	title := c.buildTitle(policyNames)
@@ -119,9 +119,17 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 }
 
 func (c *ConfTestExecutor) buildTitle(policySetNames []string) string {
-	return fmt.Sprintf("Checking plan against the following policies: \n  %s\n", strings.Join(policySetNames, "\n  "))
+	return fmt.Sprintf("Checking plan against the following policies: \n  %s\n\n", strings.Join(policySetNames, "\n  "))
 }
 
 func (c *ConfTestExecutor) sanitizeOutput(inputFile string, output string) string {
 	return strings.Replace(output, inputFile, "<redacted plan file>", -1)
+}
+
+func (c *ConfTestExecutor) processOutput(output string, policySet valid.PolicySet, err error) string {
+	// errored results need an extra newline
+	if err != nil {
+		return policySet.Name + ":\n" + output
+	}
+	return policySet.Name + ":" + output
 }


### PR DESCRIPTION
Wanted to clean up our output a little bit to make results more clear to the user. Since each policy set will run the conftest command separately, I wanted to label each output with the policy set name. See the updated testfixture test examples to see what this looks like. 