### PR TITLE
Dismiss approvals when sha doesn't exist

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1425,12 +1425,12 @@ func (t *testStaleCommandChecker) CommandIsStale(ctx *command.Context) bool {
 }
 
 type mockCommitFetcher struct {
-	commit   []*github.Commit
+	commit   []*github.RepositoryCommit
 	error    error
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchPRCommits(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.Commit, error) {
+func (c *mockCommitFetcher) FetchPRCommits(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.RepositoryCommit, error) {
 	c.isCalled = true
 	return c.commit, c.error
 }

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1430,7 +1430,7 @@ type mockCommitFetcher struct {
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchPRCommits(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*github.Commit, error) {
+func (c *mockCommitFetcher) FetchPRCommits(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.Commit, error) {
 	c.isCalled = true
 	return c.commit, c.error
 }

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1425,12 +1425,12 @@ func (t *testStaleCommandChecker) CommandIsStale(ctx *command.Context) bool {
 }
 
 type mockCommitFetcher struct {
-	commit   *github.Commit
+	commit   []*github.Commit
 	error    error
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchLatestPRCommit(_ context.Context, _ int64, _ models.Repo, _ int) (*github.Commit, error) {
+func (c *mockCommitFetcher) FetchPRCommits(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*github.Commit, error) {
 	c.isCalled = true
 	return c.commit, c.error
 }

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -7,7 +7,6 @@ import (
 	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/metrics"
-	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"path/filepath"
 	"strings"
@@ -19,7 +18,7 @@ import (
 )
 
 type policyFilter interface {
-	Filter(ctx context.Context, logger logging.Logger, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
+	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
 }
 
 type exec interface {
@@ -113,7 +112,7 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 		return output, errors.New(internalError)
 	}
 
-	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.Log, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
 	if err != nil {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("error filtering out approved policies: %s", err.Error()))
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -7,6 +7,7 @@ import (
 	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,7 @@ import (
 )
 
 type policyFilter interface {
-	Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
+	Filter(ctx context.Context, logger logging.Logger, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error)
 }
 
 type exec interface {
@@ -112,7 +113,7 @@ func (c *ConfTestExecutor) Run(_ context.Context, prjCtx command.ProjectContext,
 		return output, errors.New(internalError)
 	}
 
-	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
+	failedPolicies, err := c.PolicyFilter.Filter(prjCtx.RequestCtx, prjCtx.Log, prjCtx.InstallationToken, prjCtx.HeadRepo, prjCtx.Pull.Num, failedPolicies)
 	if err != nil {
 		prjCtx.Log.ErrorContext(prjCtx.RequestCtx, fmt.Sprintf("error filtering out approved policies: %s", err.Error()))
 		scope.Counter(metrics.ExecutionErrorMetric).Inc(1)

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -2,10 +2,13 @@ package events
 
 import (
 	"context"
+	"fmt"
 	gh "github.com/google/go-github/v45/github"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	"strings"
 	"time"
 )
 
@@ -49,14 +52,14 @@ func NewApprovedPolicyFilter(
 }
 
 // Filter will remove failed policies if the underlying PR has been approved by a policy owner
-func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error) {
+func (p *ApprovedPolicyFilter) Filter(ctx context.Context, log logging.Logger, installationToken int64, repo models.Repo, prNum int, failedPolicies []valid.PolicySet) ([]valid.PolicySet, error) {
 	// Skip GH API calls if no policies failed
 	if len(failedPolicies) == 0 {
 		return failedPolicies, nil
 	}
 
 	// Need to dismiss stale reviews before determining which failed policies can be bypassed
-	err := p.dismissStalePRReviews(ctx, installationToken, repo, prNum)
+	err := p.dismissStalePRReviews(ctx, log, installationToken, repo, prNum)
 	if err != nil {
 		return failedPolicies, errors.Wrap(err, "failed to dismiss stale PR reviews")
 	}
@@ -81,7 +84,7 @@ func (p *ApprovedPolicyFilter) Filter(ctx context.Context, installationToken int
 	return filteredFailedPolicies, nil
 }
 
-func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, installationToken int64, repo models.Repo, prNum int) error {
+func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, log logging.Logger, installationToken int64, repo models.Repo, prNum int) error {
 	approvalReviews, err := p.prReviewFetcher.ListApprovalReviews(ctx, installationToken, repo, prNum)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch GH PR reviews")
@@ -91,11 +94,17 @@ func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, instal
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch GH PR commits")
 	}
+	var commitShas []string
+	for idx, commit := range commits {
+		commitShas = append(commitShas, fmt.Sprintf("Commit %d: %s", idx, commit.GetSHA()))
+	}
+	log.Info(fmt.Sprintf("commits: \n%s", strings.Join(commitShas, " \n")))
 
 	latestCommitTimestamp, err := fetchLatestCommitTimestamp(commits)
 	if err != nil {
 		return err
 	}
+	log.Info(fmt.Sprintf("latest commit timestamp %s", latestCommitTimestamp.String()))
 
 	for _, approval := range approvalReviews {
 		// don't dismiss approvals if reviewer is not a policy owner
@@ -109,6 +118,13 @@ func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, instal
 
 		// dismiss if review's sha doesn't exist (due to git history edits) OR if approval came before latest commit
 		if !approvalCommitExists(approval, commits) || approval.GetSubmittedAt().Before(latestCommitTimestamp) {
+			if !approvalCommitExists(approval, commits) {
+				log.Info(fmt.Sprintf("approval commit DNE: approval commit=%s", approval.GetCommitID()))
+			}
+			if approval.GetSubmittedAt().Before(latestCommitTimestamp) {
+				log.Info(fmt.Sprintf("approval before latest commit: approval commit=%s commit time= %s",
+					approval.GetSubmittedAt().String(), latestCommitTimestamp.String()))
+			}
 			err = p.prReviewDismisser.Dismiss(ctx, installationToken, repo, prNum, approval.GetID())
 			if err != nil {
 				return errors.Wrap(err, "failed to dismiss GH PR reviews")

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -22,10 +22,12 @@ const (
 	testSHA2    = "d4e5f6"
 )
 
-func createCommit(time time.Time, sha string) *github.Commit {
-	return &github.Commit{
-		Committer: &github.CommitAuthor{
-			Date: &time,
+func createCommit(time time.Time, sha string) *github.RepositoryCommit {
+	return &github.RepositoryCommit{
+		Commit: &github.Commit{
+			Committer: &github.CommitAuthor{
+				Date: &time,
+			},
 		},
 		SHA: github.String(sha),
 	}
@@ -53,7 +55,7 @@ func TestFilter_Approved(t *testing.T) {
 		members: []string{ownerA, ownerB, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time.Time{}, testSHA), createCommit(time1, testSHA2)},
+		commits: []*github.RepositoryCommit{createCommit(time.Time{}, testSHA), createCommit(time1, testSHA2)},
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -85,7 +87,7 @@ func TestFilter_Approved_NoDismissal(t *testing.T) {
 		},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time1, testSHA)},
+		commits: []*github.RepositoryCommit{createCommit(time1, testSHA)},
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	teamFetcher := &mockTeamMemberFetcher{
@@ -123,7 +125,7 @@ func TestFilter_NotApproved(t *testing.T) {
 		members: []string{ownerA, ownerB, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time.Time{}, testSHA), createCommit(time2, testSHA2)},
+		commits: []*github.RepositoryCommit{createCommit(time.Time{}, testSHA), createCommit(time2, testSHA2)},
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -158,7 +160,7 @@ func TestFilter_NotApproved_NoCommitFound(t *testing.T) {
 		members: []string{ownerA, ownerB, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time1, testSHA)},
+		commits: []*github.RepositoryCommit{createCommit(time1, testSHA)},
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -184,7 +186,7 @@ func TestFilter_NotApproved_NoDismissal(t *testing.T) {
 		members: []string{ownerA, ownerC},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time.Time{}, testSHA)},
+		commits: []*github.RepositoryCommit{createCommit(time.Time{}, testSHA)},
 	}
 	reviewDismisser := &mockReviewDismisser{}
 	failedPolicies := []valid.PolicySet{
@@ -334,7 +336,7 @@ func TestFilter_FailedDismiss(t *testing.T) {
 		},
 	}
 	commitFetcher := &mockCommitFetcher{
-		commits: []*github.Commit{createCommit(time.Time{}, testSHA), createCommit(time2, testSHA2)},
+		commits: []*github.RepositoryCommit{createCommit(time.Time{}, testSHA), createCommit(time2, testSHA2)},
 	}
 	reviewDismisser := &mockReviewDismisser{
 		error: assert.AnError,
@@ -377,12 +379,12 @@ func (f *mockReviewFetcher) ListApprovalReviews(_ context.Context, _ int64, _ mo
 }
 
 type mockCommitFetcher struct {
-	commits  []*github.Commit
+	commits  []*github.RepositoryCommit
 	error    error
 	isCalled bool
 }
 
-func (c *mockCommitFetcher) FetchPRCommits(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.Commit, error) {
+func (c *mockCommitFetcher) FetchPRCommits(_ context.Context, _ int64, _ models.Repo, _ int) ([]*github.RepositoryCommit, error) {
 	c.isCalled = true
 	return c.commits, c.error
 }

--- a/server/vcs/provider/github/pr_commit_fetcher.go
+++ b/server/vcs/provider/github/pr_commit_fetcher.go
@@ -46,3 +46,29 @@ func (c *CommitFetcher) FetchLatestPRCommit(ctx context.Context, installationTok
 	}
 	return latestCommit, nil
 }
+
+func (c *CommitFetcher) FetchPRCommits(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.Commit, error) {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating installation client")
+	}
+	run := func(ctx context.Context, nextPage int) ([]*gh.RepositoryCommit, *gh.Response, error) {
+		listOptions := gh.ListOptions{
+			PerPage: 100,
+		}
+		listOptions.Page = nextPage
+		return client.PullRequests.ListCommits(ctx, repo.Owner, repo.Name, prNum, &listOptions)
+	}
+	repositoryCommits, err := Iterate(ctx, run)
+	if err != nil {
+		return nil, errors.Wrap(err, "iterating through entries")
+	}
+	var commits []*gh.Commit
+	for _, repositoryCommit := range repositoryCommits {
+		if repositoryCommit.GetCommit() == nil {
+			return nil, errors.New("getting commit")
+		}
+		commits = append(commits, repositoryCommit.GetCommit())
+	}
+	return commits, nil
+}

--- a/server/vcs/provider/github/pr_commit_fetcher.go
+++ b/server/vcs/provider/github/pr_commit_fetcher.go
@@ -47,7 +47,7 @@ func (c *CommitFetcher) FetchLatestPRCommit(ctx context.Context, installationTok
 	return latestCommit, nil
 }
 
-func (c *CommitFetcher) FetchPRCommits(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.Commit, error) {
+func (c *CommitFetcher) FetchPRCommits(ctx context.Context, installationToken int64, repo models.Repo, prNum int) ([]*gh.RepositoryCommit, error) {
 	client, err := c.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating installation client")
@@ -63,12 +63,5 @@ func (c *CommitFetcher) FetchPRCommits(ctx context.Context, installationToken in
 	if err != nil {
 		return nil, errors.Wrap(err, "iterating through entries")
 	}
-	var commits []*gh.Commit
-	for _, repositoryCommit := range repositoryCommits {
-		if repositoryCommit.GetCommit() == nil {
-			return nil, errors.New("getting commit")
-		}
-		commits = append(commits, repositoryCommit.GetCommit())
-	}
-	return commits, nil
+	return repositoryCommits, nil
 }


### PR DESCRIPTION
Idea here is sha for approval is missing due to git history modifications like force pushes. 