### PR TITLE
Ensure manual deploys are manually confirmed.

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -17,7 +17,7 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-const warningMessage = "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and approve the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
+const warningMessage = "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and confirm the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
 
 // Comment is our internal representation of a vcs based comment event.
 type Comment struct {

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -1,6 +1,8 @@
 package terraform
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -61,21 +63,37 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 
 	request := terraform.Request{
 		Repo:         deploymentInfo.Repo,
-		Root:         deploymentInfo.Root,
+		Root:         r.buildRequestRoot(deploymentInfo.Root, diffDirection),
 		DeploymentID: id.String(),
 		Revision:     deploymentInfo.Revision,
 	}
 
-	// force plan reviews if we have diverged
-	if diffDirection == activities.DirectionDiverged {
-		request.Root = request.Root.WithPlanApprovalOverride(terraformActivities.PlanApproval{
-			Type:   terraformActivities.ManualApproval,
-			Reason: ":warning: Requested Revision is not ahead of deployed revision, please confirm the changes described in the plan.",
-		})
-	}
-
 	future := workflow.ExecuteChildWorkflow(ctx, r.Workflow, request)
 	return r.awaitWorkflow(ctx, future, deploymentInfo)
+}
+
+func (r *WorkflowRunner) buildRequestRoot(root terraformActivities.Root, diffDirection activities.DiffDirection) terraformActivities.Root {
+	var approvalType terraformActivities.PlanApprovalType
+	var reasons []string
+
+	if diffDirection == activities.DirectionDiverged || root.Trigger == terraformActivities.ManualTrigger {
+		approvalType = terraformActivities.ManualApproval
+	}
+
+	if diffDirection == activities.DirectionDiverged {
+		reasons = append(reasons, ":warning: Requested Revision is not ahead of deployed revision, please confirm the changes described in the plan.")
+	}
+
+	if root.Trigger == terraformActivities.ManualTrigger {
+		reasons = append(reasons, ":warning: Manually Triggered Deploys must be confirmed before proceeding.")
+	}
+
+	return root.WithPlanApprovalOverride(
+		terraformActivities.PlanApproval{
+			Type:   approvalType,
+			Reason: strings.Join(reasons, "\n"),
+		},
+	)
 }
 
 func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.ChildWorkflowFuture, deploymentInfo DeploymentInfo) error {


### PR DESCRIPTION
It probably doesn't make sense for these to be automatic, let's just keep them as manual for now since it's in the PR anyways.