### PR TITLE
Dismiss reviews on pull update/comment events

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -841,8 +841,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		members: []string{},
 	}
 	reviewDismisser := &mockReviewDismisser{}
-	commitFetcher := &mockCommitFetcher{}
-	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, globalCfg.PolicySets.PolicySets)
+	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, globalCfg.PolicySets.PolicySets)
 	conftestExecutor := &policy.ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
 		PolicyFilter: policyFilter,
@@ -1422,17 +1421,6 @@ type testStaleCommandChecker struct{}
 
 func (t *testStaleCommandChecker) CommandIsStale(ctx *command.Context) bool {
 	return false
-}
-
-type mockCommitFetcher struct {
-	commit   *github.Commit
-	error    error
-	isCalled bool
-}
-
-func (c *mockCommitFetcher) FetchLatestPRCommit(_ context.Context, _ int64, _ models.Repo, _ int) (*github.Commit, error) {
-	c.isCalled = true
-	return c.commit, c.error
 }
 
 type mockReviewDismisser struct {

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -45,16 +45,13 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.Polic
 	reviewDismisser := &github.PRReviewDismisser{
 		ClientCreator: creator,
 	}
-	commitFetcher := &github.CommitFetcher{
-		ClientCreator: creator,
-	}
 	teamMemberFetcher := &github.TeamMemberFetcher{
 		ClientCreator: creator,
 		Org:           policySets.Organization,
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamMemberFetcher, policySets.PolicySets),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamMemberFetcher, policySets.PolicySets),
 	}
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -18,7 +18,7 @@ import (
 )
 
 type policyFilter interface {
-	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
+	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, trigger command.CommandTrigger, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
 }
 
 type exec interface {
@@ -112,7 +112,7 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 		return output, errors.New(internalError)
 	}
 
-	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, prjCtx.Trigger, failedPolicies)
 	if err != nil {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("error filtering out approved policies: %s", err.Error()))
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)

--- a/server/core/runtime/policy/conftest_executor_test.go
+++ b/server/core/runtime/policy/conftest_executor_test.go
@@ -187,7 +187,7 @@ type mockPolicyFilter struct {
 	error    error
 }
 
-func (r *mockPolicyFilter) Filter(_ context.Context, _ int64, _ models.Repo, _ int, _ []valid.PolicySet) ([]valid.PolicySet, error) {
+func (r *mockPolicyFilter) Filter(_ context.Context, _ int64, _ models.Repo, _ int, _ command.CommandTrigger, _ []valid.PolicySet) ([]valid.PolicySet, error) {
 	r.isCalled = true
 	return r.policies, r.error
 }

--- a/server/events/command/context.go
+++ b/server/events/command/context.go
@@ -18,6 +18,9 @@ const (
 
 	// Commands that are triggered by comments (ie. atlantis plan)
 	CommentTrigger
+
+	// Commands that are triggered by PR reviews (ie. atlantis policy checks)
+	PRReviewTrigger
 )
 
 // Context represents the context of a command that should be executed

--- a/server/events/command/project_context.go
+++ b/server/events/command/project_context.go
@@ -79,6 +79,7 @@ func NewProjectContext(
 		RequestCtx:           ctx.RequestCtx,
 		WorkflowModeType:     projCfg.WorkflowMode,
 		InstallationToken:    ctx.InstallationToken,
+		Trigger:              ctx.Trigger,
 	}
 }
 
@@ -160,6 +161,7 @@ type ProjectContext struct {
 
 	WorkflowModeType  valid.WorkflowModeType
 	InstallationToken int64
+	Trigger           CommandTrigger
 }
 
 // ProjectCloneDir creates relative path to clone the repo to. If we are running

--- a/server/events/command_runner.go
+++ b/server/events/command_runner.go
@@ -254,7 +254,7 @@ func (c *DefaultCommandRunner) RunPRReviewCommand(ctx context.Context, repo mode
 		Pull:              pull,
 		PullStatus:        status,
 		HeadRepo:          repo,
-		Trigger:           command.AutoTrigger,
+		Trigger:           command.PRReviewTrigger,
 		Scope:             scope,
 		TriggerTimestamp:  timestamp,
 		RequestCtx:        ctx,

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -88,7 +88,7 @@ func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, instal
 	}
 
 	// Dismiss all approvals on pull event
-	if trigger == command.AutoTrigger {
+	if trigger == command.AutoTrigger || trigger == command.CommentTrigger {
 		for _, approval := range approvalReviews {
 			isOwner, err := p.approverIsOwner(ctx, installationToken, approval)
 			if err != nil {

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -9,9 +9,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
-type prLatestCommitFetcher interface {
-	FetchLatestPRCommit(ctx context.Context, installationToken int64, repo models.Repo, prNum int) (*gh.Commit, error)
-}
 type prReviewFetcher interface {
 	ListLatestApprovalUsernames(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]string, error)
 	ListApprovalReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.PullRequestReview, error)
@@ -26,25 +23,22 @@ type teamMemberFetcher interface {
 }
 
 type ApprovedPolicyFilter struct {
-	prReviewDismisser     prReviewDismisser
-	prReviewFetcher       prReviewFetcher
-	prLatestCommitFetcher prLatestCommitFetcher
-	teamMemberFetcher     teamMemberFetcher
-	policies              []valid.PolicySet
+	prReviewDismisser prReviewDismisser
+	prReviewFetcher   prReviewFetcher
+	teamMemberFetcher teamMemberFetcher
+	policies          []valid.PolicySet
 }
 
 func NewApprovedPolicyFilter(
 	prReviewFetcher prReviewFetcher,
 	prReviewDismisser prReviewDismisser,
-	prLatestCommitFetcher prLatestCommitFetcher,
 	teamMemberFetcher teamMemberFetcher,
 	policySets []valid.PolicySet) *ApprovedPolicyFilter {
 	return &ApprovedPolicyFilter{
-		prReviewFetcher:       prReviewFetcher,
-		prReviewDismisser:     prReviewDismisser,
-		prLatestCommitFetcher: prLatestCommitFetcher,
-		teamMemberFetcher:     teamMemberFetcher,
-		policies:              policySets,
+		prReviewFetcher:   prReviewFetcher,
+		prReviewDismisser: prReviewDismisser,
+		teamMemberFetcher: teamMemberFetcher,
+		policies:          policySets,
 	}
 }
 
@@ -55,10 +49,13 @@ func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int
 		return failedPolicies, nil
 	}
 
-	// Need to dismiss stale reviews before determining which failed policies can be bypassed
-	err := p.dismissStalePRReviews(ctx, installationToken, repo, prNum, trigger)
-	if err != nil {
-		return failedPolicies, errors.Wrap(err, "failed to dismiss stale PR reviews")
+	// Dismiss PR reviews when event came from pull request change/atlantis plan comment
+	if trigger == command.AutoTrigger || trigger == command.CommentTrigger {
+		err := p.dismissStalePRReviews(ctx, installationToken, repo, prNum)
+		if err != nil {
+			return failedPolicies, errors.Wrap(err, "failed to dismiss stale PR reviews")
+		}
+		return failedPolicies, nil
 	}
 
 	// Fetch reviewers who approved the PR
@@ -81,40 +78,13 @@ func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int
 	return filteredFailedPolicies, nil
 }
 
-func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int, trigger command.CommandTrigger) error {
+func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) error {
 	approvalReviews, err := p.prReviewFetcher.ListApprovalReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch GH PR reviews")
 	}
 
-	// Dismiss all approvals on pull event
-	if trigger == command.AutoTrigger || trigger == command.CommentTrigger {
-		for _, approval := range approvalReviews {
-			isOwner, err := p.approverIsOwner(ctx, installationToken, approval)
-			if err != nil {
-				return errors.Wrap(err, "failed to validate approver is owner")
-			}
-			if isOwner {
-				err = p.prReviewDismisser.Dismiss(ctx, installationToken, repo, prNum, approval.GetID())
-				if err != nil {
-					return errors.Wrap(err, "failed to dismiss GH PR reviews")
-				}
-			}
-		}
-		return nil
-	}
-
-	// Backup, attempt to dismissal approvals after latest timestamp here
-	latestCommit, err := p.prLatestCommitFetcher.FetchLatestPRCommit(ctx, installationToken, repo, prNum)
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch GH PR latest commit timestamp")
-	}
-
 	for _, approval := range approvalReviews {
-		// don't dismiss approvals after latest commit (check this first to avoid extra GH calls when possible)
-		if approval.GetSubmittedAt().After(latestCommit.GetCommitter().GetDate()) {
-			continue
-		}
 		isOwner, err := p.approverIsOwner(ctx, installationToken, approval)
 		if err != nil {
 			return errors.Wrap(err, "failed to validate approver is owner")

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -87,7 +87,7 @@ func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, instal
 		return errors.Wrap(err, "failed to fetch GH PR reviews")
 	}
 
-	// Dismiss all approvals on push event
+	// Dismiss all approvals on pull event
 	if trigger == command.AutoTrigger {
 		for _, approval := range approvalReviews {
 			isOwner, err := p.approverIsOwner(ctx, installationToken, approval)

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -57,7 +57,7 @@ func TestFilter_Approved(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -155,7 +155,7 @@ func TestFilter_Approved_NoDismissal(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -189,7 +189,7 @@ func TestFilter_NotApproved(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -213,7 +213,7 @@ func TestFilter_NotApproved_NoDismissal(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -235,7 +235,7 @@ func TestFilter_NoFailedPolicies(t *testing.T) {
 
 	var failedPolicies []valid.PolicySet
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
 	assert.False(t, reviewFetcher.listApprovalsIsCalled)
@@ -259,7 +259,7 @@ func TestFilter_FailedListLatestApprovalUsernames(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -283,7 +283,7 @@ func TestFilter_FailedListApprovalReviews(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -307,7 +307,7 @@ func TestFilter_FailedFetchLatestCommitTime(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -331,7 +331,7 @@ func TestFilter_FailedTeamMemberFetch(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
@@ -367,7 +367,7 @@ func TestFilter_FailedDismiss(t *testing.T) {
 	}
 
 	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, commitFetcher, teamFetcher, failedPolicies)
-	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)

--- a/server/vcs/provider/github/pr_review_dimisser.go
+++ b/server/vcs/provider/github/pr_review_dimisser.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 )
 
-const DismissReason = "**New commits have triggered policy failures that must be approved by policy owners.**"
+const DismissReason = "**New plans have triggered policy failures that must be approved by policy owners.**"
 
 type PRReviewDismisser struct {
 	ClientCreator githubapp.ClientCreator


### PR DESCRIPTION
Matches the legacy approve policies workflow by ensure policy approvals are up to date when we new plan is generated (i.e. after atlantis plan comment or new commit pushed onto a branch). 