### PR TITLE
Add action required conclusion to check runs

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -188,6 +188,9 @@ func getCheckStateAndConclusion(internalState internal.CheckRunState) (string, s
 	case internal.CheckRunSuccess:
 		state = "completed"
 		conclusion = "success"
+	case internal.CheckRunActionRequired:
+		state = "completed"
+		conclusion = "action_required"
 	default:
 		state = string(internalState)
 	}

--- a/server/neptune/workflows/activities/github/checks.go
+++ b/server/neptune/workflows/activities/github/checks.go
@@ -47,12 +47,13 @@ func CreatePlanReviewAction(t PlanReviewActionType) CheckRunAction {
 type PlanReviewActionType string
 
 const (
-	CheckRunSuccess CheckRunState = "success"
-	CheckRunFailure CheckRunState = "failure"
-	CheckRunTimeout CheckRunState = "timed_out"
-	CheckRunPending CheckRunState = "in_progress"
-	CheckRunQueued  CheckRunState = "queued"
-	CheckRunUnknown CheckRunState = ""
+	CheckRunSuccess        CheckRunState = "success"
+	CheckRunFailure        CheckRunState = "failure"
+	CheckRunTimeout        CheckRunState = "timed_out"
+	CheckRunPending        CheckRunState = "in_progress"
+	CheckRunQueued         CheckRunState = "queued"
+	CheckRunActionRequired CheckRunState = "action_required"
+	CheckRunUnknown        CheckRunState = ""
 
 	Approve PlanReviewActionType = "Approve"
 	Reject  PlanReviewActionType = "Reject"

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -22,15 +22,17 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 
 	var actions []github.CheckRunAction
 	var summary string
+	state := github.CheckRunQueued
 	if lock.Status == LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
+		state = github.CheckRunActionRequired
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
 	}
 
 	for _, i := range infos {
 		err := workflow.ExecuteActivity(ctx, u.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
 			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
-			State:   github.CheckRunActionRequired,
+			State:   state,
 			Repo:    i.Repo,
 			ID:      i.CheckRunID,
 			Summary: summary,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -30,7 +30,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	for _, i := range infos {
 		err := workflow.ExecuteActivity(ctx, u.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
 			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
-			State:   github.CheckRunQueued,
+			State:   github.CheckRunActionRequired,
 			Repo:    i.Repo,
 			ID:      i.CheckRunID,
 			Summary: summary,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -39,7 +39,7 @@ func TestLockStateUpdater_unlocked(t *testing.T) {
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
 		Title: terraform.BuildCheckRunTitle(info.Root.Name),
-		State: github.CheckRunActionRequired,
+		State: github.CheckRunQueued,
 		Repo:  info.Repo,
 		ID:    info.CheckRunID,
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -39,7 +39,7 @@ func TestLockStateUpdater_unlocked(t *testing.T) {
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
 		Title: terraform.BuildCheckRunTitle(info.Root.Name),
-		State: github.CheckRunQueued,
+		State: github.CheckRunActionRequired,
 		Repo:  info.Repo,
 		ID:    info.CheckRunID,
 	}
@@ -82,7 +82,7 @@ func TestLockStateUpdater_locked(t *testing.T) {
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
 		Title:   terraform.BuildCheckRunTitle(info.Root.Name),
-		State:   github.CheckRunQueued,
+		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
 		Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -142,7 +142,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 		ExternalID: id,
 		Summary:    summary,
 		Actions:    actions,
-		State:      github.CheckRunQueued,
+		State:      github.CheckRunActionRequired,
 	}).Get(ctx, &resp)
 
 	// don't block on error here, we'll just try again later when we have our result.

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -128,9 +128,11 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	lock := n.queue.GetLockState()
 	var actions []github.CheckRunAction
 	var summary string
+	state := github.CheckRunQueued
 
 	if lock.Status == queue.LockedStatus && (root.Trigger == activity.MergeTrigger) {
 		actions = append(actions, github.CreateUnlockAction())
+		state = github.CheckRunActionRequired
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
 	}
 
@@ -142,7 +144,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 		ExternalID: id,
 		Summary:    summary,
 		Actions:    actions,
-		State:      github.CheckRunActionRequired,
+		State:      state,
 	}).Get(ctx, &resp)
 
 	// don't block on error here, we'll just try again later when we have our result.

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -134,7 +134,7 @@ func TestEnqueue(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
+		State:      github.CheckRunActionRequired,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -190,7 +190,7 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
+		State:      github.CheckRunActionRequired,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -247,7 +247,7 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
+		State:      github.CheckRunActionRequired,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -311,7 +311,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 		ExternalID: id.String(),
 		Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
 		Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
-		State:      github.CheckRunQueued,
+		State:      github.CheckRunActionRequired,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -134,7 +134,7 @@ func TestEnqueue(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunActionRequired,
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -190,7 +190,7 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunActionRequired,
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
@@ -247,7 +247,7 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 		Sha:        rev,
 		Repo:       github.Repo{Name: "nish"},
 		ExternalID: id.String(),
-		State:      github.CheckRunActionRequired,
+		State:      github.CheckRunQueued,
 	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -124,6 +124,14 @@ func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Jo
 }
 
 func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState {
+	if workflowState.Plan != nil && len(workflowState.Plan.OnWaitingActions.Actions) > 0 {
+		return github.CheckRunActionRequired
+	}
+
+	if workflowState.Apply != nil && len(workflowState.Apply.OnWaitingActions.Actions) > 0 {
+		return github.CheckRunActionRequired
+	}
+
 	if workflowState.Result.Status != state.CompleteWorkflowStatus {
 		return github.CheckRunPending
 	}

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -124,11 +124,7 @@ func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Jo
 }
 
 func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState {
-	if workflowState.Plan != nil && len(workflowState.Plan.OnWaitingActions.Actions) > 0 {
-		return github.CheckRunActionRequired
-	}
-
-	if workflowState.Apply != nil && len(workflowState.Apply.OnWaitingActions.Actions) > 0 {
+	if waitingForActionOn(workflowState.Plan) || waitingForActionOn(workflowState.Apply) {
 		return github.CheckRunActionRequired
 	}
 
@@ -145,4 +141,8 @@ func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState 
 	}
 
 	return github.CheckRunFailure
+}
+
+func waitingForActionOn(job *state.Job) bool {
+	return job != nil && job.Status == state.WaitingJobStatus && len(job.OnWaitingActions.Actions) > 0
 }

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -148,7 +148,7 @@ func TestStateReceive(t *testing.T) {
 					},
 				},
 			},
-			ExpectedCheckRunState: github.CheckRunPending,
+			ExpectedCheckRunState: github.CheckRunActionRequired,
 			ExpectedActions: []github.CheckRunAction{
 				{
 					Label:       "Confirm",


### PR DESCRIPTION
Per GH [docs](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28#about-check-runs), let's use the action required conclusion in our check run UIs when a user needs to perform an action (i.e. unlock/confirm/reject).