### PR TITLE
Create a queued check run in gateway

### DIFF
--- a/server/events/command/vcs.go
+++ b/server/events/command/vcs.go
@@ -107,6 +107,8 @@ func (d *VCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx Project
 func (d *VCSStatusUpdater) statusDescription(status models.VCSStatus) string {
 	var description string
 	switch status {
+	case models.QueuedVCSStatus:
+		description = "queued."
 	case models.PendingVCSStatus:
 		description = "in progress..."
 	case models.FailedVCSStatus:

--- a/server/events/command/vcs_test.go
+++ b/server/events/command/vcs_test.go
@@ -35,6 +35,11 @@ func TestUpdateCombined(t *testing.T) {
 		expDescrip string
 	}{
 		{
+			status:     models.QueuedVCSStatus,
+			command:    command.Plan,
+			expDescrip: "Plan queued.",
+		},
+		{
 			status:     models.PendingVCSStatus,
 			command:    command.Plan,
 			expDescrip: "Plan in progress...",
@@ -99,6 +104,13 @@ func TestUpdateCombinedCount(t *testing.T) {
 		numTotal   int
 		expDescrip string
 	}{
+		{
+			status:     models.QueuedVCSStatus,
+			command:    command.Plan,
+			numSuccess: 0,
+			numTotal:   2,
+			expDescrip: "0/2 projects planned successfully.",
+		},
 		{
 			status:     models.PendingVCSStatus,
 			command:    command.Plan,

--- a/server/events/models/commit_status.go
+++ b/server/events/models/commit_status.go
@@ -23,6 +23,7 @@ const (
 	PendingVCSStatus VCSStatus = iota
 	SuccessVCSStatus
 	FailedVCSStatus
+	QueuedVCSStatus
 )
 
 func (s VCSStatus) String() string {
@@ -33,6 +34,8 @@ func (s VCSStatus) String() string {
 		return "success"
 	case FailedVCSStatus:
 		return "failed"
+	case QueuedVCSStatus:
+		return "queued"
 	}
 	return "failed"
 }

--- a/server/events/models/commit_status_test.go
+++ b/server/events/models/commit_status_test.go
@@ -10,6 +10,7 @@ import (
 func TestStatus_String(t *testing.T) {
 	cases := map[models.VCSStatus]string{
 		models.PendingVCSStatus: "pending",
+		models.QueuedVCSStatus:  "queued",
 		models.SuccessVCSStatus: "success",
 		models.FailedVCSStatus:  "failed",
 	}

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -554,6 +554,8 @@ func (g *GithubClient) updateCheckRun(ctx context.Context, request types.UpdateS
 
 func (g *GithubClient) resolveState(state models.VCSStatus) string {
 	switch state {
+	case models.QueuedVCSStatus:
+		return "Queued"
 	case models.PendingVCSStatus:
 		return "In Progress"
 	case models.SuccessVCSStatus:
@@ -645,6 +647,9 @@ func (g *GithubClient) resolveChecksStatus(state models.VCSStatus) (string, stri
 	case models.FailedVCSStatus:
 		status = Completed
 		conclusion = Failure
+
+	case models.QueuedVCSStatus:
+		status = Queued
 	}
 
 	return status.String(), conclusion.String()

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -111,7 +111,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 			cmdCtx.Log.ErrorContext(cmdCtx.RequestCtx, errors.Wrap(err, "updating atlantis apply status").Error())
 		}
 	}
-	if _, err := r.VCSStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, "", "Adding request to the queue"); err != nil {
+	if _, err := r.VCSStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, "", "Request received. Adding to the queue..."); err != nil {
 		cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 	return true, nil

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -111,7 +111,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 			cmdCtx.Log.ErrorContext(cmdCtx.RequestCtx, errors.Wrap(err, "updating atlantis apply status").Error())
 		}
 	}
-	if _, err := r.VCSStatusUpdater.UpdateCombinedCount(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, 0, 0, ""); err != nil {
+	if _, err := r.VCSStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, "", ""); err != nil {
 		cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 	return true, nil

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -111,7 +111,7 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 			cmdCtx.Log.ErrorContext(cmdCtx.RequestCtx, errors.Wrap(err, "updating atlantis apply status").Error())
 		}
 	}
-	if _, err := r.VCSStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, "", ""); err != nil {
+	if _, err := r.VCSStatusUpdater.UpdateCombined(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, "", "Adding request to the queue"); err != nil {
 		cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
 	}
 	return true, nil

--- a/server/lyft/gateway/autoplan_builder.go
+++ b/server/lyft/gateway/autoplan_builder.go
@@ -111,6 +111,9 @@ func (r *AutoplanValidator) isValid(ctx context.Context, logger logging.Logger, 
 			cmdCtx.Log.ErrorContext(cmdCtx.RequestCtx, errors.Wrap(err, "updating atlantis apply status").Error())
 		}
 	}
+	if _, err := r.VCSStatusUpdater.UpdateCombinedCount(ctx, baseRepo, pull, models.QueuedVCSStatus, command.Plan, 0, 0, ""); err != nil {
+		cmdCtx.Log.WarnContext(cmdCtx.RequestCtx, fmt.Sprintf("unable to update commit status: %s", err))
+	}
 	return true, nil
 }
 

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -157,14 +157,13 @@ func TestIsValid_TerraformChanges(t *testing.T) {
 
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(context.TODO(), log, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	Assert(t, containsTerraformChanges == true, "should have terraform changes")
-	vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombinedCount(
+	vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombined(
 		matchers.AnyContextContext(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
 		matchers.EqModelsVcsStatus(models.QueuedVCSStatus),
 		matchers.AnyModelsCommandName(),
-		AnyInt(),
-		AnyInt(),
+		AnyString(),
 		AnyString())
 	workingDir.VerifyWasCalledOnce().Delete(matchers.AnyModelsRepo(), matchers.AnyModelsPullRequest())
 	workingDirLocker.VerifyWasCalledOnce().TryLock(AnyString(), AnyInt(), AnyString())
@@ -219,14 +218,13 @@ func TestIsValid_TerraformChanges_PlatformMode(t *testing.T) {
 
 			containsTerraformChanges := autoplanValidator.InstrumentedIsValid(context.TODO(), log, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 			Assert(t, containsTerraformChanges == true, "should have terraform changes")
-			vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombinedCount(
+			vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombined(
 				matchers.AnyContextContext(),
 				matchers.AnyModelsRepo(),
 				matchers.AnyModelsPullRequest(),
 				matchers.EqModelsVcsStatus(models.QueuedVCSStatus),
-				matchers.AnyModelsCommandName(),
-				AnyInt(),
-				AnyInt(),
+				matchers.EqCommandName(command.Plan),
+				AnyString(),
 				AnyString())
 
 			// Should only happen if both the conditions are met
@@ -235,8 +233,8 @@ func TestIsValid_TerraformChanges_PlatformMode(t *testing.T) {
 					matchers.AnyContextContext(),
 					matchers.AnyModelsRepo(),
 					matchers.AnyModelsPullRequest(),
-					matchers.AnyModelsVcsStatus(),
-					matchers.AnyModelsCommandName(),
+					matchers.EqModelsVcsStatus(models.SuccessVCSStatus),
+					matchers.EqCommandName(command.Apply),
 					AnyString(),
 					AnyString(),
 				)

--- a/server/lyft/gateway/autoplan_builder_test.go
+++ b/server/lyft/gateway/autoplan_builder_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"context"
 	"errors"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"testing"
 
 	. "github.com/petergtz/pegomock"
@@ -39,6 +40,7 @@ func (t *testFeatureAllocator) ShouldAllocate(featureID feature.Name, featureCtx
 	return t.Enabled, t.Err
 }
 
+// TODO: replace mock library with our own mocks
 func setupAutoplan(t *testing.T) *vcsmocks.MockClient {
 	RegisterMockTestingT(t)
 	projectCommandBuilder = mocks.NewMockProjectCommandBuilder()
@@ -155,11 +157,11 @@ func TestIsValid_TerraformChanges(t *testing.T) {
 
 	containsTerraformChanges := autoplanValidator.InstrumentedIsValid(context.TODO(), log, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 	Assert(t, containsTerraformChanges == true, "should have terraform changes")
-	vcsStatusUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+	vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombinedCount(
 		matchers.AnyContextContext(),
 		matchers.AnyModelsRepo(),
 		matchers.AnyModelsPullRequest(),
-		matchers.AnyModelsVcsStatus(),
+		matchers.EqModelsVcsStatus(models.QueuedVCSStatus),
 		matchers.AnyModelsCommandName(),
 		AnyInt(),
 		AnyInt(),
@@ -217,11 +219,11 @@ func TestIsValid_TerraformChanges_PlatformMode(t *testing.T) {
 
 			containsTerraformChanges := autoplanValidator.InstrumentedIsValid(context.TODO(), log, fixtures.GithubRepo, fixtures.GithubRepo, fixtures.Pull, fixtures.User)
 			Assert(t, containsTerraformChanges == true, "should have terraform changes")
-			vcsStatusUpdater.VerifyWasCalled(Never()).UpdateCombinedCount(
+			vcsStatusUpdater.VerifyWasCalled(Once()).UpdateCombinedCount(
 				matchers.AnyContextContext(),
 				matchers.AnyModelsRepo(),
 				matchers.AnyModelsPullRequest(),
-				matchers.AnyModelsVcsStatus(),
+				matchers.EqModelsVcsStatus(models.QueuedVCSStatus),
 				matchers.AnyModelsCommandName(),
 				AnyInt(),
 				AnyInt(),

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/events/command"
 	"net/http"
 
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
@@ -44,7 +45,8 @@ func NewVCSEventsController(
 	asyncScheduler scheduler,
 	temporalClient client.Client,
 	rootConfigBuilder *gateway_handlers.RootConfigBuilder,
-	checkRunFetcher *github.CheckRunsFetcher) *VCSEventsController {
+	checkRunFetcher *github.CheckRunsFetcher,
+	vcsStatusUpdater *command.VCSStatusUpdater) *VCSEventsController {
 	pullEventWorkerProxy := gateway_handlers.NewPullEventWorkerProxy(
 		snsWriter, logger,
 	)
@@ -72,7 +74,7 @@ func NewVCSEventsController(
 		commentParser,
 		repoAllowlistChecker,
 		vcsClient,
-		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, vcsClient),
+		gateway_handlers.NewCommentEventWorkerProxy(logger, snsWriter, featureAllocator, asyncScheduler, rootDeployer, vcsClient, vcsStatusUpdater),
 		logger,
 	)
 

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -3,6 +3,7 @@ package event
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/runatlantis/atlantis/server/events/vcs"
@@ -20,6 +21,10 @@ import (
 const warningMessage = "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and confirm the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
 
 type LegacyApplyCommentInput struct{}
+
+type statusUpdater interface {
+	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error)
+}
 
 // Comment is our internal representation of a vcs based comment event.
 type Comment struct {
@@ -40,24 +45,27 @@ func NewCommentEventWorkerProxy(
 	allocator feature.Allocator,
 	scheduler scheduler,
 	rootDeployer rootDeployer,
-	vcsClient vcs.Client) *CommentEventWorkerProxy {
+	vcsClient vcs.Client,
+	vcsStatusUpdater statusUpdater) *CommentEventWorkerProxy {
 	return &CommentEventWorkerProxy{
-		logger:       logger,
-		snsWriter:    snsWriter,
-		allocator:    allocator,
-		scheduler:    scheduler,
-		vcsClient:    vcsClient,
-		rootDeployer: rootDeployer,
+		logger:           logger,
+		snsWriter:        snsWriter,
+		allocator:        allocator,
+		scheduler:        scheduler,
+		vcsClient:        vcsClient,
+		rootDeployer:     rootDeployer,
+		vcsStatusUpdater: vcsStatusUpdater,
 	}
 }
 
 type CommentEventWorkerProxy struct {
-	logger       logging.Logger
-	snsWriter    Writer
-	allocator    feature.Allocator
-	scheduler    scheduler
-	vcsClient    vcs.Client
-	rootDeployer rootDeployer
+	logger           logging.Logger
+	snsWriter        Writer
+	allocator        feature.Allocator
+	scheduler        scheduler
+	vcsClient        vcs.Client
+	rootDeployer     rootDeployer
+	vcsStatusUpdater statusUpdater
 }
 
 func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
@@ -67,7 +75,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 
 	if err != nil {
 		p.logger.ErrorContext(ctx, "unable to allocate platform mode")
-		return p.forwardToSns(ctx, request)
+		return p.handleLegacyComment(ctx, request, event, cmd)
 	}
 
 	if shouldAllocate && cmd.ForceApply {
@@ -80,12 +88,20 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 		})
 
 	}
+	return p.handleLegacyComment(ctx, request, event, cmd)
+}
+
+func (p *CommentEventWorkerProxy) handleLegacyComment(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
+	if cmd.Name == command.Plan || cmd.Name == command.Apply {
+		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", ""); err != nil {
+			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
+		}
+	}
 	return p.forwardToSns(ctx, request)
 }
 
 func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *http.BufferedRequest) error {
 	buffer := bytes.NewBuffer([]byte{})
-
 	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
 		return errors.Wrap(err, "writing request to buffer")
 	}
@@ -93,7 +109,6 @@ func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *htt
 	if err := p.snsWriter.WriteWithContext(ctx, buffer.Bytes()); err != nil {
 		return errors.Wrap(err, "writing buffer to sns")
 	}
-
 	p.logger.InfoContext(ctx, "proxied request to sns")
 
 	return nil

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -93,7 +93,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 
 func (p *CommentEventWorkerProxy) handleLegacyComment(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
 	if cmd.Name == command.Plan || cmd.Name == command.Apply {
-		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", ""); err != nil {
+		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Adding request to the queue"); err != nil {
 			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
 		}
 	}

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -93,7 +93,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 
 func (p *CommentEventWorkerProxy) handleLegacyComment(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
 	if cmd.Name == command.Plan || cmd.Name == command.Apply {
-		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Adding request to the queue"); err != nil {
+		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Request received. Adding to the queue..."); err != nil {
 			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
 		}
 	}

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -239,13 +239,14 @@ func NewServer(config Config) (*Server, error) {
 	asyncScheduler := sync.NewAsyncScheduler(ctxLogger, syncScheduler)
 
 	gatewaySnsWriter := sns.NewWriterWithStats(session, config.SNSTopicArn, statsScope.SubScope("aws.sns.gateway"))
+	vcsStatusUpdater := &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: config.GithubStatusName}}
 	autoplanValidator := &lyft_gateway.AutoplanValidator{
 		Scope:                         statsScope.SubScope("validator"),
 		VCSClient:                     vcsClient,
 		PreWorkflowHooksCommandRunner: preWorkflowHooksCommandRunner,
 		Drainer:                       drainer,
 		GlobalCfg:                     globalCfg,
-		VCSStatusUpdater:              &command.VCSStatusUpdater{Client: vcsClient, TitleBuilder: vcs.StatusTitleBuilder{TitlePrefix: config.GithubStatusName}},
+		VCSStatusUpdater:              vcsStatusUpdater,
 		PrjCmdBuilder:                 projectCommandBuilder,
 		OutputUpdater:                 outputUpdater,
 		WorkingDir:                    workingDir,
@@ -325,6 +326,7 @@ func NewServer(config Config) (*Server, error) {
 		temporalClient,
 		rootConfigBuilder,
 		checkRunFetcher,
+		vcsStatusUpdater,
 	)
 
 	router := mux.NewRouter()


### PR DESCRIPTION
For plan/apply comments and autoplan events, let's create a queued combined check run to notify the user that their terraform changes were received.

Next step: look into doing the same for temporal deploy check runs