### PR TITLE
Dismiss approvals v2

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -836,9 +836,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 	// binary
 	conftextExec.VersionCache = conftestCache
 
-	reviewFetcher := &mockReviewFetcher{
-		approvers: []string{},
-	}
+	reviewFetcher := &mockReviewFetcher{}
 	teamFetcher := &mockTeamFetcher{
 		members: []string{},
 	}
@@ -1448,22 +1446,14 @@ func (d *mockReviewDismisser) Dismiss(_ context.Context, _ int64, _ models.Repo,
 }
 
 type mockReviewFetcher struct {
-	approvers             []string
-	listUsernamesIsCalled bool
-	listUsernamesError    error
-	reviews               []*github.PullRequestReview
-	listApprovalsIsCalled bool
-	listApprovalsError    error
+	reviews  []*github.PullRequestReview
+	isCalled bool
+	error    error
 }
 
-func (f *mockReviewFetcher) ListLatestApprovalUsernames(_ context.Context, _ int64, _ models.Repo, _ int) ([]string, error) {
-	f.listUsernamesIsCalled = true
-	return f.approvers, f.listUsernamesError
-}
-
-func (f *mockReviewFetcher) ListApprovalReviews(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.PullRequestReview, error) {
-	f.listApprovalsIsCalled = true
-	return f.reviews, f.listApprovalsError
+func (f *mockReviewFetcher) ListReviews(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.PullRequestReview, error) {
+	f.isCalled = true
+	return f.reviews, f.error
 }
 
 type mockTeamFetcher struct {

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -42,13 +42,19 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 	reviewsFetcher := &github.PRReviewerFetcher{
 		ClientCreator: creator,
 	}
+	reviewDismisser := &github.PRReviewDismisser{
+		ClientCreator: creator,
+	}
+	commitFetcher := &github.PRCommitFetcher{
+		ClientCreator: creator,
+	}
 	teamMemberFetcher := &github.TeamMemberFetcher{
 		ClientCreator: creator,
 		Org:           org,
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, teamMemberFetcher),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, reviewDismisser, commitFetcher, teamMemberFetcher),
 	}
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -38,8 +38,8 @@ type ConfTestExecutor struct {
 	PolicyFilter policyFilter
 }
 
-func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestExecutor {
-	reviewsFetcher := &github.PRReviewerFetcher{
+func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets) *ConfTestExecutor {
+	reviewFetcher := &github.PRReviewFetcher{
 		ClientCreator: creator,
 	}
 	reviewDismisser := &github.PRReviewDismisser{
@@ -50,11 +50,11 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, org string) *ConfTestE
 	}
 	teamMemberFetcher := &github.TeamMemberFetcher{
 		ClientCreator: creator,
-		Org:           org,
+		Org:           policySets.Organization,
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewsFetcher, reviewDismisser, commitFetcher, teamMemberFetcher),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamMemberFetcher, policySets.PolicySets),
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -588,7 +588,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	legacyConftestExecutor := policy.NewConfTestExecutorWorkflow(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets.Organization)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		legacyConftestExecutor,

--- a/server/vcs/provider/github/pr_commit_fetcher.go
+++ b/server/vcs/provider/github/pr_commit_fetcher.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"context"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"time"
+)
+
+type PRCommitFetcher struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (c *PRCommitFetcher) FetchLatestCommitTime(ctx context.Context, installationToken int64, repo models.Repo, prNum int) (time.Time, error) {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "creating installation client")
+	}
+	run := func(ctx context.Context, nextPage int) ([]*gh.RepositoryCommit, *gh.Response, error) {
+		listOptions := gh.ListOptions{
+			PerPage: 100,
+		}
+		listOptions.Page = nextPage
+		return client.PullRequests.ListCommits(ctx, repo.Owner, repo.Name, prNum, &listOptions)
+	}
+	commits, err := Iterate(ctx, run)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "iterating through entries")
+	}
+	latestCommitTimestamp := time.Time{}
+	for _, commit := range commits {
+		if commit.GetCommit() == nil {
+			return time.Time{}, errors.New("getting latest commit")
+		}
+		if commit.GetCommit().GetCommitter() == nil {
+			return time.Time{}, errors.New("getting latest committer")
+		}
+		commitTimestamp := commit.GetCommit().GetCommitter().GetDate()
+		if commitTimestamp.After(latestCommitTimestamp) {
+			latestCommitTimestamp = commitTimestamp
+		}
+	}
+	return latestCommitTimestamp, nil
+}

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 )
 
-const DismissReason = "Atlantis automatically dismisses stale reviews prior to the latest commits from policy owners."
+const DismissReason = "Atlantis automatically dismisses reviews from policy owners made prior to the latest commit."
 
 type PRReviewDismisser struct {
 	ClientCreator githubapp.ClientCreator

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	gh "github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"net/http"
+)
+
+const DismissReason = "Atlantis automatically dismisses stale reviews prior to the latest commits from policy owners."
+
+type PRReviewDismisser struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (r *PRReviewDismisser) Dismiss(ctx context.Context, installationToken int64, repo models.Repo, prNum int, reviewID int64) error {
+	client, err := r.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return errors.Wrap(err, "creating installation client")
+	}
+	dismissRequest := &gh.PullRequestReviewDismissalRequest{
+		Message: gh.String(DismissReason),
+	}
+
+	_, resp, err := client.PullRequests.DismissReview(ctx, repo.Owner, repo.Name, prNum, reviewID, dismissRequest)
+	if err != nil {
+		return errors.Wrap(err, "error running gh api call")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("not ok status running gh api call: %s", resp.Status)
+	}
+	return nil
+}

--- a/server/vcs/provider/github/reviewer_fetcher.go
+++ b/server/vcs/provider/github/reviewer_fetcher.go
@@ -14,50 +14,6 @@ type PRReviewFetcher struct {
 	ClientCreator githubapp.ClientCreator
 }
 
-func (r *PRReviewFetcher) ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
-	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
-	if err != nil {
-		return nil, errors.Wrap(err, "iterating through entries")
-	}
-	var approvals []*gh.PullRequestReview
-	for _, review := range reviews {
-		if review.GetState() == ApprovalState {
-			approvals = append(approvals, review)
-		}
-	}
-	return approvals, nil
-}
-
-func (r *PRReviewFetcher) ListLatestApprovalUsernames(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
-	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
-	if err != nil {
-		return nil, errors.Wrap(err, "iterating through entries")
-	}
-	return findLatestApprovals(reviews), nil
-}
-
-// only return an approval from a user if it is their most recent review
-// this is because a user can approve a PR then request more changes later on
-func findLatestApprovals(reviews []*gh.PullRequestReview) []string {
-	var approvalReviewers []string
-	reviewers := make(map[string]bool)
-
-	//reviews are returned chronologically
-	for i := len(reviews) - 1; i >= 0; i-- {
-		review := reviews[i]
-		reviewer := review.GetUser()
-		if reviewer == nil {
-			continue
-		}
-		// add reviewer if an approval + we have not already processed their most recent review
-		if review.GetState() == ApprovalState && !reviewers[reviewer.GetLogin()] {
-			approvalReviewers = append(approvalReviewers, reviewer.GetLogin())
-		}
-		reviewers[reviewer.GetLogin()] = true
-	}
-	return approvalReviewers
-}
-
 func (r *PRReviewFetcher) ListReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
 	client, err := r.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {

--- a/server/vcs/provider/github/reviewer_fetcher.go
+++ b/server/vcs/provider/github/reviewer_fetcher.go
@@ -10,24 +10,26 @@ import (
 
 const ApprovalState = "APPROVED"
 
-type PRReviewerFetcher struct {
+type PRReviewFetcher struct {
 	ClientCreator githubapp.ClientCreator
 }
 
-func (r *PRReviewerFetcher) ListApprovalReviewers(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
-	client, err := r.ClientCreator.NewInstallationClient(installationToken)
+func (r *PRReviewFetcher) ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
+	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating installation client")
+		return nil, errors.Wrap(err, "iterating through entries")
 	}
-
-	run := func(ctx context.Context, nextPage int) ([]*gh.PullRequestReview, *gh.Response, error) {
-		listOptions := gh.ListOptions{
-			PerPage: 100,
+	var approvals []*gh.PullRequestReview
+	for _, review := range reviews {
+		if review.GetState() == ApprovalState {
+			approvals = append(approvals, review)
 		}
-		listOptions.Page = nextPage
-		return client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
 	}
-	reviews, err := Iterate(ctx, run)
+	return approvals, nil
+}
+
+func (r *PRReviewFetcher) ListLatestApprovalUsernames(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error) {
+	reviews, err := r.ListReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
 		return nil, errors.Wrap(err, "iterating through entries")
 	}
@@ -56,7 +58,7 @@ func findLatestApprovals(reviews []*gh.PullRequestReview) []string {
 	return approvalReviewers
 }
 
-func (r *PRReviewerFetcher) ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
+func (r *PRReviewFetcher) ListReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error) {
 	client, err := r.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating installation client")
@@ -69,19 +71,5 @@ func (r *PRReviewerFetcher) ListApprovalReviews(ctx context.Context, installatio
 		listOptions.Page = nextPage
 		return client.PullRequests.ListReviews(ctx, repo.Owner, repo.Name, prNum, &listOptions)
 	}
-	reviews, err := Iterate(ctx, run)
-	if err != nil {
-		return nil, errors.Wrap(err, "iterating through entries")
-	}
-	return findApprovals(reviews), nil
-}
-
-func findApprovals(reviews []*gh.PullRequestReview) []*gh.PullRequestReview {
-	var approvals []*gh.PullRequestReview
-	for _, review := range reviews {
-		if review.GetState() == ApprovalState {
-			approvals = append(approvals, review)
-		}
-	}
-	return approvals
+	return Iterate(ctx, run)
 }


### PR DESCRIPTION
Alternative implementation of dismissing stale approvals with one GH call for fetching PR reviews. Instead of re-fetching after performing dismissals, this maintains application's in-memory logic as source of truth. 