### PR TITLE
Fix fa check run handling in gateway.

### DIFF
--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -85,6 +85,7 @@ func NewVCSEventsController(
 	checkRunHandler := &gateway_handlers.CheckRunHandler{
 		Logger:            logger,
 		RootConfigBuilder: rootConfigBuilder,
+		SyncScheduler:     syncScheduler,
 		AsyncScheduler:    asyncScheduler,
 		DeploySignaler:    deploySignaler,
 	}

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -39,7 +39,8 @@ func NewVCSEventsController(
 	pullConverter converters.PullConverter,
 	githubClient converters.PullGetter,
 	featureAllocator feature.Allocator,
-	scheduler scheduler,
+	syncScheduler scheduler,
+	asyncScheduler scheduler,
 	temporalClient client.Client,
 	rootConfigBuilder *gateway_handlers.RootConfigBuilder,
 	checkRunFetcher *github.CheckRunsFetcher) *VCSEventsController {
@@ -48,7 +49,7 @@ func NewVCSEventsController(
 	)
 
 	asyncAutoplannerWorkerProxy := gateway_handlers.NewAutoplannerValidatorProxy(
-		autoplanValidator, logger, pullEventWorkerProxy, scheduler,
+		autoplanValidator, logger, pullEventWorkerProxy, asyncScheduler,
 	)
 
 	prHandler := handlers.NewPullRequestEventWithEventTypeHandlers(
@@ -70,13 +71,13 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, scheduler, rootDeployer, vcsClient),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, vcsClient),
 		logger,
 	)
 
 	pushHandler := &gateway_handlers.PushHandler{
 		Allocator:    featureAllocator,
-		Scheduler:    scheduler,
+		Scheduler:    asyncScheduler,
 		Logger:       logger,
 		RootDeployer: rootDeployer,
 	}
@@ -84,19 +85,19 @@ func NewVCSEventsController(
 	checkRunHandler := &gateway_handlers.CheckRunHandler{
 		Logger:            logger,
 		RootConfigBuilder: rootConfigBuilder,
-		Scheduler:         scheduler,
+		AsyncScheduler:    asyncScheduler,
 		DeploySignaler:    deploySignaler,
 	}
 
 	checkSuiteHandler := &gateway_handlers.CheckSuiteHandler{
 		Logger:       logger,
-		Scheduler:    scheduler,
+		Scheduler:    asyncScheduler,
 		RootDeployer: rootDeployer,
 	}
 
 	pullRequestReviewHandler := &gateway_handlers.PullRequestReviewWorkerProxy{
 		Allocator:       featureAllocator,
-		Scheduler:       scheduler,
+		Scheduler:       asyncScheduler,
 		SnsWriter:       snsWriter,
 		Logger:          logger,
 		CheckRunFetcher: checkRunFetcher,

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -20,8 +20,11 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    &mockDeploySignaler{},
+
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: &mockDeploySignaler{},
 		}
 		e := event.CheckRun{
 			Name: "something",
@@ -37,8 +40,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("test"),
@@ -72,8 +77,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: rootConfigBuilder,
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("test"),
@@ -92,8 +99,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("test"),
@@ -112,8 +121,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.WrappedCheckRunAction("requested_action"),
@@ -130,8 +141,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
@@ -152,12 +165,14 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
-				Identifier: "Approve",
+				Identifier: "Confirm",
 			},
 			ExternalID: workflowID,
 			User:       user,
@@ -176,8 +191,10 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
@@ -220,12 +237,14 @@ func TestCheckRunHandler(t *testing.T) {
 		subject := event.CheckRunHandler{
 			Logger:            logging.NewNoopCtxLogger(t),
 			RootConfigBuilder: &mockRootConfigBuilder{},
-			Scheduler:         &sync.SynchronousScheduler{Logger: logger},
-			DeploySignaler:    signaler,
+			// both are synchronous to keep our tests predictable
+			SyncScheduler:  &sync.SynchronousScheduler{Logger: logger},
+			AsyncScheduler: &sync.SynchronousScheduler{Logger: logger},
+			DeploySignaler: signaler,
 		}
 		e := event.CheckRun{
 			Action: event.RequestedActionChecksAction{
-				Identifier: "Approve",
+				Identifier: "Confirm",
 			},
 			ExternalID: workflowID,
 			User:       user,

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -233,7 +233,10 @@ func NewServer(config Config) (*Server, error) {
 		config.MaxProjectsPerPR,
 	)
 
-	asyncScheduler := sync.NewAsyncScheduler(ctxLogger)
+	syncScheduler := &sync.SynchronousScheduler{
+		Logger: ctxLogger,
+	}
+	asyncScheduler := sync.NewAsyncScheduler(ctxLogger, syncScheduler)
 
 	gatewaySnsWriter := sns.NewWriterWithStats(session, config.SNSTopicArn, statsScope.SubScope("aws.sns.gateway"))
 	autoplanValidator := &lyft_gateway.AutoplanValidator{
@@ -316,6 +319,7 @@ func NewServer(config Config) (*Server, error) {
 		pullConverter,
 		vcsClient,
 		featureAllocator,
+		syncScheduler,
 		asyncScheduler,
 		temporalClient,
 		rootConfigBuilder,

--- a/server/neptune/sync/scheduler.go
+++ b/server/neptune/sync/scheduler.go
@@ -23,13 +23,11 @@ type AsyncScheduler struct {
 	wg        sync.WaitGroup
 }
 
-func NewAsyncScheduler(logger logging.Logger) *AsyncScheduler {
+func NewAsyncScheduler(logger logging.Logger, delegate *SynchronousScheduler) *AsyncScheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &AsyncScheduler{
-		delegate: &SynchronousScheduler{
-			Logger: logger,
-		},
+		delegate:  delegate,
 		poolCtx:   ctx,
 		cancelCtx: cancel,
 	}


### PR DESCRIPTION
Use synchronous scheduler effectively as a wrapper for err handling at the handler level.