### PR TITLE
List Modified Files in a PR and Identify if a PR needs to be rebased

### DIFF
--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -27,10 +27,10 @@ type DeployWorkflowSignaler struct {
 func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(ctx context.Context, rootCfg *valid.MergedProjectCfg, rootDeployOptions RootDeployOptions) (client.WorkflowRun, error) {
 	options := client.StartWorkflowOptions{
 		TaskQueue: workflows.DeployTaskQueue,
-		SearchAttributes: map[string]interface{}{
-			"atlantis_repository": rootDeployOptions.Repo.FullName,
-			"atlantis_root":       rootCfg.Name,
-		},
+		// SearchAttributes: map[string]interface{}{
+		// 	"atlantis_repository": rootDeployOptions.Repo.FullName,
+		// 	"atlantis_root":       rootCfg.Name,
+		// },
 	}
 
 	repo := rootDeployOptions.Repo

--- a/server/neptune/gateway/event/deploy_workflow_signaler.go
+++ b/server/neptune/gateway/event/deploy_workflow_signaler.go
@@ -27,10 +27,10 @@ type DeployWorkflowSignaler struct {
 func (d *DeployWorkflowSignaler) SignalWithStartWorkflow(ctx context.Context, rootCfg *valid.MergedProjectCfg, rootDeployOptions RootDeployOptions) (client.WorkflowRun, error) {
 	options := client.StartWorkflowOptions{
 		TaskQueue: workflows.DeployTaskQueue,
-		// SearchAttributes: map[string]interface{}{
-		// 	"atlantis_repository": rootDeployOptions.Repo.FullName,
-		// 	"atlantis_root":       rootCfg.Name,
-		// },
+		SearchAttributes: map[string]interface{}{
+			"atlantis_repository": rootDeployOptions.Repo.FullName,
+			"atlantis_root":       rootCfg.Name,
+		},
 	}
 
 	repo := rootDeployOptions.Repo

--- a/server/neptune/workflows/activities/github/client.go
+++ b/server/neptune/workflows/activities/github/client.go
@@ -94,3 +94,20 @@ func (c *Client) ListPullRequests(ctx Context, owner, repo, base, state string) 
 
 	return gh_helper.Iterate(ctx, run)
 }
+
+func (c *Client) ListModifiedFiles(ctx Context, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+	if err != nil {
+		return nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	run := func(ctx context.Context, nextPage int) ([]*github.CommitFile, *github.Response, error) {
+		listOptions := github.ListOptions{
+			PerPage: 100,
+		}
+		listOptions.Page = nextPage
+		return client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, &listOptions)
+	}
+
+	return gh_helper.Iterate(ctx, run)
+}

--- a/server/neptune/workflows/activities/terraform/root.go
+++ b/server/neptune/workflows/activities/terraform/root.go
@@ -10,12 +10,15 @@ type Root struct {
 	Name string
 
 	// Path is the relative path from the repo
-	Path      string
-	TfVersion string
-	Apply     execute.Job
-	Plan      PlanJob
-	Trigger   Trigger
-	Rerun     bool
+	Path string
+
+	// When modified is a list of docker style filepaths that correspond to this root
+	WhenModified []string
+	TfVersion    string
+	Apply        execute.Job
+	Plan         PlanJob
+	Trigger      Trigger
+	Rerun        bool
 }
 
 func (r Root) WithPlanApprovalOverride(a PlanApproval) Root {

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -341,8 +341,9 @@ func (c *testGithubClient) ListModifiedFiles(ctx internalGithub.Context, owner, 
 	}]
 
 	for _, file := range modifiedFiles.Files {
+		fileCopy := file // creating a copy to avoid memory aliasing in for loop
 		files = append(files, &github.CommitFile{
-			Filename: &file,
+			Filename: &fileCopy,
 		})
 	}
 	return files, nil

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -20,10 +20,11 @@ func Root(external request.Root) terraform.Root {
 				Type: terraform.PlanApprovalType(external.PlanApproval.Type),
 			},
 		},
-		Path:      external.RepoRelPath,
-		TfVersion: external.TfVersion,
-		Trigger:   terraform.Trigger(external.Trigger),
-		Rerun:     external.Rerun,
+		Path:         external.RepoRelPath,
+		WhenModified: external.WhenModified,
+		TfVersion:    external.TfVersion,
+		Trigger:      terraform.Trigger(external.Trigger),
+		Rerun:        external.Rerun,
 	}
 
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -142,7 +142,7 @@ func (p *Deployer) rebaseOpenPRsForRoot(ctx workflow.Context, requestedDeploymen
 		listFilesErr := future.Get(ctx, &result)
 		if listFilesErr != nil {
 			logger.Error(ctx, "error listing modified files in PR", key.ErrKey, listFilesErr, "pull_num", pullRequest.Number)
-			prsToRebase = append(prsToRebase, pullRequest)
+			prsToRebase = append(prsToRebase, pullRequest) // nolint: staticcheck
 			continue
 		}
 
@@ -152,7 +152,7 @@ func (p *Deployer) rebaseOpenPRsForRoot(ctx workflow.Context, requestedDeploymen
 		}
 
 		// rebase PR if err is not nil as a safety measure
-		prsToRebase = append(prsToRebase, pullRequest)
+		prsToRebase = append(prsToRebase, pullRequest) // nolint: staticcheck
 	}
 
 	// TODO: Use prsToRebase list to request rebase

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -57,12 +57,12 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 
 		// allows all signals to be received even in a cancellation state
 		WaitForCancellation: true,
-		SearchAttributes: map[string]interface{}{
-			"atlantis_repository": deploymentInfo.Repo.GetFullName(),
-			"atlantis_root":       deploymentInfo.Root.Name,
-			"atlantis_trigger":    deploymentInfo.Root.Trigger,
-			"atlantis_revision":   deploymentInfo.Revision,
-		},
+		// SearchAttributes: map[string]interface{}{
+		// 	"atlantis_repository": deploymentInfo.Repo.GetFullName(),
+		// 	"atlantis_root":       deploymentInfo.Root.Name,
+		// 	"atlantis_trigger":    deploymentInfo.Root.Trigger,
+		// 	"atlantis_revision":   deploymentInfo.Revision,
+		// },
 	})
 
 	request := terraform.Request{


### PR DESCRIPTION
In #529, we added support for listing open PRs in a repository. This PR adds support to list modified files in each of the open PR in parallel and identify if it needs to be rebased based on the `when_modified` config. 

