### PR TITLE
Support actions summary.

### DIFF
--- a/server/core/config/raw/temporal.go
+++ b/server/core/config/raw/temporal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 
-const DefaultTaskqueue = "deploy"
+const DefaultTaskqueue = "terraform"
 
 type Temporal struct {
 	Port               string `yaml:"port" json:"port"`

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -276,23 +276,12 @@ func (s Server) shutdown() {
 	s.TemporalClient.Close()
 }
 
-// // allows us to know which worker is polling which task queue without having to
-// // dig through the UI
-// // additionally, this also allows us to share our temporal client across workers
-// func generateWorkerID(taskQueue string) string {
-// 	hostname, err := os.Hostname()
-// 	if err != nil {
-// 		hostname = "Unknown"
-// 	}
-
-// 	return fmt.Sprintf("%d@%s@%s", os.Getpid(), hostname, taskQueue)
-// }
-
+// TODO: consider building these before initializing the server so that the server is just responsible
+// for running the workers and has no knowledge of their dependencies.
 func (s Server) buildDeployWorker() worker.Worker {
 	// pass the underlying client otherwise this will panic()
 	deployWorker := worker.New(s.TemporalClient.Client, workflows.DeployTaskQueue, worker.Options{
 		WorkerStopTimeout: TemporalWorkerTimeout,
-		// Identity:          generateWorkerID(workflows.DeployTaskQueue),
 	})
 	deployWorker.RegisterActivity(s.DeployActivities)
 	deployWorker.RegisterActivity(s.GithubActivities)
@@ -306,7 +295,6 @@ func (s Server) buildTerraformWorker() worker.Worker {
 	// pass the underlying client otherwise this will panic()
 	terraformWorker := worker.New(s.TemporalClient.Client, s.TerraformTaskQueue, worker.Options{
 		WorkerStopTimeout: TemporalWorkerTimeout,
-		// Identity:          generateWorkerID(s.TerraformTaskQueue),
 	})
 	terraformWorker.RegisterActivity(s.TerraformActivities)
 	terraformWorker.RegisterActivity(s.GithubActivities)

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -16,12 +16,13 @@ var checkrunTemplateStr string
 var checkrunTemplate = template.Must(template.New("").Parse(checkrunTemplateStr))
 
 type checkrunTemplateData struct {
-	PlanStatus    string
-	PlanLogURL    string
-	ApplyStatus   string
-	ApplyLogURL   string
-	InternalError bool
-	TimedOut      bool
+	ApplyActionsSummary string
+	PlanStatus          string
+	PlanLogURL          string
+	ApplyStatus         string
+	ApplyLogURL         string
+	InternalError       bool
+	TimedOut            bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -33,13 +34,19 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	internalError := workflowState.Result.Reason == state.InternalServiceError
 	timedOut := workflowState.Result.Reason == state.TimedOutError
 
+	var applyActionsSummary string
+
+	if workflowState.Apply != nil {
+		applyActionsSummary = workflowState.Apply.GetActions().Summary
+	}
 	return renderTemplate(checkrunTemplate, checkrunTemplateData{
-		PlanStatus:    planStatus,
-		PlanLogURL:    planLogURL,
-		ApplyStatus:   applyStatus,
-		ApplyLogURL:   applyLogURL,
-		InternalError: internalError,
-		TimedOut:      timedOut,
+		PlanStatus:          planStatus,
+		PlanLogURL:          planLogURL,
+		ApplyStatus:         applyStatus,
+		ApplyLogURL:         applyLogURL,
+		InternalError:       internalError,
+		TimedOut:            timedOut,
+		ApplyActionsSummary: applyActionsSummary,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -1,3 +1,12 @@
+{{ if .ApplyActionsSummary }}
+## Required Actions :heavy_exclamation_mark:
+
+Github Actions are blocking this deployment from proceeding.
+
+### Summary
+{{ .ApplyActionsSummary }} 
+{{end}}
+
 | Operation | **Status** | **Logs** |  
 | - | - | - |
 | Plan | {{ if .PlanStatus }}`{{.PlanStatus}}`{{else}}N/A{{end}} |{{ if .PlanLogURL }}[Click Here]({{.PlanLogURL}}){{else}}N/A{{end}} |

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -64,11 +64,10 @@ func (n *StateReceiver) updateCheckRun(ctx workflow.Context, workflowState *stat
 		Summary: summary,
 	}
 
-	if workflowState.Plan != nil && workflowState.Plan.Status == state.SuccessJobStatus &&
-		workflowState.Apply != nil && workflowState.Apply.Status == state.WaitingJobStatus {
-		request.Actions = []github.CheckRunAction{
-			github.CreatePlanReviewAction(github.Approve),
-			github.CreatePlanReviewAction(github.Reject),
+	if workflowState.Apply != nil {
+		// add any actions pertaining to the apply job
+		for _, a := range workflowState.Apply.GetActions().Actions {
+			request.Actions = append(request.Actions, a.ToGithubCheckRunAction())
 		}
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -138,12 +138,22 @@ func TestStateReceive(t *testing.T) {
 				Apply: &state.Job{
 					Output: jobOutput,
 					Status: state.WaitingJobStatus,
+					OnWaitingActions: state.JobActions{
+						Actions: []state.JobAction{
+							{
+								ID:   "Confirm",
+								Info: "confirm",
+							},
+						},
+					},
 				},
 			},
 			ExpectedCheckRunState: github.CheckRunPending,
 			ExpectedActions: []github.CheckRunAction{
-				github.CreatePlanReviewAction(github.Approve),
-				github.CreatePlanReviewAction(github.Reject),
+				{
+					Label:       "Confirm",
+					Description: "confirm",
+				},
 			},
 		},
 		{

--- a/server/neptune/workflows/internal/terraform/gate/review_test.go
+++ b/server/neptune/workflows/internal/terraform/gate/review_test.go
@@ -13,38 +13,60 @@ import (
 )
 
 type res struct {
-	Status gate.PlanStatus
+	Status                        gate.PlanStatus
+	ActionsClientCalled           bool
+	ActionsClientCapturedApproval terraform.PlanApproval
 }
 
 type req struct {
-	PlanSummary terraform.PlanSummary
+	PlanSummary      terraform.PlanSummary
+	ApprovalOverride terraform.PlanApproval
+}
+
+type testClient struct {
+	called           bool
+	capturedApproval terraform.PlanApproval
+}
+
+func (c *testClient) UpdateApprovalActions(approval terraform.PlanApproval) error {
+	c.called = true
+	c.capturedApproval = approval
+
+	return nil
 }
 
 func testReviewWorkflow(ctx workflow.Context, r req) (res, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 30 * time.Second,
 	})
+
+	c := &testClient{}
 	review := gate.Review{
 		Timeout:        10 * time.Second,
 		MetricsHandler: client.MetricsNopHandler,
+		Client:         c,
 	}
 
-	status := review.Await(ctx, terraform.Root{
+	status, err := review.Await(ctx, terraform.Root{
 		Plan: terraform.PlanJob{
-			Approval: terraform.PlanApproval{
-				Type: terraform.ManualApproval,
-			},
+			Approval: r.ApprovalOverride,
 		},
 	}, r.PlanSummary)
 
 	return res{
-		Status: status,
-	}, nil
+		Status:                        status,
+		ActionsClientCalled:           c.called,
+		ActionsClientCapturedApproval: c.capturedApproval,
+	}, err
 }
 
 func TestAwait_timesOut(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+
+	approvalOverride := terraform.PlanApproval{
+		Type: terraform.ManualApproval,
+	}
 
 	env.ExecuteWorkflow(testReviewWorkflow, req{PlanSummary: terraform.PlanSummary{
 		Updates: []terraform.ResourceSummary{
@@ -52,18 +74,38 @@ func TestAwait_timesOut(t *testing.T) {
 				Address: "addr",
 			},
 		},
-	}})
+	}, ApprovalOverride: approvalOverride})
 
 	var r res
 	err := env.GetWorkflowResult(&r)
 	assert.NoError(t, err)
 
 	assert.Equal(t, r, res{
-		Status: gate.Rejected,
+		Status:                        gate.Rejected,
+		ActionsClientCalled:           true,
+		ActionsClientCapturedApproval: approvalOverride,
 	})
 }
 
 func TestAwait_approvesEmptyPlan(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(testReviewWorkflow, req{
+		ApprovalOverride: terraform.PlanApproval{
+			Type: terraform.ManualApproval,
+		},
+	})
+
+	var r res
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r, res{
+		Status: gate.Approved,
+	})
+}
+func TestAwait_autoApprove(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -83,10 +83,19 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			metrics.RootTag: request.Root.Name,
 		})
 
+	// We have critical things relying on this notification so this workflow provides guarantees around this. (ie. compliance auditing)  There should
+	// be no situation where we are deploying while this is failing.
+	store := state.NewWorkflowStore(
+		func(s *state.Workflow) error {
+			return workflow.SignalExternalWorkflow(ctx, parent.ID, parent.RunID, state.WorkflowStateChangeSignal, s).Get(ctx, nil)
+		},
+	)
+
 	return &Runner{
 		ReviewGate: &gate.Review{
 			MetricsHandler: metricsHandler,
 			Timeout:        ReviewGateTimeout,
+			Client:         store,
 		},
 		GithubActivities:    ga,
 		TerraformActivities: ta,
@@ -106,11 +115,7 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 		MetricsHandler: metricsHandler,
 		// We have critical things relying on this notification so this workflow provides guarantees around this. (ie. compliance auditing)  There should
 		// be no situation where we are deploying while this is failing.
-		Store: state.NewWorkflowStore(
-			func(s *state.Workflow) error {
-				return workflow.SignalExternalWorkflow(ctx, parent.ID, parent.RunID, state.WorkflowStateChangeSignal, s).Get(ctx, nil)
-			},
-		),
+		Store: store,
 	}
 }
 
@@ -160,7 +165,11 @@ func (r *Runner) Apply(ctx workflow.Context, root *terraform.LocalRoot, serverUR
 		return errors.Wrap(err, "initializing job")
 	}
 
-	planStatus := r.ReviewGate.Await(ctx, root.Root, planResponse.Summary)
+	planStatus, err := r.ReviewGate.Await(ctx, root.Root, planResponse.Summary)
+	if err != nil {
+		logger.Error(ctx, "error waiting for plan review.", key.ErrKey, err)
+		return newPlanRejectedError()
+	}
 
 	if planStatus == gate.Rejected {
 		if err := r.Store.UpdateApplyJobWithStatus(state.RejectedJobStatus); err != nil {

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -113,9 +113,7 @@ func newRunner(ctx workflow.Context, request Request) *Runner {
 			Ta:      ta,
 		},
 		MetricsHandler: metricsHandler,
-		// We have critical things relying on this notification so this workflow provides guarantees around this. (ie. compliance auditing)  There should
-		// be no situation where we are deploying while this is failing.
-		Store: store,
+		Store:          store,
 	}
 }
 


### PR DESCRIPTION
Allows us to provide reasoning when actions are displayed on the github check run.  For now we only add this for the manual step involved in diverged revision deploys

Tested locally and looks like this:
<img width="747" alt="Screenshot 2023-01-18 at 11 17 34 AM" src="https://user-images.githubusercontent.com/7416619/213283416-e02d82e9-8d72-4d98-8ac0-eef6f21a2ece.png">
