### PR TITLE
Add workflow execution custom metrics and some.

### DIFF
--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -28,4 +28,13 @@ const (
 
 	// Signal receive is when we receive it off the channel
 	SignalReceive = "signal_receive"
+
+	// Metrics are scoped to workflow namespaces anyways so let's
+	// keep these metrics simple.
+	WorkflowSuccess = "success"
+	WorkflowFailure = "failure"
+	WorkflowLatency = "latency"
+
+	ManualOverride          = "manual_override"
+	ManualOverrideReasonTag = "reason"
 )

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -26,7 +26,7 @@ func NewValidationError(msg string, format ...interface{}) *ValidationError {
 }
 
 type terraformWorkflowRunner interface {
-	Run(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo, diffDirection activities.DiffDirection) error
+	Run(ctx workflow.Context, deploymentInfo terraformWorkflow.DeploymentInfo, diffDirection activities.DiffDirection, scope metrics.Scope) error
 }
 
 type dbActivities interface {
@@ -74,7 +74,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWor
 	}
 
 	// don't wrap this err as it's not necessary and will mess with any err type assertions we might need to do
-	err = p.TerraformWorkflowRunner.Run(ctx, requestedDeployment, commitDirection)
+	err = p.TerraformWorkflowRunner.Run(ctx, requestedDeployment, commitDirection, scope)
 
 	// No need to persist deployment if it's a PlanRejectionError
 	if _, ok := err.(*terraformWorkflow.PlanRejectionError); ok {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -34,7 +34,7 @@ type testTerraformWorkflowRunner struct {
 	expectedErrorType  ErrorType
 }
 
-func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, diffDirection activities.DiffDirection) error {
+func (r testTerraformWorkflowRunner) Run(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, diffDirection activities.DiffDirection, scope metrics.Scope) error {
 	if r.expectedErrorType == PlanRejectionError {
 		return terraform.NewPlanRejectionError("plan rejected")
 	} else if r.expectedErrorType == TerraformClientError {

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -47,6 +47,11 @@ func (q *Deploy) GetLockState() LockState {
 }
 
 func (q *Deploy) SetLockForMergedItems(ctx workflow.Context, state LockState) {
+	if state.Status == LockedStatus {
+		q.scope.Counter("locked").Inc(1)
+	} else {
+		q.scope.Counter("unlocked").Inc(1)
+	}
 	q.lock = state
 	q.lockStatusCallback(ctx, q)
 }

--- a/server/neptune/workflows/internal/deploy/terraform/runner_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +82,7 @@ func parentWorkflow(ctx workflow.Context, r request) (response, error) {
 		runner.Workflow = testTerraformWorkflow
 	}
 
-	if err := runner.Run(ctx, r.Info, r.DiffDirection); err != nil {
+	if err := runner.Run(ctx, r.Info, r.DiffDirection, metrics.NewNullableScope()); err != nil {
 		if _, ok := err.(internalTerraform.PlanRejectionError); ok {
 			return response{
 				PlanRejection: true,

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -111,7 +111,6 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 
 func (r *Runner) shutdown() {
 	r.Scope.Gauge(ActiveDeployWorkflowStat).Update(0)
-	r.Scope.Counter(SuccessDeployWorkflowStat).Inc(1)
 }
 
 func (r *Runner) Run(ctx workflow.Context) error {


### PR DESCRIPTION
I also added some stats around when we override to manual deploys due to diverging revisions AND around our queue locks.  This will let us alarm.

Also fixed a bug where our latencies were calculated wrong since they need to be wrapped in a function before passing it to defer.

Finally, i removed the active workflow stat because it's not really proving useful.