### PR TITLE
Add 'Github' prefix to activities for stats purposes.

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -81,7 +81,7 @@ type UpdateCheckRunResponse struct {
 	ID int64
 }
 
-func (a *githubActivities) UpdateCheckRun(ctx context.Context, request UpdateCheckRunRequest) (UpdateCheckRunResponse, error) {
+func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request UpdateCheckRunRequest) (UpdateCheckRunResponse, error) {
 	output := github.CheckRunOutput{
 		Title:   &request.Title,
 		Text:    &request.Title,
@@ -125,7 +125,7 @@ func (a *githubActivities) UpdateCheckRun(ctx context.Context, request UpdateChe
 	}, nil
 }
 
-func (a *githubActivities) CreateCheckRun(ctx context.Context, request CreateCheckRunRequest) (CreateCheckRunResponse, error) {
+func (a *githubActivities) GithubCreateCheckRun(ctx context.Context, request CreateCheckRunRequest) (CreateCheckRunResponse, error) {
 	output := github.CheckRunOutput{
 		Title:   &request.Title,
 		Text:    &request.Title,
@@ -211,7 +211,7 @@ type FetchRootResponse struct {
 
 // FetchRoot fetches a link to the archive URL using the GH client, processes that URL into a download URL that the
 // go-getter library can use, and then go-getter to download/extract files/subdirs within the root path to the destinationPath.
-func (a *githubActivities) FetchRoot(ctx context.Context, request FetchRootRequest) (FetchRootResponse, error) {
+func (a *githubActivities) GithubFetchRoot(ctx context.Context, request FetchRootRequest) (FetchRootResponse, error) {
 	cancel := temporal.StartHeartbeat(ctx, temporal.HeartbeatTimeout)
 	defer cancel()
 
@@ -260,7 +260,7 @@ type CompareCommitResponse struct {
 	CommitComparison DiffDirection
 }
 
-func (a *githubActivities) CompareCommit(ctx context.Context, request CompareCommitRequest) (CompareCommitResponse, error) {
+func (a *githubActivities) GithubCompareCommit(ctx context.Context, request CompareCommitRequest) (CompareCommitResponse, error) {
 	comparison, resp, err := a.Client.CompareCommits(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, request.LatestDeployedRevision, request.DeployRequestRevision, &github.ListOptions{})
 
 	if err != nil {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -34,8 +34,8 @@ type dbActivities interface {
 }
 
 type githubActivities interface {
-	CompareCommit(ctx context.Context, request activities.CompareCommitRequest) (activities.CompareCommitResponse, error)
-	UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
+	GithubCompareCommit(ctx context.Context, request activities.CompareCommitRequest) (activities.CompareCommitResponse, error)
+	GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
 }
 
 type deployerActivities interface {
@@ -107,7 +107,7 @@ func (p *Deployer) getDeployRequestCommitDirection(ctx workflow.Context, deployR
 		return activities.DirectionAhead, nil
 	}
 	var compareCommitResp activities.CompareCommitResponse
-	err := workflow.ExecuteActivity(ctx, p.Activities.CompareCommit, activities.CompareCommitRequest{
+	err := workflow.ExecuteActivity(ctx, p.Activities.GithubCompareCommit, activities.CompareCommitRequest{
 		DeployRequestRevision:  deployRequest.Revision,
 		LatestDeployedRevision: latestDeployment.Revision,
 		Repo:                   deployRequest.Repo,
@@ -123,7 +123,7 @@ func (p *Deployer) updateCheckRun(ctx workflow.Context, deployRequest terraformW
 	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
 		MaximumAttempts: UpdateCheckRunRetryCount,
 	})
-	err := workflow.ExecuteActivity(ctx, p.Activities.UpdateCheckRun, activities.UpdateCheckRunRequest{
+	err := workflow.ExecuteActivity(ctx, p.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
 		Title:   terraformWorkflow.BuildCheckRunTitle(deployRequest.Root.Name),
 		State:   state,
 		Repo:    deployRequest.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -52,11 +52,11 @@ func (t *testDeployActivity) StoreLatestDeployment(ctx context.Context, deployer
 	return nil
 }
 
-func (t *testDeployActivity) CompareCommit(ctx context.Context, deployerRequest activities.CompareCommitRequest) (activities.CompareCommitResponse, error) {
+func (t *testDeployActivity) GithubCompareCommit(ctx context.Context, deployerRequest activities.CompareCommitRequest) (activities.CompareCommitResponse, error) {
 	return activities.CompareCommitResponse{}, nil
 }
 
-func (t *testDeployActivity) UpdateCheckRun(ctx context.Context, deployerRequest activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
+func (t *testDeployActivity) GithubUpdateCheckRun(ctx context.Context, deployerRequest activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
 	return activities.UpdateCheckRunResponse{}, nil
 }
 
@@ -218,7 +218,7 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 		CommitComparison: activities.DirectionAhead,
 	}
 
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
 
 	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
@@ -290,7 +290,7 @@ func TestDeployer_CompareCommit_Identical(t *testing.T) {
 		CommitComparison: activities.DirectionIdentical,
 	}
 
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
 		Info:         deploymentInfo,
 		LatestDeploy: latestDeployedRevision,
@@ -372,8 +372,8 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			ID: updateCheckRunRequest.ID,
 		}
 
-		env.OnActivity(da.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
-		env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+		env.OnActivity(da.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+		env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 
 		env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
 			Info:         deploymentInfo,
@@ -416,8 +416,8 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 				ID: updateCheckRunRequest.ID,
 			}
 
-			env.OnActivity(da.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
-			env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+			env.OnActivity(da.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 
 			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
 				Info:         deploymentInfo,
@@ -494,7 +494,7 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 		CommitComparison: activities.DirectionDiverged,
 	}
 
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
 
 	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
@@ -569,7 +569,7 @@ func TestDeployer_WorkflowFailure_PlanRejection_SkipUpdateLatestDeployment(t *te
 		CommitComparison: activities.DirectionAhead,
 	}
 
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 
 	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
 		Info:         deploymentInfo,
@@ -655,7 +655,7 @@ func TestDeployer_TerraformClientError_UpdateLatestDeployment(t *testing.T) {
 		},
 	}
 
-	env.OnActivity(da.CompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
 
 	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -28,7 +28,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	}
 
 	for _, i := range infos {
-		err := workflow.ExecuteActivity(ctx, u.Activities.UpdateCheckRun, activities.UpdateCheckRunRequest{
+		err := workflow.ExecuteActivity(ctx, u.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
 			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
 			State:   github.CheckRunQueued,
 			Repo:    i.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -48,7 +48,7 @@ func TestLockStateUpdater_unlocked(t *testing.T) {
 		ID: updateCheckRunRequest.ID,
 	}
 
-	env.OnActivity(a.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
 
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},
@@ -95,7 +95,7 @@ func TestLockStateUpdater_locked(t *testing.T) {
 		ID: updateCheckRunRequest.ID,
 	}
 
-	env.OnActivity(a.UpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
 
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -41,7 +41,7 @@ type DeploymentStore interface {
 }
 
 type Activities interface {
-	CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
+	GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
 }
 
 func NewReceiver(ctx workflow.Context, queue Queue, activities Activities, generator idGenerator, worker DeploymentStore) *Receiver {
@@ -125,7 +125,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	}
 
 	var resp activities.CreateCheckRunResponse
-	err := workflow.ExecuteActivity(ctx, n.activities.CreateCheckRun, activities.CreateCheckRunRequest{
+	err := workflow.ExecuteActivity(ctx, n.activities.GithubCreateCheckRun, activities.CreateCheckRunRequest{
 		Title:      terraform.BuildCheckRunTitle(root.Name),
 		Sha:        revision,
 		Repo:       repo,

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -63,7 +63,7 @@ type response struct {
 
 type testActivities struct{}
 
-func (a *testActivities) CreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+func (a *testActivities) GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
 	return activities.CreateCheckRunResponse{}, nil
 }
 
@@ -129,7 +129,7 @@ func TestEnqueue(t *testing.T) {
 
 	id := uuid.Must(uuid.NewUUID())
 
-	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
 		Title:      "atlantis/deploy: root",
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
@@ -185,7 +185,7 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 
 	id := uuid.Must(uuid.NewUUID())
 
-	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
 		Title:      "atlantis/deploy: root",
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
@@ -242,7 +242,7 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 
 	id := uuid.Must(uuid.NewUUID())
 
-	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
 		Title:      "atlantis/deploy: root",
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
@@ -304,7 +304,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 
 	id := uuid.Must(uuid.NewUUID())
 
-	env.OnActivity(a.CreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
 		Title:      "atlantis/deploy: root",
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -23,7 +23,7 @@ type auditActivities interface {
 
 type receiverActivities interface {
 	auditActivities
-	UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
+	GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
 }
 
 type StateReceiver struct {
@@ -79,7 +79,7 @@ func (n *StateReceiver) updateCheckRun(ctx workflow.Context, workflowState *stat
 	}
 
 	// TODO: should we block here? maybe we can just make this async
-	return workflow.ExecuteActivity(ctx, n.Activity.UpdateCheckRun, request).Get(ctx, nil)
+	return workflow.ExecuteActivity(ctx, n.Activity.GithubUpdateCheckRun, request).Get(ctx, nil)
 }
 
 func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Job, deploymentInfo DeploymentInfo) error {

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -23,7 +23,7 @@ import (
 type testActivities struct {
 }
 
-func (a *testActivities) UpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
+func (a *testActivities) GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
 	return activities.UpdateCheckRunResponse{}, nil
 }
 
@@ -291,7 +291,7 @@ func TestStateReceive(t *testing.T) {
 			var a = &testActivities{}
 			env.RegisterActivity(a)
 
-			env.OnActivity(a.UpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
+			env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
 				Title: "atlantis/deploy: root",
 				State: c.ExpectedCheckRunState,
 				Repo: github.Repo{

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -16,7 +16,7 @@ type RootFetcher struct {
 // Fetch returns a local root and a cleanup function
 func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func(workflow.Context) error, error) {
 	var fetchRootResponse activities.FetchRootResponse
-	err := workflow.ExecuteActivity(ctx, r.Ga.FetchRoot, activities.FetchRootRequest{
+	err := workflow.ExecuteActivity(ctx, r.Ga.GithubFetchRoot, activities.FetchRootRequest{
 		Repo:         r.Request.Repo,
 		Root:         r.Request.Root,
 		DeploymentID: r.Request.DeploymentID,

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -23,7 +23,7 @@ import (
 )
 
 type githubActivities interface {
-	FetchRoot(ctx context.Context, request activities.FetchRootRequest) (activities.FetchRootResponse, error)
+	GithubFetchRoot(ctx context.Context, request activities.FetchRootRequest) (activities.FetchRootResponse, error)
 }
 
 type terraformActivities interface {

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -74,7 +74,7 @@ func (g *testURLGenerator) Generate(jobID fmt.Stringer, BaseURL fmt.Stringer) (*
 
 type githubActivities struct{}
 
-func (a *githubActivities) FetchRoot(_ context.Context, _ activities.FetchRootRequest) (activities.FetchRootResponse, error) {
+func (a *githubActivities) GithubFetchRoot(_ context.Context, _ activities.FetchRootRequest) (activities.FetchRootResponse, error) {
 	return activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -251,7 +251,7 @@ func TestSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	// set activity expectations
-	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+	env.OnActivity(ga.GithubFetchRoot, mock.Anything, activities.FetchRootRequest{
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
@@ -446,7 +446,7 @@ func TestUpdateJobError(t *testing.T) {
 	assert.NoError(t, err)
 
 	// set activity expectations
-	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+	env.OnActivity(ga.GithubFetchRoot, mock.Anything, activities.FetchRootRequest{
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
@@ -492,7 +492,7 @@ func TestPlanRejection(t *testing.T) {
 	assert.NoError(t, err)
 
 	// set activity expectations
-	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+	env.OnActivity(ga.GithubFetchRoot, mock.Anything, activities.FetchRootRequest{
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
@@ -655,7 +655,7 @@ func TestFetchRootError(t *testing.T) {
 	env.RegisterActivity(ta)
 
 	// set activity expectations
-	env.OnActivity(ga.FetchRoot, mock.Anything, activities.FetchRootRequest{
+	env.OnActivity(ga.GithubFetchRoot, mock.Anything, activities.FetchRootRequest{
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,


### PR DESCRIPTION
Makes it easy to capture all github activity metrics in one graph

ie
```
temporal_activity_execution_failed:count:sum{activity_type=~"Github.*" }
```