### PR TITLE
[neptune] modify env step to lazy load within subsequent activities

### DIFF
--- a/server/neptune/workflows/activities/execute.go
+++ b/server/neptune/workflows/activities/execute.go
@@ -32,7 +32,7 @@ func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request E
 
 	requestEnvVars, err := getEnvs(request.EnvVars, request.DynamicEnvVars)
 	if err != nil {
-		return ExecuteCommandResponse{}, errors.Wrap(err, "getting env vars")
+		return ExecuteCommandResponse{}, err
 	}
 	for key, val := range requestEnvVars {
 		finalEnvVars = append(finalEnvVars, fmt.Sprintf("%s=%s", key, val))
@@ -49,6 +49,7 @@ func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request E
 	}, nil
 }
 
+// StringCommand is a command that outputs a string
 type StringCommand struct {
 	Command        string
 	Dir            string

--- a/server/neptune/workflows/activities/execute.go
+++ b/server/neptune/workflows/activities/execute.go
@@ -71,7 +71,7 @@ func (l *StringCommand) Load() (string, error) {
 		return "", errors.Wrap(err, "executing cmd")
 	}
 
-	// Trim newline from res to support running `echo env_value` which has
+	// Trim newline from `out` to support running `echo env_value` which has
 	// a newline. We don't recommend users run echo -n env_value to remove the
 	// newline because -n doesn't work in the sh shell which is what we use
 	// to run commands.

--- a/server/neptune/workflows/activities/execute.go
+++ b/server/neptune/workflows/activities/execute.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
@@ -17,9 +18,10 @@ type ExecuteCommandResponse struct {
 }
 
 type ExecuteCommandRequest struct {
-	Step    execute.Step
-	Path    string
-	EnvVars map[string]string
+	Step           execute.Step
+	Path           string
+	EnvVars        map[string]string
+	DynamicEnvVars []EnvVar
 }
 
 func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request ExecuteCommandRequest) (ExecuteCommandResponse, error) {
@@ -27,7 +29,12 @@ func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request E
 	cmd.Dir = request.Path
 
 	finalEnvVars := os.Environ()
-	for key, val := range request.EnvVars {
+
+	requestEnvVars, err := getEnvs(request.EnvVars, request.DynamicEnvVars)
+	if err != nil {
+		return ExecuteCommandResponse{}, errors.Wrap(err, "getting env vars")
+	}
+	for key, val := range requestEnvVars {
 		finalEnvVars = append(finalEnvVars, fmt.Sprintf("%s=%s", key, val))
 	}
 
@@ -40,4 +47,51 @@ func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request E
 	return ExecuteCommandResponse{
 		Output: string(out),
 	}, nil
+}
+
+type StringCommand struct {
+	Command        string
+	Dir            string
+	AdditionalEnvs map[string]string
+}
+
+func (l *StringCommand) Load() (string, error) {
+	cmd := exec.Command("sh", "-c", l.Command) // #nosec
+	cmd.Dir = l.Dir
+
+	finalEnvVars := os.Environ()
+	for key, val := range l.AdditionalEnvs {
+		finalEnvVars = append(finalEnvVars, fmt.Sprintf("%s=%s", key, val))
+	}
+
+	cmd.Env = finalEnvVars
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", errors.Wrap(err, "executing cmd")
+	}
+
+	// Trim newline from res to support running `echo env_value` which has
+	// a newline. We don't recommend users run echo -n env_value to remove the
+	// newline because -n doesn't work in the sh shell which is what we use
+	// to run commands.
+	// n
+	return strings.TrimSuffix(string(out), "\n"), err
+}
+
+// EnvVar is a container used for activity requests
+// and we use basic json serialization so we need to be explicit
+// about our fields and can't do any clever interfacing here.
+type EnvVar struct {
+	Name    string
+	Value   string
+	Command StringCommand
+}
+
+func (v EnvVar) GetValue() (string, error) {
+	if v.Value != "" {
+		return v.Value, nil
+	}
+
+	return v.Command.Load()
 }

--- a/server/neptune/workflows/activities/execute.go
+++ b/server/neptune/workflows/activities/execute.go
@@ -75,7 +75,6 @@ func (l *StringCommand) Load() (string, error) {
 	// a newline. We don't recommend users run echo -n env_value to remove the
 	// newline because -n doesn't work in the sh shell which is what we use
 	// to run commands.
-	// n
 	return strings.TrimSuffix(string(out), "\n"), err
 }
 

--- a/server/neptune/workflows/activities/execute_test.go
+++ b/server/neptune/workflows/activities/execute_test.go
@@ -1,0 +1,40 @@
+package activities_test
+
+import (
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvVar(t *testing.T) {
+
+	t.Run("prioritizes value", func(t *testing.T) {
+		subject := activities.EnvVar{
+			Name:  "some-name",
+			Value: "some-val",
+			Command: activities.StringCommand{
+				Command: "echo 'hello'",
+			},
+		}
+
+		v, err := subject.GetValue()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "some-val", v)
+	})
+
+	t.Run("runs command when value dne", func(t *testing.T) {
+		subject := activities.EnvVar{
+			Name: "some-name",
+			Command: activities.StringCommand{
+				Command: "echo 'hello'",
+			},
+		}
+
+		v, err := subject.GetValue()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", v)
+	})
+}

--- a/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
@@ -24,9 +24,8 @@ type testCmdExecuteActivity struct {
 func (a *testCmdExecuteActivity) ExecuteCommand(ctx context.Context, request activities.ExecuteCommandRequest) (activities.ExecuteCommandResponse, error) {
 
 	var sorted []activities.EnvVar
-	for _, v := range request.DynamicEnvVars {
-		sorted = append(sorted, v)
-	}
+	sorted = append(sorted, request.DynamicEnvVars...)
+
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i].Name < sorted[j].Name
 	})

--- a/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
@@ -2,6 +2,7 @@ package job_test
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -21,7 +22,15 @@ type testCmdExecuteActivity struct {
 }
 
 func (a *testCmdExecuteActivity) ExecuteCommand(ctx context.Context, request activities.ExecuteCommandRequest) (activities.ExecuteCommandResponse, error) {
-	assert.Equal(a.t, a.expectedReq, request.DynamicEnvVars)
+
+	var sorted []activities.EnvVar
+	for _, v := range request.DynamicEnvVars {
+		sorted = append(sorted, v)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	assert.Equal(a.t, a.expectedReq, sorted)
 	return activities.ExecuteCommandResponse{}, nil
 }
 
@@ -45,7 +54,6 @@ func testCmdWorkflow(ctx workflow.Context, r request) (string, error) {
 }
 
 func TestRunRunner_ShouldSetupEnvVars(t *testing.T) {
-
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 

--- a/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
@@ -2,7 +2,6 @@ package job_test
 
 import (
 	"context"
-	"sort"
 	"testing"
 	"time"
 
@@ -22,14 +21,7 @@ type testCmdExecuteActivity struct {
 }
 
 func (a *testCmdExecuteActivity) ExecuteCommand(ctx context.Context, request activities.ExecuteCommandRequest) (activities.ExecuteCommandResponse, error) {
-
-	var sorted []activities.EnvVar
-	sorted = append(sorted, request.DynamicEnvVars...)
-
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Name < sorted[j].Name
-	})
-	assert.Equal(a.t, a.expectedReq, sorted)
+	assert.Equal(a.t, a.expectedReq, request.DynamicEnvVars)
 	return activities.ExecuteCommandResponse{}, nil
 }
 

--- a/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/cmd_step_runner_test.go
@@ -17,11 +17,11 @@ import (
 
 type testCmdExecuteActivity struct {
 	t           *testing.T
-	expectedReq map[string]string
+	expectedReq []activities.EnvVar
 }
 
 func (a *testCmdExecuteActivity) ExecuteCommand(ctx context.Context, request activities.ExecuteCommandRequest) (activities.ExecuteCommandResponse, error) {
-	assert.Equal(a.t, a.expectedReq, request.EnvVars)
+	assert.Equal(a.t, a.expectedReq, request.DynamicEnvVars)
 	return activities.ExecuteCommandResponse{}, nil
 }
 
@@ -33,7 +33,6 @@ func testCmdWorkflow(ctx workflow.Context, r request) (string, error) {
 	jobExecutionCtx := &runner.ExecutionContext{
 		Context:   ctx,
 		Path:      ProjectPath,
-		Envs:      map[string]string{},
 		TfVersion: r.LocalRoot.Root.TfVersion,
 	}
 
@@ -50,12 +49,27 @@ func TestRunRunner_ShouldSetupEnvVars(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	expectedEnvVars := map[string]string{
-		"BASE_REPO_NAME":  RepoName,
-		"BASE_REPO_OWNER": RepoOwner,
-		"DIR":             ProjectPath,
-		"PROJECT_NAME":    ProjectName,
-		"REPO_REL_DIR":    "project",
+	expectedEnvVars := []activities.EnvVar{
+		{
+			Name:  "BASE_REPO_NAME",
+			Value: RepoName,
+		},
+		{
+			Name:  "BASE_REPO_OWNER",
+			Value: RepoOwner,
+		},
+		{
+			Name:  "DIR",
+			Value: ProjectPath,
+		},
+		{
+			Name:  "PROJECT_NAME",
+			Value: ProjectName,
+		},
+		{
+			Name:  "REPO_REL_DIR",
+			Value: "project",
+		},
 	}
 	testExecuteActivity := &testCmdExecuteActivity{
 		t:           t,

--- a/server/neptune/workflows/internal/terraform/job/env_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/env_step_runner.go
@@ -1,25 +1,95 @@
 package job
 
 import (
-	"strings"
-
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/version"
+	"go.temporal.io/sdk/workflow"
 )
 
 type EnvStepRunner struct {
 	CmdStepRunner CmdStepRunner
 }
 
-func (e *EnvStepRunner) Run(executionContext *ExecutionContext, localRoot *terraform.LocalRoot, step execute.Step) (string, error) {
+func (e *EnvStepRunner) Run(ctx *ExecutionContext, localRoot *terraform.LocalRoot, step execute.Step) (EnvVar, error) {
 	if step.EnvVarValue != "" {
-		return step.EnvVarValue, nil
+		return NewEnvVarFromString(step.EnvVarName, step.EnvVarValue), nil
 	}
 
-	res, err := e.CmdStepRunner.Run(executionContext, localRoot, step)
-	// Trim newline from res to support running `echo env_value` which has
-	// a newline. We don't recommend users run echo -n env_value to remove the
-	// newline because -n doesn't work in the sh shell which is what we use
-	// to run commands.
-	return strings.TrimSuffix(res, "\n"), err
+	return e.getEnv(ctx, localRoot, step)
+}
+
+func (e *EnvStepRunner) getEnv(ctx *ExecutionContext, localRoot *terraform.LocalRoot, step execute.Step) (EnvVar, error) {
+	version := workflow.GetVersion(ctx, version.LazyLoadEnvVars, workflow.DefaultVersion, 1)
+
+	if version == workflow.DefaultVersion {
+		return e.getLegacyEnvVar(ctx, localRoot, step)
+	}
+
+	relPath := localRoot.RelativePathFromRepo()
+	envVars := map[string]string{
+		"BASE_REPO_NAME":  localRoot.Repo.Name,
+		"BASE_REPO_OWNER": localRoot.Repo.Owner,
+		"DIR":             ctx.Path,
+		"PROJECT_NAME":    localRoot.Root.Name,
+		"REPO_REL_DIR":    relPath,
+	}
+
+	return NewEnvVarFromCmd(step.EnvVarName, step.RunCommand, ctx.Path, envVars), nil
+}
+
+func (e *EnvStepRunner) getLegacyEnvVar(ctx *ExecutionContext, localRoot *terraform.LocalRoot, step execute.Step) (EnvVar, error) {
+	res, err := e.CmdStepRunner.Run(ctx, localRoot, step)
+	return NewEnvVarFromString(step.EnvVarName, res), err
+}
+
+type StringEnvVar struct {
+	name  string
+	value string
+}
+
+func (v StringEnvVar) ToActivityEnvVar() activities.EnvVar {
+	return activities.EnvVar{
+		Name:  v.name,
+		Value: v.value,
+	}
+}
+
+type EnvVar interface {
+	ToActivityEnvVar() activities.EnvVar
+}
+
+type CommandEnvVar struct {
+	name           string
+	command        string
+	dir            string
+	additionalEnvs map[string]string
+}
+
+func (v CommandEnvVar) ToActivityEnvVar() activities.EnvVar {
+	return activities.EnvVar{
+		Name: v.name,
+		Command: activities.StringCommand{
+			Command:        v.command,
+			Dir:            v.dir,
+			AdditionalEnvs: v.additionalEnvs,
+		},
+	}
+}
+
+func NewEnvVarFromCmd(name string, command string, dir string, additionalEnvs map[string]string) CommandEnvVar {
+	return CommandEnvVar{
+		name:           name,
+		command:        command,
+		dir:            dir,
+		additionalEnvs: additionalEnvs,
+	}
+}
+
+func NewEnvVarFromString(name string, value string) StringEnvVar {
+	return StringEnvVar{
+		name:  name,
+		value: value,
+	}
 }

--- a/server/neptune/workflows/internal/terraform/job/env_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/env_step_runner_test.go
@@ -2,15 +2,18 @@ package job_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	runner "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/job"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
 
 const (
@@ -25,32 +28,40 @@ type request struct {
 	Step      execute.Step
 }
 
-func TestEnvRunner_EnvVarValueNotSet(t *testing.T) {
+func testEnvRunnerWorkflow(ctx workflow.Context, r request) (activities.EnvVar, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
+
+	jobExecutionCtx := &runner.ExecutionContext{
+		Context:   ctx,
+		Path:      ProjectPath,
+		TfVersion: r.LocalRoot.Root.TfVersion,
+	}
+
+	var a *testCmdExecuteActivity
+
+	envStepRunner := runner.EnvStepRunner{
+		CmdStepRunner: runner.CmdStepRunner{
+			Activity: a,
+		},
+	}
+
+	envVar, err := envStepRunner.Run(jobExecutionCtx, &r.LocalRoot, r.Step)
+	return envVar.ToActivityEnvVar(), err
+}
+
+func TestEnvRunner_CommandEnvVar(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
+	env.OnGetVersion(version.LazyLoadEnvVars, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+
 	testExecuteActivity := &testCmdExecuteActivity{}
 	env.RegisterActivity(testExecuteActivity)
-	env.RegisterWorkflow(testCmdWorkflow)
+	env.RegisterWorkflow(testEnvRunnerWorkflow)
 
-	env.OnActivity(testExecuteActivity.ExecuteCommand, mock.Anything, activities.ExecuteCommandRequest{
-		Step: execute.Step{
-			StepName:   "env",
-			RunCommand: "echo 'Hello World'",
-		},
-		Path: ProjectPath,
-		EnvVars: map[string]string{
-			"BASE_REPO_NAME":  RepoName,
-			"BASE_REPO_OWNER": RepoOwner,
-			"DIR":             ProjectPath,
-			"PROJECT_NAME":    ProjectName,
-			"REPO_REL_DIR":    "project",
-		},
-	}).Return(activities.ExecuteCommandResponse{
-		Output: "Hello World",
-	}, nil)
-
-	env.ExecuteWorkflow(testCmdWorkflow, request{
+	env.ExecuteWorkflow(testEnvRunnerWorkflow, request{
 		LocalRoot: terraform.LocalRoot{
 			Root: terraform.Root{
 				Name: ProjectName,
@@ -63,29 +74,136 @@ func TestEnvRunner_EnvVarValueNotSet(t *testing.T) {
 		},
 		Step: execute.Step{
 			StepName:   "env",
+			EnvVarName: "nish",
 			RunCommand: "echo 'Hello World'",
 		},
 	})
 
-	var resp string
+	var resp activities.EnvVar
+	assert.NoError(t, env.GetWorkflowResult(&resp))
+
+	assert.Equal(t, activities.EnvVar{
+		Name: "nish",
+		Command: activities.StringCommand{
+			Command: "echo 'Hello World'",
+			Dir:     ProjectPath,
+			AdditionalEnvs: map[string]string{
+				"BASE_REPO_NAME":  RepoName,
+				"BASE_REPO_OWNER": RepoOwner,
+				"DIR":             ProjectPath,
+				"PROJECT_NAME":    ProjectName,
+				"REPO_REL_DIR":    "project",
+			},
+		},
+	}, resp)
+
+	env.AssertNotCalled(t, "ExecuteCommand", mock.Anything, mock.Anything)
+}
+
+func TestEnvRunner_StringEnvVar(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	testExecuteActivity := &testCmdExecuteActivity{}
+	env.RegisterActivity(testExecuteActivity)
+	env.RegisterWorkflow(testEnvRunnerWorkflow)
+
+	env.ExecuteWorkflow(testEnvRunnerWorkflow, request{
+		LocalRoot: terraform.LocalRoot{
+			Root: terraform.Root{
+				Name: ProjectName,
+				Path: "project",
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+			},
+		},
+		Step: execute.Step{
+			StepName:    "env",
+			EnvVarName:  "nish",
+			EnvVarValue: "Hello",
+		},
+	})
+
+	var resp activities.EnvVar
+	assert.NoError(t, env.GetWorkflowResult(&resp))
+
+	assert.Equal(t, activities.EnvVar{
+		Name:  "nish",
+		Value: "Hello",
+	}, resp)
+
+	env.AssertNotCalled(t, "ExecuteCommand", mock.Anything, mock.Anything)
+}
+
+func TestEnvRunner_ExecutesCommandForLegacyVersion(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	env.OnGetVersion(version.LazyLoadEnvVars, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+
+	testExecuteActivity := &testCmdExecuteActivity{}
+	env.RegisterActivity(testExecuteActivity)
+	env.RegisterWorkflow(testEnvRunnerWorkflow)
+
+	env.OnActivity(testExecuteActivity.ExecuteCommand, mock.Anything, activities.ExecuteCommandRequest{
+		Step: execute.Step{
+			EnvVarName: "nish",
+			StepName:   "env",
+			RunCommand: "echo 'Hello World'",
+		},
+		Path: ProjectPath,
+		DynamicEnvVars: []activities.EnvVar{
+			{
+				Name:  "BASE_REPO_NAME",
+				Value: RepoName,
+			},
+			{
+				Name:  "BASE_REPO_OWNER",
+				Value: RepoOwner,
+			},
+			{
+				Name:  "DIR",
+				Value: ProjectPath,
+			},
+			{
+				Name:  "PROJECT_NAME",
+				Value: ProjectName,
+			},
+			{
+				Name:  "REPO_REL_DIR",
+				Value: "project",
+			},
+		},
+	}).Return(activities.ExecuteCommandResponse{
+		Output: "Hello World",
+	}, nil)
+
+	env.ExecuteWorkflow(testEnvRunnerWorkflow, request{
+		LocalRoot: terraform.LocalRoot{
+			Root: terraform.Root{
+				Name: ProjectName,
+				Path: "project",
+			},
+			Repo: github.Repo{
+				Name:  RepoName,
+				Owner: RepoOwner,
+			},
+		},
+		Step: execute.Step{
+			StepName:   "env",
+			EnvVarName: "nish",
+			RunCommand: "echo 'Hello World'",
+		},
+	})
+
+	var resp activities.EnvVar
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "Hello World", resp)
-}
-
-func TestEnvRunne_EnvVarValueSet(t *testing.T) {
-	executioncontext := &runner.ExecutionContext{}
-	localRoot := &terraform.LocalRoot{}
-
-	step := execute.Step{
-		EnvVarName:  "TEST_VAR",
-		EnvVarValue: "TEST_VALUE",
-	}
-
-	runner := runner.EnvStepRunner{}
-
-	out, err := runner.Run(executioncontext, localRoot, step)
-	assert.Nil(t, err)
-	assert.Equal(t, out, step.EnvVarValue)
+	assert.Equal(t, activities.EnvVar{
+		Name:  "nish",
+		Value: "Hello World",
+	}, resp)
 }

--- a/server/neptune/workflows/internal/terraform/job/env_step_runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/env_step_runner_test.go
@@ -153,7 +153,8 @@ func TestEnvRunner_ExecutesCommandForLegacyVersion(t *testing.T) {
 			StepName:   "env",
 			RunCommand: "echo 'Hello World'",
 		},
-		Path: ProjectPath,
+		Path:    ProjectPath,
+		EnvVars: map[string]string{},
 		DynamicEnvVars: []activities.EnvVar{
 			{
 				Name:  "BASE_REPO_NAME",

--- a/server/neptune/workflows/internal/terraform/version/name.go
+++ b/server/neptune/workflows/internal/terraform/version/name.go
@@ -1,0 +1,5 @@
+package version
+
+// This version removes an activity that computes env vars from commands and instead opts
+// for lazy loading within each of the following steps.
+const LazyLoadEnvVars = "lazy-load-env-vars"


### PR DESCRIPTION
Basically we're open to a security risk right now however with this change we only compute the env var within our activities which is a blackbox.

However, since we are now taking production traffic I've wrapped this in a versioning constraint.  This is to ensure that any replays don't break because we are now missing an activity.  Additionally, I made sure that old activity inputs are supported just in case, though this shouldn't be necessary.  We can remove this once this rolls out and when we know this is the only version out there.

All this versioning might have been overkill tbh, but i wanted to try it out and see how hard it was to write code like this. It wasn't too bad all in all.