### PR TITLE
Ensure platform mode does not trigger apply requirements.

### DIFF
--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/core/runtime"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
@@ -293,7 +294,7 @@ func (p *DefaultProjectCommandRunner) doApply(ctx command.ProjectContext) (apply
 		return "", "", DirNotExistErr{RepoRelDir: ctx.RepoRelDir}
 	}
 
-	if !ctx.ForceApply {
+	if !ctx.ForceApply && ctx.WorkflowModeType != valid.PlatformWorkflowMode {
 		failure, err = p.AggregateApplyRequirements.ValidateProject(repoDir, ctx)
 		if failure != "" || err != nil {
 			return "", failure, err

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -462,6 +462,36 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 	Equals(t, "Pull request must be approved by at least one person other than the author before running apply.", firstRes.Failure)
 }
 
+func TestDefaultProjectCommandRunner_ForceOverridesApplyReqs_IfPlatformMode(t *testing.T) {
+	RegisterMockTestingT(t)
+	mockWorkingDir := mocks.NewMockWorkingDir()
+	mockSender := mocks.NewMockWebhooksSender()
+	runner := &events.DefaultProjectCommandRunner{
+		WorkingDir:       mockWorkingDir,
+		StepsRunner:      smocks.NewMockStepsRunner(),
+		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
+		AggregateApplyRequirements: &events.AggregateApplyRequirements{
+			WorkingDir: mockWorkingDir,
+		},
+		Webhooks: mockSender,
+	}
+	prjCtx := command.ProjectContext{
+		PullReqStatus: models.PullReqStatus{
+			ApprovalStatus: models.ApprovalStatus{
+				IsApproved: false,
+			},
+		},
+		ApplyRequirements: []string{"approved"},
+		WorkflowModeType:  valid.PlatformWorkflowMode,
+	}
+	tmp, cleanup := TempDir(t)
+	defer cleanup()
+	When(mockWorkingDir.GetWorkingDir(prjCtx.BaseRepo, prjCtx.Pull, prjCtx.Workspace)).ThenReturn(tmp, nil)
+
+	firstRes := runner.Apply(prjCtx)
+	Equals(t, "", firstRes.Failure)
+}
+
 func TestDefaultProjectCommandRunner_ForceOverridesApplyReqs(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockWorkingDir := mocks.NewMockWorkingDir()

--- a/server/lyft/command/feature_runner.go
+++ b/server/lyft/command/feature_runner.go
@@ -6,9 +6,75 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/runatlantis/atlantis/server/neptune/template"
 )
+
+type Commenter interface {
+	CreateComment(repo models.Repo, pullNum int, comment string, command string) error
+}
+
+type LegacyApplyCommentInput struct{}
+
+type PlatformModeRunner struct {
+	command.Runner
+	Allocator      feature.Allocator
+	Logger         logging.Logger
+	Builder        events.ProjectApplyCommandBuilder
+	TemplateLoader template.Loader[LegacyApplyCommentInput]
+	VCSClient      Commenter
+}
+
+func (a *PlatformModeRunner) Run(ctx *command.Context, cmd *command.Comment) {
+	if cmd.Name != command.Apply {
+		a.Runner.Run(ctx, cmd)
+		return
+	}
+
+	shouldAllocate, err := a.Allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{RepoName: ctx.HeadRepo.FullName})
+	if err != nil {
+		a.Logger.ErrorContext(ctx.RequestCtx, fmt.Sprintf("unable to allocate for feature: %s, error: %s", feature.PlatformMode, err))
+	}
+
+	// if this isn't allocated don't worry about the rest
+	if !shouldAllocate {
+		a.Runner.Run(ctx, cmd)
+		return
+	}
+
+	// now let's determine whether the repo is configured for platform mode by building commands
+	var projectCmds []command.ProjectContext
+	projectCmds, err = a.Builder.BuildApplyCommands(ctx, cmd)
+	if err != nil {
+		a.Logger.ErrorContext(ctx.RequestCtx, err.Error())
+		return
+	}
+
+	// is this possible? Not sure, let's be safe tho and just bail into the delegate
+	if len(projectCmds) == 0 {
+		a.Logger.WarnContext(ctx.RequestCtx, "no project commands. unable to determine workflow mode type")
+		a.Runner.Run(ctx, cmd)
+		return
+	}
+
+	if shouldAllocate && (projectCmds[0].WorkflowModeType == valid.PlatformWorkflowMode) {
+		// return error if loading template fails since we should have default templates configured
+		comment, err := a.TemplateLoader.Load(template.LegacyApplyComment, ctx.Pull.BaseRepo, LegacyApplyCommentInput{})
+		if err != nil {
+			a.Logger.ErrorContext(ctx.RequestCtx, fmt.Sprintf("loading template: %s", template.LegacyApplyComment))
+		}
+
+		if err := a.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, comment, ""); err != nil {
+			a.Logger.ErrorContext(ctx.RequestCtx, err.Error())
+		}
+	}
+
+	// at this point we've either commented about this being a legacy apply or not, so let's just proceed with
+	// the run now.
+	a.Runner.Run(ctx, cmd)
+}
 
 // DefaultProjectCommandRunner implements ProjectCommandRunner.
 type PlatformModeProjectRunner struct { //create object and test

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"gopkg.in/go-playground/assert.v1"
-
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -13,6 +11,8 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 	lyftCommand "github.com/runatlantis/atlantis/server/lyft/command"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+	"github.com/stretchr/testify/assert"
 )
 
 type testAllocator struct {
@@ -60,6 +60,221 @@ func (r *testRunner) ApprovePolicies(ctx command.ProjectContext) command.Project
 
 func (r *testRunner) Version(ctx command.ProjectContext) command.ProjectResult {
 	return r.expectedVersionResult
+}
+
+type testCMDRunner struct {
+	expectedCmd *command.Comment
+	t           *testing.T
+	called      bool
+}
+
+func (r *testCMDRunner) Run(ctx *command.Context, cmd *command.Comment) {
+	r.called = true
+	assert.Equal(r.t, r.expectedCmd, cmd)
+}
+
+type TestBuilder struct {
+	Type   valid.WorkflowModeType
+	called bool
+}
+
+func (b *TestBuilder) BuildApplyCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	b.called = true
+	return []command.ProjectContext{
+		{
+			WorkflowModeType: b.Type,
+		},
+	}, nil
+}
+
+type TestCommenter struct {
+	expectedComment string
+	expectedPullNum int
+	expectedRepo    models.Repo
+	expectedCommand string
+	expectedT       *testing.T
+
+	called bool
+}
+
+func (c *TestCommenter) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
+
+	c.called = true
+	assert.Equal(c.expectedT, c.expectedComment, comment)
+	assert.Equal(c.expectedT, c.expectedPullNum, pullNum)
+	assert.Equal(c.expectedT, c.expectedRepo, repo)
+	assert.Equal(c.expectedT, c.expectedCommand, command)
+
+	return nil
+}
+
+func TestPlatformModeRunner_allocatesButNotPlatformMode(t *testing.T) {
+
+	ctx := &command.Context{
+		RequestCtx: context.Background(),
+		HeadRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		Pull: models.PullRequest{
+			Num: 1,
+			BaseRepo: models.Repo{
+				FullName: "owner/base",
+			},
+		},
+	}
+	cmd := &command.Comment{
+		Workspace: "hi",
+	}
+
+	commenter := &TestCommenter{
+		expectedT:       t,
+		expectedComment: "Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. ",
+		expectedPullNum: 1,
+		expectedRepo:    ctx.Pull.BaseRepo,
+	}
+
+	builder := &TestBuilder{
+		Type: valid.DefaultWorkflowMode,
+	}
+	runner := &testCMDRunner{
+		t:           t,
+		expectedCmd: cmd,
+	}
+
+	subject := &lyftCommand.PlatformModeRunner{
+		Allocator: &testAllocator{
+			expectedFeatureName: feature.PlatformMode,
+			expectedT:           t,
+			expectedCtx:         feature.FeatureContext{RepoName: "owner/repo"},
+			expectedResult:      true,
+		},
+		Logger:  logging.NewNoopCtxLogger(t),
+		Builder: builder,
+		TemplateLoader: template.Loader[lyftCommand.LegacyApplyCommentInput]{
+			GlobalCfg: valid.GlobalCfg{},
+		},
+		VCSClient: commenter,
+		Runner:    runner,
+	}
+
+	subject.Run(ctx, cmd)
+
+	assert.True(t, runner.called)
+	assert.True(t, builder.called)
+	assert.False(t, commenter.called)
+}
+
+func TestPlatformModeRunner_doesntAllocate(t *testing.T) {
+
+	ctx := &command.Context{
+		RequestCtx: context.Background(),
+		HeadRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		Pull: models.PullRequest{
+			Num: 1,
+			BaseRepo: models.Repo{
+				FullName: "owner/base",
+			},
+		},
+	}
+	cmd := &command.Comment{
+		Workspace: "hi",
+	}
+
+	commenter := &TestCommenter{
+		expectedT:       t,
+		expectedComment: "Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. ",
+		expectedPullNum: 1,
+		expectedRepo:    ctx.Pull.BaseRepo,
+	}
+
+	builder := &TestBuilder{
+		Type: valid.PlatformWorkflowMode,
+	}
+	runner := &testCMDRunner{
+		t:           t,
+		expectedCmd: cmd,
+	}
+
+	subject := &lyftCommand.PlatformModeRunner{
+		Allocator: &testAllocator{
+			expectedFeatureName: feature.PlatformMode,
+			expectedT:           t,
+			expectedCtx:         feature.FeatureContext{RepoName: "owner/repo"},
+			expectedResult:      false,
+		},
+		Logger:  logging.NewNoopCtxLogger(t),
+		Builder: builder,
+		TemplateLoader: template.Loader[lyftCommand.LegacyApplyCommentInput]{
+			GlobalCfg: valid.GlobalCfg{},
+		},
+		VCSClient: commenter,
+		Runner:    runner,
+	}
+
+	subject.Run(ctx, cmd)
+
+	assert.True(t, runner.called)
+	assert.False(t, builder.called)
+	assert.False(t, commenter.called)
+}
+
+func TestPlatformModeRunner_success(t *testing.T) {
+
+	ctx := &command.Context{
+		RequestCtx: context.Background(),
+		HeadRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		Pull: models.PullRequest{
+			Num: 1,
+			BaseRepo: models.Repo{
+				FullName: "owner/base",
+			},
+		},
+	}
+	cmd := &command.Comment{
+		Workspace: "hi",
+	}
+
+	builder := &TestBuilder{
+		Type: valid.PlatformWorkflowMode,
+	}
+	runner := &testCMDRunner{
+		t:           t,
+		expectedCmd: cmd,
+	}
+
+	commenter := &TestCommenter{
+		expectedT:       t,
+		expectedComment: "Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. ",
+		expectedPullNum: 1,
+		expectedRepo:    ctx.Pull.BaseRepo,
+	}
+
+	subject := &lyftCommand.PlatformModeRunner{
+		Allocator: &testAllocator{
+			expectedFeatureName: feature.PlatformMode,
+			expectedT:           t,
+			expectedCtx:         feature.FeatureContext{RepoName: "owner/repo"},
+			expectedResult:      true,
+		},
+		Logger:  logging.NewNoopCtxLogger(t),
+		Builder: builder,
+		TemplateLoader: template.Loader[lyftCommand.LegacyApplyCommentInput]{
+			GlobalCfg: valid.GlobalCfg{},
+		},
+		VCSClient: commenter,
+		Runner:    runner,
+	}
+
+	subject.Run(ctx, cmd)
+
+	assert.True(t, runner.called)
+	assert.True(t, builder.called)
+	assert.True(t, commenter.called)
+
 }
 
 func TestPlatformModeProjectRunner_plan(t *testing.T) {
@@ -115,6 +330,7 @@ func TestPlatformModeProjectRunner_plan(t *testing.T) {
 					expectedCtx: feature.FeatureContext{
 						RepoName: "nish/repo",
 					},
+					expectedT: t,
 				},
 				Logger: logging.NewNoopCtxLogger(t),
 			}
@@ -185,6 +401,7 @@ func TestPlatformModeProjectRunner_policyCheck(t *testing.T) {
 					expectedCtx: feature.FeatureContext{
 						RepoName: "nish/repo",
 					},
+					expectedT: t,
 				},
 				Logger: logging.NewNoopCtxLogger(t),
 			}
@@ -277,6 +494,7 @@ func TestPlatformModeProjectRunner_apply(t *testing.T) {
 					expectedCtx: feature.FeatureContext{
 						RepoName: "nish/repo",
 					},
+					expectedT: t,
 				},
 				Logger: logging.NewNoopCtxLogger(t),
 			}
@@ -351,6 +569,7 @@ func TestPlatformModeProjectRunner_approvePolicies(t *testing.T) {
 					expectedCtx: feature.FeatureContext{
 						RepoName: "nish/repo",
 					},
+					expectedT: t,
 				},
 				Logger: logging.NewNoopCtxLogger(t),
 			}
@@ -421,6 +640,7 @@ func TestPlatformModeProjectRunner_version(t *testing.T) {
 					expectedCtx: feature.FeatureContext{
 						RepoName: "nish/repo",
 					},
+					expectedT: t,
 				},
 				Logger: logging.NewNoopCtxLogger(t),
 			}

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	gateway_handlers "github.com/runatlantis/atlantis/server/neptune/gateway/event"
 	"github.com/runatlantis/atlantis/server/neptune/sync"
-	"github.com/runatlantis/atlantis/server/neptune/template"
 	converters "github.com/runatlantis/atlantis/server/vcs/provider/github/converter"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github/request"
 	"github.com/uber-go/tally/v4"
@@ -45,7 +44,6 @@ func NewVCSEventsController(
 	asyncScheduler scheduler,
 	temporalClient client.Client,
 	rootConfigBuilder *gateway_handlers.RootConfigBuilder,
-	templateLoader template.Loader[any],
 	checkRunFetcher *github.CheckRunsFetcher) *VCSEventsController {
 	pullEventWorkerProxy := gateway_handlers.NewPullEventWorkerProxy(
 		snsWriter, logger,
@@ -74,7 +72,7 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, templateLoader, vcsClient),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, vcsClient),
 		logger,
 	)
 

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -37,7 +37,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/sync"
 	internalSync "github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/sync/crons"
-	"github.com/runatlantis/atlantis/server/neptune/template"
 	"github.com/runatlantis/atlantis/server/neptune/temporal"
 	middleware "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/vcs/markdown"
@@ -305,8 +304,6 @@ func NewServer(config Config) (*Server, error) {
 		ClientCreator: clientCreator,
 	}
 
-	templateLoader := template.NewLoader[any](globalCfg)
-
 	gatewayEventsController := lyft_gateway.NewVCSEventsController(
 		statsScope,
 		[]byte(config.GithubWebhookSecret),
@@ -326,7 +323,6 @@ func NewServer(config Config) (*Server, error) {
 		asyncScheduler,
 		temporalClient,
 		rootConfigBuilder,
-		templateLoader,
 		checkRunFetcher,
 	)
 


### PR DESCRIPTION
Changing the implementation from 413299b28f8f64a87538fd22dd0f2b0ec9f96000 to actually execute on legacy worker instead since we want to ensure any project level apply checks are marked green as well. 

Additionally, noticed this in another PR, that we were respecting apply requirements for neptune which doesn't make sense so we want to just pass all apply requirements and just mark all apply statuses green.