### PR TITLE
Add Github list open PRs activity in deploy workflow

### DIFF
--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -71,6 +71,7 @@ func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(ctx context.Context, ro
 				Credentials: workflows.AppCredentials{
 					InstallationToken: rootDeployOptions.InstallationToken,
 				},
+				DefaultBranch: repo.DefaultBranch,
 			},
 			Tags: rootCfg.Tags,
 		},

--- a/server/neptune/gateway/event/deploy_workflow_signaler_test.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler_test.go
@@ -77,12 +77,14 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 	repoName := "repo"
 	repoURL := "www.nish.com"
 	sha := "12345"
+	defaultBranch := "main"
 
 	repo := models.Repo{
-		FullName: repoFullName,
-		Owner:    repoOwner,
-		Name:     repoName,
-		CloneURL: repoURL,
+		FullName:      repoFullName,
+		Owner:         repoOwner,
+		Name:          repoName,
+		CloneURL:      repoURL,
+		DefaultBranch: defaultBranch,
 	}
 
 	user := models.User{
@@ -124,10 +126,11 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					Name: user.Username,
 				},
 				Repo: workflows.Repo{
-					FullName: repoFullName,
-					Name:     repoName,
-					Owner:    repoOwner,
-					URL:      repoURL,
+					FullName:      repoFullName,
+					Name:          repoName,
+					Owner:         repoOwner,
+					URL:           repoURL,
+					DefaultBranch: defaultBranch,
 				},
 			},
 			expectedWorkflow: workflows.Deploy,
@@ -196,10 +199,11 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					Name: user.Username,
 				},
 				Repo: workflows.Repo{
-					FullName: repoFullName,
-					Name:     repoName,
-					Owner:    repoOwner,
-					URL:      repoURL,
+					FullName:      repoFullName,
+					Name:          repoName,
+					Owner:         repoOwner,
+					URL:           repoURL,
+					DefaultBranch: defaultBranch,
 				},
 				Tags: map[string]string{
 					event.Deprecated: event.Destroy,
@@ -243,16 +247,18 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 	repoName := "repo"
 	repoURL := "www.nish.com"
 	sha := "12345"
+	defaultBranch := "main"
 
 	user := models.User{
 		Username: "test-user",
 	}
 
 	repo := models.Repo{
-		FullName: repoFullName,
-		Owner:    repoOwner,
-		Name:     repoName,
-		CloneURL: repoURL,
+		FullName:      repoFullName,
+		Owner:         repoOwner,
+		Name:          repoName,
+		CloneURL:      repoURL,
+		DefaultBranch: defaultBranch,
 	}
 
 	version, err := version.NewVersion("1.0.3")
@@ -288,10 +294,11 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 				Name: user.Username,
 			},
 			Repo: workflows.Repo{
-				FullName: repoFullName,
-				Name:     repoName,
-				Owner:    repoOwner,
-				URL:      repoURL,
+				FullName:      repoFullName,
+				Name:          repoName,
+				Owner:         repoOwner,
+				URL:           repoURL,
+				DefaultBranch: defaultBranch,
 			},
 		},
 		expectedWorkflow: workflows.Deploy,

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -300,9 +300,7 @@ func (a *githubActivities) GithubListOpenPRs(ctx context.Context, request ListOp
 	pullRequests := []internal.PullRequest{}
 	for _, pullRequest := range prs {
 		pullRequests = append(pullRequests, internal.PullRequest{
-			ID:     pullRequest.GetID(),
 			Number: pullRequest.GetNumber(),
-			State:  pullRequest.GetState(),
 		})
 	}
 

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -19,6 +19,8 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 )
 
+const PullRequestOpenState = "open"
+
 type ClientContext struct {
 	InstallationToken int64
 	context.Context
@@ -290,8 +292,7 @@ type ListOpenPRsResponse struct {
 }
 
 func (a *githubActivities) GithubListOpenPRs(ctx context.Context, request ListOpenPRsRequest) (ListOpenPRsResponse, error) {
-	state := "open"
-	prs, err := a.Client.ListPullRequests(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, request.Repo.DefaultBranch, state)
+	prs, err := a.Client.ListPullRequests(internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken), request.Repo.Owner, request.Repo.Name, request.Repo.DefaultBranch, PullRequestOpenState)
 	if err != nil {
 		return ListOpenPRsResponse{}, errors.Wrap(err, "listing open pull requests")
 	}

--- a/server/neptune/workflows/activities/github/pull.go
+++ b/server/neptune/workflows/activities/github/pull.go
@@ -2,7 +2,5 @@ package github
 
 // Add more fields as necessary
 type PullRequest struct {
-	ID     int64
 	Number int
-	State  string
 }

--- a/server/neptune/workflows/activities/github/pull.go
+++ b/server/neptune/workflows/activities/github/pull.go
@@ -1,0 +1,8 @@
+package github
+
+// Add more fields as necessary
+type PullRequest struct {
+	ID     int64
+	Number int
+	State  string
+}

--- a/server/neptune/workflows/activities/github/repo.go
+++ b/server/neptune/workflows/activities/github/repo.go
@@ -8,6 +8,8 @@ type Repo struct {
 	Name string
 	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
 	URL string
+	// Repo's default branch
+	DefaultBranch string
 
 	Credentials AppCredentials
 }

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -292,3 +292,7 @@ func (c *testGithubClient) CompareCommits(ctx internalGithub.Context, owner, rep
 		Status: github.String("ahead"),
 	}, &github.Response{}, nil
 }
+
+func (c *testGithubClient) ListPullRequests(ctx internalGithub.Context, owner, repo, base, state string) ([]*github.PullRequest, error) {
+	return []*github.PullRequest{}, nil
+}

--- a/server/neptune/workflows/internal/deploy/request/converter/repo.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/repo.go
@@ -13,6 +13,7 @@ func Repo(external request.Repo) github.Repo {
 		Credentials: github.AppCredentials{
 			InstallationToken: external.Credentials.InstallationToken,
 		},
+		DefaultBranch: external.DefaultBranch,
 	}
 }
 

--- a/server/neptune/workflows/internal/deploy/request/repo.go
+++ b/server/neptune/workflows/internal/deploy/request/repo.go
@@ -12,6 +12,8 @@ type Repo struct {
 	Name string
 	// URL is the ssh clone URL (ie. git@github.com:owner/repo.git)
 	URL string
+	// Repo's default branch
+	DefaultBranch string
 
 	Credentials AppCredentials
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -109,7 +109,9 @@ func (p *Deployer) rebaseOpenPRsForRoot(ctx workflow.Context, repo github.Repo) 
 	// configure infinite retries and ScheduleToCloseTimeout to 8 hours to allow for the GH API Ratelimit to revive if we hit the ratelimit since it resets every hour
 	opts := workflow.GetActivityOptions(ctx)
 	opts.ScheduleToCloseTimeout = RebaseScheduleToCloseTimeout
-	opts.RetryPolicy.MaximumAttempts = 0
+	opts.RetryPolicy = &temporal.RetryPolicy{
+		MaximumAttempts: 0,
+	}
 	ctx = workflow.WithActivityOptions(ctx, opts)
 
 	// list open PRs

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -65,6 +65,10 @@ func (t *testDeployActivity) AuditJob(ctx context.Context, request activities.Au
 	return nil
 }
 
+func (t *testDeployActivity) GithubListOpenPRs(ctx context.Context, request activities.ListOpenPRsRequest) (activities.ListOpenPRsResponse, error) {
+	return activities.ListOpenPRsResponse{}, nil
+}
+
 type deployerRequest struct {
 	Info         terraform.DeploymentInfo
 	LatestDeploy *deployment.Info

--- a/server/neptune/workflows/internal/terraform/version/name.go
+++ b/server/neptune/workflows/internal/terraform/version/name.go
@@ -1,5 +1,10 @@
 package version
 
-// This version removes an activity that computes env vars from commands and instead opts
-// for lazy loading within each of the following steps.
-const LazyLoadEnvVars = "lazy-load-env-vars"
+const (
+	// This version removes an activity that computes env vars from commands and instead opts
+	// for lazy loading within each of the following steps.
+	LazyLoadEnvVars = "lazy-load-env-vars"
+
+	// This version allows rebasing open PRs for a root once a deploy is complete
+	RebaseOpenPRs = "rebase-open-prs"
+)


### PR DESCRIPTION
This PR adds `ListOpenPRs` activity to the deploy workflow. We will use the open PRs to identify if it needs rebase based on the files modified in a subsequent PR. 
