### PR TITLE
Add workflow metrics abstraction and some more stats.

### DIFF
--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -114,6 +114,7 @@ func NewWorker(
 		Queue:            q,
 		Deployer:         deployer,
 		latestDeployment: latestDeployment,
+		Scope:            scope,
 	}, nil
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -42,9 +42,7 @@ const (
 	CompleteWorkerState WorkerState = "complete"
 
 	UnlockSignalName = "unlock"
-
-	ManualDeployWorkflowStat = "workflow.deploy.trigger.manual"
-	MergeDeployWorkflowStat  = "workflow.deploy.trigger.merge"
+	SignalNameTag    = "signal_name"
 )
 
 type UnlockSignalRequest struct {
@@ -169,7 +167,7 @@ func (w *Worker) Work(ctx workflow.Context) {
 			logger.Info(ctx, "Processing... ")
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
-			w.Scope.SubScopeWithTags(map[string]string{"signal_name": UnlockSignalName}).
+			w.Scope.SubScopeWithTags(map[string]string{SignalNameTag: UnlockSignalName}).
 				Counter(ctx, "signal_receive").
 				Inc(1)
 			w.Queue.SetLockForMergedItems(ctx, LockState{

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
-	"go.temporal.io/sdk/client"
 
 	"github.com/pkg/errors"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
@@ -14,6 +13,7 @@ import (
 	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -64,9 +64,9 @@ const (
 )
 
 type Worker struct {
-	Queue          queue
-	Deployer       deployer
-	MetricsHandler client.MetricsHandler
+	Queue    queue
+	Deployer deployer
+	Scope    metrics.Scope
 
 	// mutable
 	state             WorkerState
@@ -85,7 +85,7 @@ const (
 func NewWorker(
 	ctx workflow.Context,
 	q queue,
-	metricsHandler client.MetricsHandler,
+	scope metrics.Scope,
 	a workerActivities,
 	tfWorkflow terraform.Workflow,
 	repoName, rootName string,
@@ -114,7 +114,6 @@ func NewWorker(
 		Queue:            q,
 		Deployer:         deployer,
 		latestDeployment: latestDeployment,
-		MetricsHandler:   metricsHandler,
 	}, nil
 }
 
@@ -167,9 +166,11 @@ func (w *Worker) Work(ctx workflow.Context) {
 			return
 		case process:
 			logger.Info(ctx, "Processing... ")
-			currentDeployment, err = w.deploy(ctx, w.latestDeployment)
 		case receive:
 			logger.Info(ctx, "Received unlock signal... ")
+			w.Scope.SubScopeWithTags(map[string]string{"signal_name": UnlockSignalName}).
+				Counter(ctx, "signal_receive").
+				Inc(1)
 			w.Queue.SetLockForMergedItems(ctx, LockState{
 				Status: UnlockedStatus,
 			})
@@ -179,17 +180,33 @@ func (w *Worker) Work(ctx workflow.Context) {
 			return
 		}
 
+		w.state = WorkingWorkerState
+		msg, err := w.Queue.Pop()
+		if err != nil {
+			logger.Error(ctx, "failed to pop next revision off of queue, this is most definitely a bug.", key.ErrKey, err)
+			continue
+		}
+
+		scope := addRevisionSubscope(w.Scope, msg)
+
+		//TODO: pass this scope further down the code
+		currentDeployment, err = w.deploy(ctx, msg, w.latestDeployment)
+
 		// since there was no error we can safely count this as our latest deploy
 		if err == nil {
+			scope.Counter(ctx, "success").Inc(1)
 			w.latestDeployment = currentDeployment
 			selector.AddFuture(w.awaitWork(ctx), callback)
 			continue
 		}
 
+		var readableErr string
 		switch e := err.(type) {
 		case *ValidationError:
+			readableErr = "validation"
 			logger.Error(ctx, "deploy validation failed, moving to next one", key.ErrKey, e)
 		case *terraform.PlanRejectionError:
+			readableErr = "plan_rejected"
 			logger.Warn(ctx, "Plan rejected")
 		default:
 
@@ -198,8 +215,12 @@ func (w *Worker) Work(ctx workflow.Context) {
 			// it, we'd essentially go back in history which is not safe for terraform state files. So, as a safety measure, we'll update the failed
 			// deployment as latest deployment and allow redeploy as long as the failed deploy is the latest deployment.
 			w.latestDeployment = currentDeployment
+
+			readableErr = "unknown"
 			logger.Error(ctx, "failed to deploy revision, moving to next one", key.ErrKey, err)
 		}
+
+		scope.SubScopeWithTags(map[string]string{"error_type": readableErr}).Counter(ctx, "failure")
 
 		selector.AddFuture(w.awaitWork(ctx), callback)
 	}
@@ -231,31 +252,40 @@ func (w *Worker) awaitWork(ctx workflow.Context) workflow.Future {
 	return future
 }
 
-func (w *Worker) deploy(ctx workflow.Context, latestDeployment *deployment.Info) (*deployment.Info, error) {
-	w.state = WorkingWorkerState
-	msg, err := w.Queue.Pop()
-	if err != nil {
-		return nil, errors.Wrap(err, "popping off queue")
-	}
+func (w *Worker) deploy(ctx workflow.Context, requestedDeployment terraform.DeploymentInfo, latestDeployment *deployment.Info) (*deployment.Info, error) {
 	w.setCurrentDeploymentState(CurrentDeployment{
-		Deployment: msg,
+		Deployment: requestedDeployment,
 		Status:     InProgressStatus,
 	})
 	defer w.setCurrentDeploymentState(CurrentDeployment{
-		Deployment: msg,
+		Deployment: requestedDeployment,
 		Status:     CompleteStatus,
 	})
 
-	ctx = workflow.WithValue(ctx, internalContext.SHAKey, msg.Revision)
-	ctx = workflow.WithValue(ctx, internalContext.DeploymentIDKey, msg.ID)
+	ctx = workflow.WithValue(ctx, internalContext.SHAKey, requestedDeployment.Revision)
+	ctx = workflow.WithValue(ctx, internalContext.DeploymentIDKey, requestedDeployment.ID)
 
+	result, err := w.Deployer.Deploy(ctx, requestedDeployment, latestDeployment)
+
+	return result, err
+}
+
+func addRevisionSubscope(s metrics.Scope, msg terraform.DeploymentInfo) metrics.Scope {
+	scope := s.SubScope("revision")
+	tags := make(map[string]string)
 	if msg.Root.Trigger == tfModel.ManualTrigger {
-		w.MetricsHandler.Counter(ManualDeployWorkflowStat).Inc(1)
+		tags["workflow_trigger"] = "manual"
 	} else {
-		w.MetricsHandler.Counter(MergeDeployWorkflowStat).Inc(1)
+		tags["workflow_trigger"] = "merge"
 	}
 
-	return w.Deployer.Deploy(ctx, msg, latestDeployment)
+	if msg.Root.Rerun {
+		tags["deploy_type"] = "retry"
+	} else {
+		tags["deploy_type"] = "new"
+	}
+
+	return scope.SubScopeWithTags(tags)
 }
 
 func (w *Worker) GetState() WorkerState {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_state_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_state_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/stretchr/testify/assert"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 )
 
 type testBlockingDeployer struct{}
@@ -60,9 +60,9 @@ func testStateWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, e
 	})
 
 	worker := queue.Worker{
-		Queue:          q,
-		Deployer:       &testBlockingDeployer{},
-		MetricsHandler: client.MetricsNopHandler,
+		Queue:    q,
+		Deployer: &testBlockingDeployer{},
+		Scope:    metrics.NewNullableScope(),
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -131,9 +132,9 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 	}
 
 	worker := queue.Worker{
-		Queue:          q,
-		Deployer:       deployer,
-		MetricsHandler: client.MetricsNopHandler,
+		Queue:    q,
+		Deployer: deployer,
+		Scope:    metrics.NewNullableScope(),
 	}
 
 	err := workflow.SetQueryHandler(ctx, "queue", func() (queueAndState, error) {
@@ -393,7 +394,7 @@ func TestNewWorker(t *testing.T) {
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
 		q := queue.NewQueue(noopCallback, client.MetricsNopHandler)
-		_, err := queue.NewWorker(ctx, q, client.MetricsNopHandler, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
+		_, err := queue.NewWorker(ctx, q, metrics.NewNullableScope(), &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
 		return res{
 			Lock: q.GetLockState(),
 		}, err

--- a/server/neptune/workflows/internal/metrics/handler.go
+++ b/server/neptune/workflows/internal/metrics/handler.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"strings"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+const delim = "."
+
+// Scope is an interface that attempts to wrap temporal's MetricsHandler with additional
+// functionality to build namespaces.
+// Namespaces are of the following form:
+// <s1>.<s2>.<s3> and can have a number of tags associated with it.
+type Scope interface {
+	SubScope(namespace ...string) Scope
+	SubScopeWithTags(tags map[string]string) Scope
+	Counter(ctx workflow.Context, name string) client.MetricsCounter
+	Gauge(ctx workflow.Context, name string) client.MetricsGauge
+}
+
+type WorkflowScope struct {
+	namespace string
+	handler   client.MetricsHandler
+}
+
+func NewScope(handler client.MetricsHandler, namespaces ...string) *WorkflowScope {
+	return &WorkflowScope{
+		namespace: join(namespaces...),
+		handler:   handler,
+	}
+}
+
+// NewNullableScope should only be used for testing purposes since it just drops metrics
+func NewNullableScope() *WorkflowScope {
+	return &WorkflowScope{
+		handler: client.MetricsNopHandler,
+	}
+}
+
+func (s *WorkflowScope) SubScope(namespaces ...string) Scope {
+	return &WorkflowScope{
+		namespace: join(s.namespace, join(namespaces...)),
+		handler:   s.handler,
+	}
+}
+
+func (s *WorkflowScope) SubScopeWithTags(tags map[string]string) Scope {
+	return &WorkflowScope{
+		namespace: s.namespace,
+		handler:   s.handler.WithTags(tags),
+	}
+}
+
+func (s *WorkflowScope) Counter(ctx workflow.Context, name string) client.MetricsCounter {
+	return s.handler.Counter(join(s.namespace, name))
+}
+
+func (s *WorkflowScope) Gauge(ctx workflow.Context, name string) client.MetricsGauge {
+	return s.handler.Gauge(join(s.namespace, name))
+}
+
+func join(s ...string) string {
+	return strings.Join(s, delim)
+}

--- a/server/neptune/workflows/internal/metrics/handler_test.go
+++ b/server/neptune/workflows/internal/metrics/handler_test.go
@@ -1,0 +1,77 @@
+package metrics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/test"
+	"go.temporal.io/sdk/client"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+type testHandler struct {
+	t                 *testing.T
+	called            bool
+	expectedTags      map[string]string
+	expectedNamespace string
+}
+
+func (h testHandler) WithTags(tags map[string]string) client.MetricsHandler {
+	assert.Equal(h.t, h.expectedTags, tags)
+	return testHandler{
+		t:                 h.t,
+		expectedNamespace: h.expectedNamespace,
+		called:            true,
+	}
+}
+func (h testHandler) Counter(namespace string) client.MetricsCounter {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+func (h testHandler) Gauge(namespace string) client.MetricsGauge {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+func (h testHandler) Timer(namespace string) client.MetricsTimer {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+
+func (h testHandler) Inc(int64)            {}
+func (h testHandler) Update(float64)       {}
+func (h testHandler) Record(time.Duration) {}
+
+func TestScope(t *testing.T) {
+	t.Run("subscope", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "some.namespace.nish.hi",
+		}
+		_ = metrics.NewScope(handler, "some", "namespace").
+			SubScope("nish").
+			Counter(test.Background(), "hi")
+	})
+	t.Run("gauge", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "nish.hi",
+		}
+		_ = metrics.NewScope(handler, "nish").
+			Gauge(test.Background(), "hi")
+	})
+
+	t.Run("tags", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "nish.hi",
+			expectedTags:      map[string]string{"hello": "world"},
+		}
+		_ = metrics.NewScope(handler, "nish").
+			SubScopeWithTags(map[string]string{"hello": "world"}).
+			Gauge(test.Background(), "hi")
+	})
+}


### PR DESCRIPTION
I created the notion of a `Scope` here since temporal's metrics handler requires you to type out the full path of the metric name which is error prone for us since we prepend the workflow name to their respective stats.  Additionally i added modified how we track "trigger" metrics and made them tags.  I also added a couple more stats in the queue worker.

Follow ups will replace usage of the raw metrics handler in all our workflows assuming others are fine with using this.