### PR TITLE
Dismiss approvals

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -4,18 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"sync"
-	"testing"
-	"time"
-
 	"github.com/google/go-github/v45/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
@@ -27,12 +15,22 @@ import (
 	"github.com/runatlantis/atlantis/server/core/db"
 	"github.com/runatlantis/atlantis/server/core/locking"
 	"github.com/runatlantis/atlantis/server/core/runtime"
+	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/jobs"
 	lyftCommand "github.com/runatlantis/atlantis/server/lyft/command"
 	event_types "github.com/runatlantis/atlantis/server/neptune/gateway/event"
 	github_converter "github.com/runatlantis/atlantis/server/vcs/provider/github/converter"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github/request"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/runtime/policy"
 	"github.com/runatlantis/atlantis/server/core/terraform"
@@ -1427,14 +1425,14 @@ func (t *testStaleCommandChecker) CommandIsStale(ctx *command.Context) bool {
 }
 
 type mockCommitFetcher struct {
-	time     time.Time
+	commit   *github.Commit
 	error    error
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchLatestCommitTime(_ context.Context, _ int64, _ models.Repo, _ int) (time.Time, error) {
+func (c *mockCommitFetcher) FetchLatestPRCommit(_ context.Context, _ int64, _ models.Repo, _ int) (*github.Commit, error) {
 	c.isCalled = true
-	return c.time, c.error
+	return c.commit, c.error
 }
 
 type mockReviewDismisser struct {

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -45,7 +45,7 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.Polic
 	reviewDismisser := &github.PRReviewDismisser{
 		ClientCreator: creator,
 	}
-	commitFetcher := &github.PRCommitFetcher{
+	commitFetcher := &github.CommitFetcher{
 		ClientCreator: creator,
 	}
 	teamMemberFetcher := &github.TeamMemberFetcher{

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -42,13 +42,19 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 	reviewsFetcher := &github.PRReviewerFetcher{
 		ClientCreator: creator,
 	}
+	reviewDismisser := &github.PRReviewDismisser{
+		ClientCreator: creator,
+	}
+	commitFetcher := &github.PRCommitFetcher{
+		ClientCreator: creator,
+	}
 	teamMemberFetcher := &github.TeamMemberFetcher{
 		ClientCreator: creator,
 		Org:           org,
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, teamMemberFetcher),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, reviewDismisser, commitFetcher, teamMemberFetcher),
 	}
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -38,8 +38,8 @@ type ConfTestExecutor struct {
 	PolicyFilter policyFilter
 }
 
-func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestExecutor {
-	reviewsFetcher := &github.PRReviewerFetcher{
+func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets) *ConfTestExecutor {
+	reviewFetcher := &github.PRReviewFetcher{
 		ClientCreator: creator,
 	}
 	reviewDismisser := &github.PRReviewDismisser{
@@ -50,11 +50,11 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 	}
 	teamMemberFetcher := &github.TeamMemberFetcher{
 		ClientCreator: creator,
-		Org:           org,
+		Org:           policySets.Organization,
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, reviewDismisser, commitFetcher, teamMemberFetcher),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamMemberFetcher, policySets.PolicySets),
 	}
 }
 

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -100,32 +100,6 @@ func TestFilter_Approved_NoDismissal(t *testing.T) {
 	assert.Empty(t, filteredPolicies)
 }
 
-func TestFilter_ApprovedCacheMiss(t *testing.T) {
-	team := []string{ownerA, ownerB, ownerC}
-	reviewFetcher := &mockReviewFetcher{
-		approvers: []string{ownerB},
-	}
-	teamFetcher := &mockTeamMemberFetcher{
-		members: team,
-	}
-	commitFetcher := &mockCommitFetcher{}
-	reviewDismisser := &mockReviewDismisser{}
-	failedPolicies := []valid.PolicySet{
-		{Name: policyName, Owner: policyOwner},
-	}
-
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	policyFilter.owners.Store(policyOwner, team)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, failedPolicies)
-	assert.NoError(t, err)
-	assert.True(t, reviewFetcher.listUsernamesIsCalled)
-	assert.True(t, reviewFetcher.listApprovalsIsCalled)
-	assert.True(t, commitFetcher.isCalled)
-	assert.False(t, reviewDismisser.isCalled)
-	assert.False(t, teamFetcher.isCalled)
-	assert.Empty(t, filteredPolicies)
-}
-
 func TestFilter_NotApproved(t *testing.T) {
 	time1 := time.UnixMicro(1)
 	time2 := time.UnixMicro(2)

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -20,6 +20,14 @@ const (
 	policyOwner = "team"
 )
 
+func createCommit(time time.Time) *github.Commit {
+	return &github.Commit{
+		Committer: &github.CommitAuthor{
+			Date: &time,
+		},
+	}
+}
+
 func TestFilter_Approved(t *testing.T) {
 	time1 := time.UnixMicro(1)
 	time2 := time.UnixMicro(2)
@@ -40,7 +48,7 @@ func TestFilter_Approved(t *testing.T) {
 		members: []string{ownerA, ownerB, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		time: time1,
+		commit: createCommit(time1),
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -71,7 +79,7 @@ func TestFilter_Approved_NoDismissal(t *testing.T) {
 		},
 	}
 	commitFetcher := &mockCommitFetcher{
-		time: time1,
+		commit: createCommit(time1),
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	teamFetcher := &mockTeamMemberFetcher{
@@ -134,7 +142,7 @@ func TestFilter_NotApproved(t *testing.T) {
 		members: []string{ownerA, ownerB, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		time: time2,
+		commit: createCommit(time2),
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -307,7 +315,7 @@ func TestFilter_FailedDismiss(t *testing.T) {
 		},
 	}
 	commitFetcher := &mockCommitFetcher{
-		time: time2,
+		commit: createCommit(time2),
 	}
 	reviewDismisser := &mockReviewDismisser{
 		error: assert.AnError,
@@ -350,14 +358,14 @@ func (f *mockReviewFetcher) ListApprovalReviews(_ context.Context, _ int64, _ mo
 }
 
 type mockCommitFetcher struct {
-	time     time.Time
+	commit   *github.Commit
 	error    error
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchLatestCommitTime(_ context.Context, _ int64, _ models.Repo, _ int) (time.Time, error) {
+func (c *mockCommitFetcher) FetchLatestPRCommit(_ context.Context, _ int64, _ models.Repo, _ int) (*github.Commit, error) {
 	c.isCalled = true
-	return c.time, c.error
+	return c.commit, c.error
 }
 
 type mockReviewDismisser struct {

--- a/server/server.go
+++ b/server/server.go
@@ -588,7 +588,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets.Organization)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,

--- a/server/vcs/provider/github/pr_commit_fetcher.go
+++ b/server/vcs/provider/github/pr_commit_fetcher.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"context"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"time"
+)
+
+type PRCommitFetcher struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (c *PRCommitFetcher) FetchLatestCommitTime(ctx context.Context, installationToken int64, repo models.Repo, prNum int) (time.Time, error) {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "creating installation client")
+	}
+	run := func(ctx context.Context, nextPage int) ([]*gh.RepositoryCommit, *gh.Response, error) {
+		listOptions := gh.ListOptions{
+			PerPage: 100,
+		}
+		listOptions.Page = nextPage
+		return client.PullRequests.ListCommits(ctx, repo.Owner, repo.Name, prNum, &listOptions)
+	}
+	commits, err := Iterate(ctx, run)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "iterating through entries")
+	}
+	latestCommitTimestamp := time.Time{}
+	for _, commit := range commits {
+		if commit.GetCommit() == nil {
+			return time.Time{}, errors.New("getting latest commit")
+		}
+		if commit.GetCommit().GetCommitter() == nil {
+			return time.Time{}, errors.New("getting latest committer")
+		}
+		commitTimestamp := commit.GetCommit().GetCommitter().GetDate()
+		if commitTimestamp.After(latestCommitTimestamp) {
+			latestCommitTimestamp = commitTimestamp
+		}
+	}
+	return latestCommitTimestamp, nil
+}

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 )
 
-const DismissReason = "Atlantis automatically dismisses reviews from policy owners made prior to the latest commit."
+const DismissReason = "**New commits have triggered policy failures that must be approved by policy owners.**"
 
 type PRReviewDismisser struct {
 	ClientCreator githubapp.ClientCreator

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 )
 
-const DismissReason = "Atlantis automatically dismisses stale reviews prior to the latest commits from policy owners."
+const DismissReason = "Atlantis automatically dismisses reviews from policy owners made prior to the latest commit."
 
 type PRReviewDismisser struct {
 	ClientCreator githubapp.ClientCreator

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"net/http"
+)
+
+const DismissReason = "Atlantis automatically dismisses stale reviews prior to the latest commits from policy owners."
+
+type PRReviewDismisser struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (r *PRReviewDismisser) Dismiss(ctx context.Context, installationToken int64, repo models.Repo, prNum int, reviewID int64) error {
+	client, err := r.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return errors.Wrap(err, "creating installation client")
+	}
+	dismissRequest := &gh.PullRequestReviewDismissalRequest{
+		Message: gh.String(DismissReason),
+	}
+
+	_, resp, err := client.PullRequests.DismissReview(ctx, repo.Owner, repo.Name, prNum, reviewID, dismissRequest)
+	if err != nil {
+		return errors.Wrap(err, "error running gh api call")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("not ok status running gh api call: %s", resp.Status)
+	}
+	return nil
+}

--- a/server/vcs/provider/github/reviewer_fetcher.go
+++ b/server/vcs/provider/github/reviewer_fetcher.go
@@ -10,24 +10,26 @@ import (
 
 const ApprovalState = "APPROVED"
 
-type PRReviewerFetcher struct {
+type PRReviewFetcher struct {
 	ClientCreator githubapp.ClientCreator
 }
 
-func (r *PRReviewerFetcher) ListApprovalReviewers(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
-	client, err := r.ClientCreator.NewInstallationClient(installationToken)
+func (r *PRReviewFetcher) ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
+	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating installation client")
+		return nil, errors.Wrap(err, "iterating through entries")
 	}
-
-	run := func(ctx context.Context, nextPage int) ([]*gh.PullRequestReview, *gh.Response, error) {
-		listOptions := gh.ListOptions{
-			PerPage: 100,
+	var approvals []*gh.PullRequestReview
+	for _, review := range reviews {
+		if review.GetState() == ApprovalState {
+			approvals = append(approvals, review)
 		}
-		listOptions.Page = nextPage
-		return client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
 	}
-	reviews, err := Iterate(ctx, run)
+	return approvals, nil
+}
+
+func (r *PRReviewFetcher) ListLatestApprovalUsernames(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
+	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
 		return nil, errors.Wrap(err, "iterating through entries")
 	}
@@ -56,7 +58,7 @@ func findLatestApprovals(reviews []*gh.PullRequestReview) []string {
 	return approvalReviewers
 }
 
-func (r *PRReviewerFetcher) ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
+func (r *PRReviewFetcher) ListReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
 	client, err := r.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating installation client")
@@ -69,19 +71,5 @@ func (r *PRReviewerFetcher) ListApprovalReviews(ctx context.Context, installatio
 		listOptions.Page = nextPage
 		return client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
 	}
-	reviews, err := Iterate(ctx, run)
-	if err != nil {
-		return nil, errors.Wrap(err, "iterating through entries")
-	}
-	return findApprovals(reviews), nil
-}
-
-func findApprovals(reviews []*gh.PullRequestReview) []*gh.PullRequestReview {
-	var approvals []*gh.PullRequestReview
-	for _, review := range reviews {
-		if review.GetState() == ApprovalState {
-			approvals = append(approvals, review)
-		}
-	}
-	return approvals
+	return Iterate(ctx, run)
 }


### PR DESCRIPTION
Dismiss stale approvals when filtering out failed policy checks. We don't want to use approvals from policy owners that aren't for the latest PR commit.

High level pseudocode of policy check step:

- Build and run OPA policies via Conftest to identify if there are any policies that fail
- Filter out any of the failed policies by checking of GH approvals allow for a bypass:
    - Dismiss stale PR reviews (dismiss approvals from policy owners that aren’t after the latest commit)
    - Re-fetch a list of the latest approver usernames from GH
    - For each failed policy, identify if one of the approver usernames is also considered an owner of the policy
- Determine if policy check step succeeds based on if there are still any failing policies after the filter


Note: when is the policy check step run
- after plan generation is successful when a new commit is pushed
- after plan generation is successful when a user comments "atlantis plan"
- when a user submits a GH approval and atlantis finds that the current PR has failing policy checks