### PR TITLE
Ensure reruns are automatic still

### DIFF
--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -86,7 +86,7 @@ func (r *WorkflowRunner) buildRequestRoot(root terraformActivities.Root, diffDir
 		reasons = append(reasons, ":warning: Requested Revision is not ahead of deployed revision, please confirm the changes described in the plan.")
 	}
 
-	if root.Trigger == terraformActivities.ManualTrigger {
+	if root.Trigger == terraformActivities.ManualTrigger && !root.Rerun {
 		reasons = append(reasons, ":warning: Manually Triggered Deploys must be confirmed before proceeding.")
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -78,7 +78,7 @@ func (r *WorkflowRunner) buildRequestRoot(root terraformActivities.Root, diffDir
 	var approvalType terraformActivities.PlanApprovalType
 	var reasons []string
 
-	if diffDirection == activities.DirectionDiverged || root.Trigger == terraformActivities.ManualTrigger {
+	if diffDirection == activities.DirectionDiverged || (root.Trigger == terraformActivities.ManualTrigger && !root.Rerun) {
 		approvalType = terraformActivities.ManualApproval
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/runner_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner_test.go
@@ -210,6 +210,47 @@ func TestWorkflowRunner_RunWithManuallyTriggeredRoot(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWorkflowRunner_RunWithRootWithRerunEnabled(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	env.RegisterWorkflow(testTerraformWorkflow)
+
+	r := request{
+		Info:          buildDeploymentInfo(t),
+		DiffDirection: activities.DirectionAhead,
+	}
+
+	r.Info.Root.Trigger = terraform.ManualTrigger
+	r.Info.Root.Rerun = true
+
+	env.OnWorkflow(testTerraformWorkflow, mock.Anything, terraformWorkflow.Request{
+		Root: terraform.Root{
+			Name:    r.Info.Root.Name,
+			Trigger: terraform.ManualTrigger,
+			Plan: terraform.PlanJob{
+				Approval: terraform.PlanApproval{
+					Type: terraform.AutoApproval,
+				},
+			},
+			Rerun: true,
+		},
+		Repo:         r.Info.Repo,
+		DeploymentID: r.Info.ID.String(),
+		Revision:     r.Info.Revision,
+	}).Return(func(ctx workflow.Context, request terraformWorkflow.Request) error {
+		return nil
+	})
+
+	env.ExecuteWorkflow(parentWorkflow, r)
+
+	env.AssertExpectations(t)
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+}
+
 func TestWorkflowRunner_PlanRejected(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()


### PR DESCRIPTION
Reruns are a special type of manual deploy.  Since the revision would be identical to the latest on the default branch at this point, it's safe to keep these automatic.

If we decide to enable retries across all revisions on the default branch, then we'd have to revisit this.