### PR TITLE
Pass organization name into repo configuration

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -439,7 +439,7 @@ policy-v2:
 		ExpReplies [][]string
 	}{
 		{
-			Description:   "1 failing policy and 1 passing policy ",
+			Description:   "1 failing project and 1 passing project ",
 			RepoDir:       "policy-checks-multi-projects",
 			ModifiedFiles: []string{"dir1/main.tf,", "dir2/main.tf"},
 			Comments: []string{

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/exp-output-auto-policy-check.txt
@@ -7,8 +7,12 @@ Ran Policy Check for 2 projects:
 ```diff
 Checking plan against the following policies: 
   test_policy
+  test_policy_2
 
 test_policy:
+1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
+
+test_policy_2:
 1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
 
 ```
@@ -21,8 +25,14 @@ test_policy:
 exit status 1
 Checking plan against the following policies: 
   test_policy
+  test_policy_2
 
 test_policy:
+FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.
+
+1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions
+
+test_policy_2:
 FAIL - <redacted plan file> - main - WARNING: Forbidden Resource creation is prohibited.
 
 1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/repos.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/repos.yaml
@@ -6,3 +6,7 @@ policies:
       owner: runatlantis
       paths:
         - ../policies/policy.rego
+    - name: test_policy_2
+      owner: runatlantis
+      paths:
+        - ../policies/policy.rego

--- a/server/core/config/raw/policies.go
+++ b/server/core/config/raw/policies.go
@@ -8,9 +8,10 @@ import (
 
 // PolicySets is the raw schema for repo-level atlantis.yaml config.
 type PolicySets struct {
-	Version    *string      `yaml:"conftest_version,omitempty" json:"conftest_version,omitempty"`
-	Owners     PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
-	PolicySets []PolicySet  `yaml:"policy_sets" json:"policy_sets"`
+	Version      *string      `yaml:"conftest_version,omitempty" json:"conftest_version,omitempty"`
+	Owners       PolicyOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	PolicySets   []PolicySet  `yaml:"policy_sets" json:"policy_sets"`
+	Organization string       `yaml:"organization" json:"organization"`
 }
 
 func (p PolicySets) Validate() error {
@@ -28,6 +29,7 @@ func (p PolicySets) ToValid() valid.PolicySets {
 	}
 
 	policySets.Owners = p.Owners.ToValid()
+	policySets.Organization = p.Organization
 
 	validPolicySets := make([]valid.PolicySet, 0)
 	for _, rawPolicySet := range p.PolicySets {

--- a/server/core/config/raw/policies_test.go
+++ b/server/core/config/raw/policies_test.go
@@ -21,13 +21,15 @@ func TestPolicySetsConfig_YAMLMarshalling(t *testing.T) {
 			description: "valid yaml",
 			input: `
 conftest_version: v1.0.0
+organization: org
 policy_sets:
 - name: policy-name
   source: "local"
   path: "rel/path/to/policy-set"
 `,
 			exp: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name",
@@ -41,13 +43,15 @@ policy_sets:
 			description: "valid yaml with multiple paths",
 			input: `
 conftest_version: v1.0.0
+organization: org
 policy_sets:
 - name: policy-name
   source: "local"
   paths: ["rel/path/to/policy-set", "rel/path/to/another/policy-set"]
 `,
 			exp: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name",
@@ -91,7 +95,8 @@ func TestPolicySets_Validate(t *testing.T) {
 		{
 			description: "policies",
 			input: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "policy-name-1",
@@ -200,7 +205,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 		{
 			description: "valid policies with owners",
 			input: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				Owners: raw.PolicyOwners{
 					Users: []string{
 						"test",
@@ -215,7 +221,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 				},
 			},
 			exp: valid.PolicySets{
-				Version: version,
+				Organization: "org",
+				Version:      version,
 				Owners: valid.PolicyOwners{
 					Users: []string{"test"},
 				},
@@ -231,7 +238,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 		{
 			description: "valid policies without owners",
 			input: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				PolicySets: []raw.PolicySet{
 					{
 						Name:   "good-policy",
@@ -241,7 +249,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 				},
 			},
 			exp: valid.PolicySets{
-				Version: version,
+				Organization: "org",
+				Version:      version,
 				PolicySets: []valid.PolicySet{
 					{
 						Name:   "good-policy",
@@ -254,7 +263,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 		{
 			description: "valid policies with multiple paths",
 			input: raw.PolicySets{
-				Version: String("v1.0.0"),
+				Organization: "org",
+				Version:      String("v1.0.0"),
 				Owners: raw.PolicyOwners{
 					Users: []string{
 						"test",
@@ -269,7 +279,8 @@ func TestPolicySets_ToValid(t *testing.T) {
 				},
 			},
 			exp: valid.PolicySets{
-				Version: version,
+				Organization: "org",
+				Version:      version,
 				Owners: valid.PolicyOwners{
 					Users: []string{"test"},
 				},

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -16,7 +16,7 @@ type PolicySets struct {
 	Version      *version.Version
 	Owners       PolicyOwners
 	PolicySets   []PolicySet
-	Organization string
+	Organization string // Github organization each policy set owner belongs to
 }
 
 type PolicyOwners struct {

--- a/server/core/config/valid/policies.go
+++ b/server/core/config/valid/policies.go
@@ -13,9 +13,10 @@ const (
 // PolicySet objects. PolicySets struct is used by PolicyCheck workflow to build
 // context to enforce policies.
 type PolicySets struct {
-	Version    *version.Version
-	Owners     PolicyOwners
-	PolicySets []PolicySet
+	Version      *version.Version
+	Owners       PolicyOwners
+	PolicySets   []PolicySet
+	Organization string
 }
 
 type PolicyOwners struct {

--- a/server/server.go
+++ b/server/server.go
@@ -588,7 +588,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator, userConfig.GithubOrg)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets.Organization)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,


### PR DESCRIPTION
We will use this organization name for the [ListTeamMembersBySlug](https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#list-team-members) API. 