### PR TITLE
Build root config in comment handler to decide if platform mode is enabled for a repo on apply commands

### DIFF
--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -46,7 +46,9 @@ func NewVCSEventsController(
 	temporalClient client.Client,
 	rootConfigBuilder *gateway_handlers.RootConfigBuilder,
 	templateLoader template.Loader[any],
-	checkRunFetcher *github.CheckRunsFetcher) *VCSEventsController {
+	checkRunFetcher *github.CheckRunsFetcher,
+	vcsStatusUpdater events.VCSStatusUpdater,
+) *VCSEventsController {
 	pullEventWorkerProxy := gateway_handlers.NewPullEventWorkerProxy(
 		snsWriter, logger,
 	)
@@ -74,7 +76,7 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, templateLoader, vcsClient),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, rootConfigBuilder, templateLoader, vcsStatusUpdater, vcsClient),
 		logger,
 	)
 

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -91,6 +91,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 		// notify user that apply command is deprecated on platform mode
 		if cmd.Name == command.Apply {
 			p.handleLegacyApplyCommand(ctx, event, cmd)
+			return nil
 		}
 
 	}

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -239,6 +239,8 @@ func NewServer(config Config) (*Server, error) {
 	}
 	asyncScheduler := sync.NewAsyncScheduler(ctxLogger, syncScheduler)
 
+	vscStatusUpdater := &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: config.GithubStatusName}}
+
 	gatewaySnsWriter := sns.NewWriterWithStats(session, config.SNSTopicArn, statsScope.SubScope("aws.sns.gateway"))
 	autoplanValidator := &lyft_gateway.AutoplanValidator{
 		Scope:                         statsScope.SubScope("validator"),
@@ -246,7 +248,7 @@ func NewServer(config Config) (*Server, error) {
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		Drainer:                       drainer,
 		GlobalCfg:                     globalCfg,
-		VCSStatusUpdater:              &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: config.GithubStatusName}},
+		VCSStatusUpdater:              vscStatusUpdater,
 		PrjCmdBuilder:                 projectCommandBuilder,
 		OutputUpdater:                 outputUpdater,
 		WorkingDir:                    workingDir,
@@ -328,6 +330,7 @@ func NewServer(config Config) (*Server, error) {
 		rootConfigBuilder,
 		templateLoader,
 		checkRunFetcher,
+		vscStatusUpdater,
 	)
 
 	router := mux.NewRouter()


### PR DESCRIPTION
In the comment handler, we only look at the feature flag to decide if platform mode is enabled for a repo. Since we use the feature flag as a kill switch only, we also need to inspect the manifest to decide if platform mode is enabled for a specific PR. So, we build root configs in the comment handler to decide if platform mode has been enabled on a PR. 

[Platform Mode PR](https://github.com/lyft/orchestration-sandbox-neptune/pull/73)
[Non-Platform Mode PR](https://github.com/lyft/orchestration-sandbox/pull/1752)
