### PR TITLE
Add check run cache.

### DIFF
--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -116,7 +116,10 @@ func (s *S3) GetContainerName() string {
 
 type Metrics struct {
 	Statsd *Statsd
+	Log    *Log
 }
+
+type Log struct{}
 
 type Statsd struct {
 	Port         string

--- a/server/metrics/noop.go
+++ b/server/metrics/noop.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/uber-go/tally/v4"
+)
+
+// newNoopReporter returns a tally reporter that does nothing.
+func newNoopReporter() tally.StatsReporter {
+	return &noopReporter{}
+}
+
+type noopReporter struct{}
+
+// Capabilities interface.
+
+func (r *noopReporter) Reporting() bool {
+	return true
+}
+
+func (r *noopReporter) Tagging() bool {
+	return true
+}
+
+func (r *noopReporter) Capabilities() tally.Capabilities {
+	return r
+}
+
+// Reporter interface.
+
+func (r *noopReporter) Flush() {
+	// Silence.
+}
+
+func (r *noopReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	// Silence.
+}
+
+func (r *noopReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	// Silence.
+}
+
+func (r *noopReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	// Silence.
+}
+
+func (r *noopReporter) ReportHistogramValueSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound float64,
+	samples int64,
+) {
+	// Silence.
+}
+
+func (r *noopReporter) ReportHistogramDurationSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound time.Duration,
+	samples int64,
+) {
+	// Silence.
+}

--- a/server/metrics/scope.go
+++ b/server/metrics/scope.go
@@ -49,9 +49,13 @@ func NewScopeWithReporter(cfg valid.Metrics, logger logging.Logger, statsNamespa
 }
 
 func NewReporter(cfg valid.Metrics, logger logging.Logger) (tally.StatsReporter, error) {
-	if cfg.Statsd == nil {
+	if cfg.Log != nil {
 		// return logging reporter and proceed
 		return newLoggingReporter(logger), nil
+	}
+
+	if cfg.Statsd == nil {
+		return newNoopReporter(), nil
 	}
 
 	statsdCfg := cfg.Statsd

--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -134,10 +134,11 @@ func (h *CheckRunHandler) signalPlanReviewWorkflowChannel(ctx context.Context, e
 }
 
 func (h *CheckRunHandler) signalUnlockWorkflowChannel(ctx context.Context, event CheckRun, rootName string) error {
+	workflowID := buildDeployWorkflowID(event.Repo.FullName, rootName)
 	err := h.DeploySignaler.SignalWorkflow(
 		ctx,
 		// deploy workflow id is repo||root (the name of the check run is the root)
-		buildDeployWorkflowID(event.Repo.FullName, rootName),
+		workflowID,
 		// keeping this empty is fine since temporal will find the currently running workflow
 		"",
 		workflows.DeployUnlockSignalName,
@@ -145,9 +146,9 @@ func (h *CheckRunHandler) signalUnlockWorkflowChannel(ctx context.Context, event
 			User: event.User.Username,
 		})
 	if err != nil {
-		return errors.Wrapf(err, "signaling workflow with id: %s", event.ExternalID)
+		return errors.Wrapf(err, "signaling workflow with id: %s", workflowID)
 	}
-	h.Logger.InfoContext(ctx, fmt.Sprintf("Signaled workflow with id %s to unlock", event.ExternalID))
+	h.Logger.InfoContext(ctx, fmt.Sprintf("Signaled workflow with id %s to unlock", workflowID))
 	return nil
 }
 

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -66,19 +66,31 @@ type CreateCheckRunRequest struct {
 }
 
 type UpdateCheckRunRequest struct {
-	Title   string
-	State   internal.CheckRunState
-	Actions []internal.CheckRunAction
-	Repo    internal.Repo
-	ID      int64
-	Summary string
+	Title      string
+	State      internal.CheckRunState
+	Actions    []internal.CheckRunAction
+	Repo       internal.Repo
+	ID         int64
+	Summary    string
+	ExternalID string
 }
 
 type CreateCheckRunResponse struct {
-	ID int64
+	ID     int64
+	Status string
 }
+
+func (r CreateCheckRunResponse) GetStatus() string {
+	return r.Status
+}
+
 type UpdateCheckRunResponse struct {
-	ID int64
+	ID     int64
+	Status string
+}
+
+func (r UpdateCheckRunResponse) GetStatus() string {
+	return r.Status
 }
 
 func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request UpdateCheckRunRequest) (UpdateCheckRunResponse, error) {
@@ -91,9 +103,10 @@ func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request Upd
 	state, conclusion := getCheckStateAndConclusion(request.State)
 
 	opts := github.UpdateCheckRunOptions{
-		Name:   request.Title,
-		Status: github.String(state),
-		Output: &output,
+		Name:       request.Title,
+		Status:     github.String(state),
+		Output:     &output,
+		ExternalID: &request.ExternalID,
 	}
 
 	// update with any actions
@@ -120,8 +133,11 @@ func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request Upd
 		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating check run")
 	}
 
+	run.GetStatus()
+
 	return UpdateCheckRunResponse{
-		ID: run.GetID(),
+		ID:     run.GetID(),
+		Status: run.GetStatus(),
 	}, nil
 }
 
@@ -167,7 +183,8 @@ func (a *githubActivities) GithubCreateCheckRun(ctx context.Context, request Cre
 	}
 
 	return CreateCheckRunResponse{
-		ID: run.GetID(),
+		ID:     run.GetID(),
+		Status: run.GetStatus(),
 	}, nil
 }
 

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -80,17 +80,9 @@ type CreateCheckRunResponse struct {
 	Status string
 }
 
-func (r CreateCheckRunResponse) GetStatus() string {
-	return r.Status
-}
-
 type UpdateCheckRunResponse struct {
 	ID     int64
 	Status string
-}
-
-func (r UpdateCheckRunResponse) GetStatus() string {
-	return r.Status
 }
 
 func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request UpdateCheckRunRequest) (UpdateCheckRunResponse, error) {
@@ -132,8 +124,6 @@ func (a *githubActivities) GithubUpdateCheckRun(ctx context.Context, request Upd
 	if err != nil {
 		return UpdateCheckRunResponse{}, errors.Wrap(err, "creating check run")
 	}
-
-	run.GetStatus()
 
 	return UpdateCheckRunResponse{
 		ID:     run.GetID(),

--- a/server/neptune/workflows/internal/config/logger/logger.go
+++ b/server/neptune/workflows/internal/config/logger/logger.go
@@ -26,9 +26,9 @@ func Error(ctx workflow.Context, msg string, additionalKVs ...interface{}) {
 	logger.Error(msg, append(kvs, additionalKVs)...)
 }
 
-func Debug(ctx workflow.Context, msg string) {
+func Debug(ctx workflow.Context, msg string, additionalKVs ...interface{}) {
 	logger := workflow.GetLogger(ctx)
 	kvs := context.ExtractFieldsAsList(ctx)
 
-	logger.Debug(msg, kvs...)
+	logger.Debug(msg, append(kvs, additionalKVs)...)
 }

--- a/server/neptune/workflows/internal/deploy/notifier/github.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github.go
@@ -1,0 +1,118 @@
+package notifier
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	KeyDelim       = "_"
+	CompleteStatus = "complete"
+)
+
+type checksActivities interface {
+	GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
+	GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
+}
+
+// GithubCheckRunCache manages the lifecycle of a given check run.  A check run is evicted
+// from the cache when it is marked completed.  This allows consumers to not have to worry about
+// passing check run ids around or determining which github api to call.
+type GithubCheckRunCache struct {
+	// state is mutable
+	deploymentCheckRunCache map[string]int64
+	activities              checksActivities
+}
+
+func NewGithubCheckRunCache(activities checksActivities) *GithubCheckRunCache {
+	return &GithubCheckRunCache{
+		deploymentCheckRunCache: map[string]int64{},
+		activities:              activities,
+	}
+}
+
+type GithubCheckRunRequest struct {
+	Title      string
+	Sha        string
+	Repo       github.Repo
+	State      github.CheckRunState
+	Actions    []github.CheckRunAction
+	Summary    string
+	ExternalID string
+}
+
+func (c *GithubCheckRunCache) CreateOrUpdate(ctx workflow.Context, deploymentID string, request GithubCheckRunRequest) (int64, error) {
+	key := deploymentID + KeyDelim + request.Title
+	checkRunID, ok := c.deploymentCheckRunCache[key]
+
+	// if we haven't created one, let's do so now
+	if !ok {
+		resp, err := c.load(ctx, request)
+		if err != nil {
+			return 0, err
+		}
+		c.deploymentCheckRunCache[key] = resp.ID
+		c.deleteIfCompleted(resp.Status, key)
+
+		return resp.ID, nil
+	}
+
+	// update existing checks
+	resp, err := c.update(ctx, request, checkRunID)
+	if err != nil {
+		return 0, err
+	}
+	c.deleteIfCompleted(resp.Status, key)
+
+	return checkRunID, nil
+}
+
+// if the check is complete, let's remove it from the map since we don't want to be updating
+// complete checks going forward.
+func (c *GithubCheckRunCache) deleteIfCompleted(status, key string) {
+	if status == CompleteStatus {
+		delete(c.deploymentCheckRunCache, key)
+	}
+}
+
+func (c *GithubCheckRunCache) update(ctx workflow.Context, request GithubCheckRunRequest, checkRunID int64) (activities.UpdateCheckRunResponse, error) {
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title:      request.Title,
+		Repo:       request.Repo,
+		State:      request.State,
+		Actions:    request.Actions,
+		Summary:    request.Summary,
+		ID:         checkRunID,
+		ExternalID: request.ExternalID,
+	}
+
+	var resp activities.UpdateCheckRunResponse
+	err := workflow.ExecuteActivity(ctx, c.activities.GithubUpdateCheckRun, updateCheckRunRequest).Get(ctx, &resp)
+	if err != nil {
+		return resp, errors.Wrapf(err, "updating check run with id: %d", checkRunID)
+	}
+	return resp, nil
+}
+
+func (c *GithubCheckRunCache) load(ctx workflow.Context, request GithubCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+	createCheckRunRequest := activities.CreateCheckRunRequest{
+		Title:      request.Title,
+		Sha:        request.Sha,
+		Repo:       request.Repo,
+		State:      request.State,
+		Actions:    request.Actions,
+		Summary:    request.Summary,
+		ExternalID: request.ExternalID,
+	}
+
+	var resp activities.CreateCheckRunResponse
+	err := workflow.ExecuteActivity(ctx, c.activities.GithubCreateCheckRun, createCheckRunRequest).Get(ctx, &resp)
+	if err != nil {
+		return resp, errors.Wrap(err, "creating check run")
+	}
+	return resp, nil
+}

--- a/server/neptune/workflows/internal/deploy/notifier/github_test.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github_test.go
@@ -73,8 +73,7 @@ func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
 		Actions: []github.CheckRunAction{
 			github.CreatePlanReviewAction(github.Approve),
 		},
-		Summary:    "some summary",
-		ExternalID: "someid",
+		Summary: "some summary",
 	}
 
 	testRequest2 := notifier.GithubCheckRunRequest{
@@ -83,9 +82,8 @@ func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunSuccess,
-		Summary:    "some summary 2",
-		ExternalID: "someid",
+		State:   github.CheckRunSuccess,
+		Summary: "some summary 2",
 	}
 
 	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
@@ -95,7 +93,7 @@ func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
 		State:      testRequest1.State,
 		Actions:    testRequest1.Actions,
 		Summary:    testRequest1.Summary,
-		ExternalID: testRequest1.ExternalID,
+		ExternalID: "1234",
 	}).Return(activities.CreateCheckRunResponse{
 		ID: 1,
 	}, nil)
@@ -107,10 +105,10 @@ func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
 		State:      testRequest2.State,
 		Actions:    testRequest2.Actions,
 		Summary:    testRequest2.Summary,
-		ExternalID: testRequest2.ExternalID,
+		ExternalID: "1234",
 	}).Return(activities.UpdateCheckRunResponse{
 		ID:     1,
-		Status: "complete",
+		Status: "completed",
 	}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, request{
@@ -152,9 +150,8 @@ func TestGithubCheckRunCache_CreatesAcrossDeploymentIDs(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunQueued,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
 	}
 
 	testRequest2 := notifier.GithubCheckRunRequest{
@@ -163,12 +160,10 @@ func TestGithubCheckRunCache_CreatesAcrossDeploymentIDs(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunQueued,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
 	}
 
-	var id int64
 	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
 		Title:      testRequest1.Title,
 		Sha:        testRequest1.Sha,
@@ -176,13 +171,22 @@ func TestGithubCheckRunCache_CreatesAcrossDeploymentIDs(t *testing.T) {
 		State:      testRequest1.State,
 		Actions:    testRequest1.Actions,
 		Summary:    testRequest1.Summary,
-		ExternalID: testRequest1.ExternalID,
-	}).Return(func(ctx context.Context, r activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
-		id++
-		return activities.CreateCheckRunResponse{
-			ID: id,
-		}, nil
-	}).Twice()
+		ExternalID: "1234",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil).Once()
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "12345",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 2,
+	}, nil).Once()
 
 	env.ExecuteWorkflow(testWorkflow, request{
 		Requests: []struct {
@@ -223,9 +227,8 @@ func TestGithubCheckRunCache_CreatesCompleted(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunQueued,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
 	}
 
 	testRequest2 := notifier.GithubCheckRunRequest{
@@ -234,9 +237,8 @@ func TestGithubCheckRunCache_CreatesCompleted(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunQueued,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
 	}
 
 	var id int64
@@ -247,12 +249,12 @@ func TestGithubCheckRunCache_CreatesCompleted(t *testing.T) {
 		State:      testRequest1.State,
 		Actions:    testRequest1.Actions,
 		Summary:    testRequest1.Summary,
-		ExternalID: testRequest1.ExternalID,
+		ExternalID: "1234",
 	}).Return(func(ctx context.Context, r activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
 		id++
 		return activities.CreateCheckRunResponse{
 			ID:     id,
-			Status: "complete",
+			Status: "completed",
 		}, nil
 	}).Twice()
 
@@ -295,9 +297,8 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunQueued,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
 	}
 
 	testRequest2 := notifier.GithubCheckRunRequest{
@@ -309,9 +310,8 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		Actions: []github.CheckRunAction{
 			github.CreatePlanReviewAction(github.Approve),
 		},
-		State:      github.CheckRunActionRequired,
-		Summary:    "some summary 2",
-		ExternalID: "someid",
+		State:   github.CheckRunActionRequired,
+		Summary: "some summary 2",
 	}
 
 	testRequest3 := notifier.GithubCheckRunRequest{
@@ -320,9 +320,8 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		Repo: github.Repo{
 			Name: "repo",
 		},
-		State:      github.CheckRunPending,
-		Summary:    "some summary",
-		ExternalID: "someid",
+		State:   github.CheckRunPending,
+		Summary: "some summary",
 	}
 
 	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
@@ -332,7 +331,7 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		State:      testRequest1.State,
 		Actions:    testRequest1.Actions,
 		Summary:    testRequest1.Summary,
-		ExternalID: testRequest1.ExternalID,
+		ExternalID: "1234",
 	}).Return(activities.CreateCheckRunResponse{
 		ID: 1,
 	}, nil)
@@ -344,10 +343,10 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		State:      testRequest2.State,
 		Actions:    testRequest2.Actions,
 		Summary:    testRequest2.Summary,
-		ExternalID: testRequest2.ExternalID,
+		ExternalID: "1234",
 	}).Return(activities.UpdateCheckRunResponse{
 		ID:     1,
-		Status: "complete",
+		Status: "completed",
 	}, nil)
 
 	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
@@ -357,7 +356,7 @@ func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
 		State:      testRequest3.State,
 		Actions:    testRequest3.Actions,
 		Summary:    testRequest3.Summary,
-		ExternalID: testRequest3.ExternalID,
+		ExternalID: "1234",
 	}).Return(activities.CreateCheckRunResponse{
 		ID: 2,
 	}, nil)

--- a/server/neptune/workflows/internal/deploy/notifier/github_test.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github_test.go
@@ -1,0 +1,392 @@
+package notifier_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type request struct {
+	Requests []struct {
+		DeploymentID string
+		Request      notifier.GithubCheckRunRequest
+	}
+}
+
+type response struct {
+	IDs []int64
+}
+
+type testActivities struct{}
+
+func (a testActivities) GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
+	return activities.UpdateCheckRunResponse{}, nil
+}
+
+func (a testActivities) GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+	return activities.CreateCheckRunResponse{}, nil
+}
+
+func testWorkflow(ctx workflow.Context, workflowRequest request) (response, error) {
+	ctx = workflow.WithStartToCloseTimeout(ctx, 5*time.Second)
+	var a testActivities
+	c := notifier.NewGithubCheckRunCache(a)
+
+	var ids []int64
+	for _, r := range workflowRequest.Requests {
+		id, err := c.CreateOrUpdate(ctx, r.DeploymentID, r.Request)
+
+		if err != nil {
+			return response{}, err
+		}
+
+		ids = append(ids, id)
+	}
+	return response{
+		IDs: ids,
+	}, nil
+}
+
+func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State: github.CheckRunQueued,
+		Actions: []github.CheckRunAction{
+			github.CreatePlanReviewAction(github.Approve),
+		},
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunSuccess,
+		Summary:    "some summary 2",
+		ExternalID: "someid",
+	}
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: testRequest1.ExternalID,
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil)
+
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
+		Title:      testRequest2.Title,
+		ID:         1,
+		Repo:       testRequest2.Repo,
+		State:      testRequest2.State,
+		Actions:    testRequest2.Actions,
+		Summary:    testRequest2.Summary,
+		ExternalID: testRequest2.ExternalID,
+	}).Return(activities.UpdateCheckRunResponse{
+		ID:     1,
+		Status: "complete",
+	}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r.IDs, []int64{1, 1})
+}
+
+func TestGithubCheckRunCache_CreatesAcrossDeploymentIDs(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunQueued,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunQueued,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	var id int64
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: testRequest1.ExternalID,
+	}).Return(func(ctx context.Context, r activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+		id++
+		return activities.CreateCheckRunResponse{
+			ID: id,
+		}, nil
+	}).Twice()
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "12345",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 2}, r.IDs)
+}
+
+func TestGithubCheckRunCache_CreatesCompleted(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunQueued,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunQueued,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	var id int64
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: testRequest1.ExternalID,
+	}).Return(func(ctx context.Context, r activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+		id++
+		return activities.CreateCheckRunResponse{
+			ID:     id,
+			Status: "complete",
+		}, nil
+	}).Twice()
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 2}, r.IDs)
+}
+
+func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunQueued,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		Actions: []github.CheckRunAction{
+			github.CreatePlanReviewAction(github.Approve),
+		},
+		State:      github.CheckRunActionRequired,
+		Summary:    "some summary 2",
+		ExternalID: "someid",
+	}
+
+	testRequest3 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:      github.CheckRunPending,
+		Summary:    "some summary",
+		ExternalID: "someid",
+	}
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: testRequest1.ExternalID,
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil)
+
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
+		Title:      testRequest2.Title,
+		ID:         1,
+		Repo:       testRequest2.Repo,
+		State:      testRequest2.State,
+		Actions:    testRequest2.Actions,
+		Summary:    testRequest2.Summary,
+		ExternalID: testRequest2.ExternalID,
+	}).Return(activities.UpdateCheckRunResponse{
+		ID:     1,
+		Status: "complete",
+	}, nil)
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest3.Title,
+		Sha:        testRequest3.Sha,
+		Repo:       testRequest3.Repo,
+		State:      testRequest3.State,
+		Actions:    testRequest3.Actions,
+		Summary:    testRequest3.Summary,
+		ExternalID: testRequest3.ExternalID,
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 2,
+	}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest3,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 1, 2}, r.IDs)
+}

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -133,6 +133,7 @@ func (p *Deployer) updateCheckRun(ctx workflow.Context, deployRequest terraformW
 
 	request := notifier.GithubCheckRunRequest{
 		Title:   terraformWorkflow.BuildCheckRunTitle(deployRequest.Root.Name),
+		Sha:     deployRequest.Revision,
 		State:   state,
 		Repo:    deployRequest.Repo,
 		Summary: summary,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"go.temporal.io/sdk/temporal"
@@ -47,6 +48,7 @@ type deployerActivities interface {
 type Deployer struct {
 	Activities              deployerActivities
 	TerraformWorkflowRunner terraformWorkflowRunner
+	GithubCheckRunCache     CheckRunClient
 }
 
 const (
@@ -127,14 +129,15 @@ func (p *Deployer) updateCheckRun(ctx workflow.Context, deployRequest terraformW
 	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
 		MaximumAttempts: UpdateCheckRunRetryCount,
 	})
-	err := workflow.ExecuteActivity(ctx, p.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
+
+	_, err := p.GithubCheckRunCache.CreateOrUpdate(ctx, deployRequest.ID.String(), notifier.GithubCheckRunRequest{
 		Title:   terraformWorkflow.BuildCheckRunTitle(deployRequest.Root.Name),
 		State:   state,
 		Repo:    deployRequest.Repo,
-		ID:      deployRequest.CheckRunID,
 		Summary: summary,
 		Actions: actions,
-	}).Get(ctx, nil)
+	})
+
 	if err != nil {
 		logger.Error(ctx, "unable to update check run with validation error", key.ErrKey, err)
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -502,6 +502,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 				State:   github.CheckRunFailure,
 				Repo:    repo,
 				Summary: queue.DirectionBehindSummary,
+				Sha:     deploymentInfo.Revision,
 			},
 			ExpectedT: t,
 		})
@@ -541,6 +542,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 					State:   github.CheckRunFailure,
 					Repo:    repo,
 					Summary: queue.RerunNotIdenticalSummary,
+					Sha:     deploymentInfo.Revision,
 				},
 				ExpectedT: t,
 			})

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	model "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -66,9 +68,11 @@ func (t *testDeployActivity) AuditJob(ctx context.Context, request activities.Au
 }
 
 type deployerRequest struct {
-	Info         terraform.DeploymentInfo
-	LatestDeploy *deployment.Info
-	ErrType      ErrorType
+	Info              terraform.DeploymentInfo
+	LatestDeploy      *deployment.Info
+	ErrType           ErrorType
+	ExpectedGHRequest notifier.GithubCheckRunRequest
+	ExpectedT         *testing.T
 }
 
 func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.Info, error) {
@@ -84,6 +88,11 @@ func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.
 		TerraformWorkflowRunner: &testTerraformWorkflowRunner{
 			expectedDeployment: r.Info,
 			expectedErrorType:  r.ErrType,
+		},
+		GithubCheckRunCache: &testCheckRunClient{
+			expectedRequest:      r.ExpectedGHRequest,
+			expectedT:            r.ExpectedT,
+			expectedDeploymentID: r.Info.ID.String(),
 		},
 	}
 
@@ -315,7 +324,7 @@ func TestDeployer_CompareCommit_Identical(t *testing.T) {
 
 }
 
-func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
+func TestDeployer_CompareCommit_SkipDeploy_oldversion(t *testing.T) {
 	repo := github.Repo{
 		Owner: "owner",
 		Name:  "test",
@@ -373,6 +382,8 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			ID: updateCheckRunRequest.ID,
 		}
 
+		env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+
 		env.OnActivity(da.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
 		env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
 
@@ -416,6 +427,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			updateCheckRunResponse := activities.UpdateCheckRunResponse{
 				ID: updateCheckRunRequest.ID,
 			}
+			env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 
 			env.OnActivity(da.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
 			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
@@ -423,6 +435,114 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
 				Info:         deploymentInfo,
 				LatestDeploy: latestDeployedRevision,
+			})
+			env.AssertExpectations(t)
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+		})
+	}
+}
+
+func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
+	repo := github.Repo{
+		Owner: "owner",
+		Name:  "test",
+	}
+	root := model.Root{
+		Name:  "root_1",
+		Rerun: true,
+	}
+	deploymentInfo := terraform.DeploymentInfo{
+		ID:         uuid.UUID{},
+		Revision:   "3455",
+		CheckRunID: 1234,
+		Root:       root,
+		Repo:       repo,
+	}
+
+	latestDeployedRevision := &deployment.Info{
+		ID:       deploymentInfo.ID.String(),
+		Version:  1.0,
+		Revision: "3255",
+		Root: deployment.Root{
+			Name: deploymentInfo.Root.Name,
+		},
+		Repo: deployment.Repo{
+			Owner: deploymentInfo.Repo.Owner,
+			Name:  deploymentInfo.Repo.Name,
+		},
+	}
+
+	t.Run("behind deploy", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+
+		da := &testDeployActivity{}
+		env.RegisterActivity(da)
+		compareCommitRequest := activities.CompareCommitRequest{
+			Repo:                   repo,
+			DeployRequestRevision:  deploymentInfo.Revision,
+			LatestDeployedRevision: latestDeployedRevision.Revision,
+		}
+
+		compareCommitResponse := activities.CompareCommitResponse{
+			CommitComparison: activities.DirectionBehind,
+		}
+
+		env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+		env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+
+		env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+			Info:         deploymentInfo,
+			LatestDeploy: latestDeployedRevision,
+			ExpectedGHRequest: notifier.GithubCheckRunRequest{
+				Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+				State:   github.CheckRunFailure,
+				Repo:    repo,
+				Summary: queue.DirectionBehindSummary,
+			},
+			ExpectedT: t,
+		})
+		env.AssertExpectations(t)
+		var resp *deployment.Info
+		err := env.GetWorkflowResult(&resp)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	cases := []activities.DiffDirection{activities.DirectionAhead, activities.DirectionDiverged}
+	for _, diffDirection := range cases {
+		t.Run(fmt.Sprintf("rerun deploy %s", diffDirection), func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
+
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+			compareCommitRequest := activities.CompareCommitRequest{
+				Repo:                   repo,
+				DeployRequestRevision:  deploymentInfo.Revision,
+				LatestDeployedRevision: latestDeployedRevision.Revision,
+			}
+
+			compareCommitResponse := activities.CompareCommitResponse{
+				CommitComparison: diffDirection,
+			}
+
+			env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info:         deploymentInfo,
+				LatestDeploy: latestDeployedRevision,
+				ExpectedGHRequest: notifier.GithubCheckRunRequest{
+					Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+					State:   github.CheckRunFailure,
+					Repo:    repo,
+					Summary: queue.RerunNotIdenticalSummary,
+				},
+				ExpectedT: t,
 			})
 			env.AssertExpectations(t)
 			var resp *deployment.Info

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -8,12 +8,19 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"go.temporal.io/sdk/workflow"
 )
 
+type CheckRunClient interface {
+	CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error)
+}
+
 type LockStateUpdater struct {
-	Activities githubActivities
+	Activities          githubActivities
+	GithubCheckRunCache CheckRunClient
 }
 
 func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy) {
@@ -30,14 +37,28 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	}
 
 	for _, i := range infos {
-		err := workflow.ExecuteActivity(ctx, u.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
+		request := notifier.GithubCheckRunRequest{
 			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
 			State:   state,
 			Repo:    i.Repo,
-			ID:      i.CheckRunID,
 			Summary: summary,
 			Actions: actions,
-		}).Get(ctx, nil)
+		}
+		var err error
+
+		version := workflow.GetVersion(ctx, version.CacheCheckRunSessions, workflow.DefaultVersion, 1)
+		if version == workflow.DefaultVersion {
+			err = workflow.ExecuteActivity(ctx, u.Activities.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
+				Title:   request.Title,
+				State:   request.State,
+				Repo:    request.Repo,
+				Summary: request.Summary,
+				Actions: request.Actions,
+				ID:      i.CheckRunID,
+			}).Get(ctx, nil)
+		} else {
+			_, err = u.GithubCheckRunCache.CreateOrUpdate(ctx, i.ID.String(), request)
+		}
 
 		if err != nil {
 			logger.Error(ctx, fmt.Sprintf("updating check run for revision %s", i.Revision), key.ErrKey, err)

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -39,11 +39,13 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	for _, i := range infos {
 		request := notifier.GithubCheckRunRequest{
 			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
+			Sha:     i.Revision,
 			State:   state,
 			Repo:    i.Repo,
 			Summary: summary,
 			Actions: actions,
 		}
+		logger.Debug(ctx, fmt.Sprintf("Updating lock status for deployment id: %s", i.ID.String()))
 		var err error
 
 		version := workflow.GetVersion(ctx, version.CacheCheckRunSessions, workflow.DefaultVersion, 1)

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	tfActivity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -17,7 +19,20 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-func TestLockStateUpdater_unlocked(t *testing.T) {
+type testCheckRunClient struct {
+	expectedRequest      notifier.GithubCheckRunRequest
+	expectedDeploymentID string
+	expectedT            *testing.T
+}
+
+func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error) {
+	assert.Equal(t.expectedT, t.expectedRequest, request)
+	assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID)
+
+	return 1, nil
+}
+
+func TestLockStateUpdater_unlocked_old_version(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
@@ -49,6 +64,7 @@ func TestLockStateUpdater_unlocked(t *testing.T) {
 	}
 
 	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
+	env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},
@@ -60,7 +76,7 @@ func TestLockStateUpdater_unlocked(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestLockStateUpdater_locked(t *testing.T) {
+func TestLockStateUpdater_locked_old_version(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
@@ -95,6 +111,7 @@ func TestLockStateUpdater_locked(t *testing.T) {
 		ID: updateCheckRunRequest.ID,
 	}
 
+	env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, updateCheckRunRequest).Return(updateCheckRunResponse, nil)
 
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
@@ -111,9 +128,118 @@ func TestLockStateUpdater_locked(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testDeployActivity{}
+	env.RegisterActivity(a)
+
+	info := terraform.DeploymentInfo{
+		CheckRunID: 123,
+		ID:         uuid.New(),
+		Revision:   "1",
+		Root: tfActivity.Root{
+			Name:    "root",
+			Trigger: tfActivity.MergeTrigger,
+		},
+		Repo: github.Repo{
+			Name: "repo",
+		},
+	}
+
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title: terraform.BuildCheckRunTitle(info.Root.Name),
+		State: github.CheckRunQueued,
+		Repo:  info.Repo,
+		ID:    info.CheckRunID,
+	}
+
+	env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.AssertNotCalled(t, "GithubUpdateCheckRun", mock.Anything, updateCheckRunRequest)
+
+	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
+		Queue: []terraform.DeploymentInfo{info},
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title: terraform.BuildCheckRunTitle(info.Root.Name),
+			State: github.CheckRunQueued,
+			Repo:  info.Repo,
+		},
+		ExpectedDeploymentID: info.ID.String(),
+		ExpectedT:            t,
+	})
+
+	err := env.GetWorkflowResult(nil)
+	env.AssertExpectations(t)
+
+	assert.NoError(t, err)
+}
+
+func TestLockStateUpdater_locked_new_version(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testDeployActivity{}
+	env.RegisterActivity(a)
+
+	info := terraform.DeploymentInfo{
+		CheckRunID: 123,
+		ID:         uuid.New(),
+		Revision:   "1",
+		Root: tfActivity.Root{
+			Name:    "root",
+			Trigger: tfActivity.MergeTrigger,
+		},
+		Repo: github.Repo{
+			Name: "repo",
+		},
+	}
+
+	updateCheckRunRequest := activities.UpdateCheckRunRequest{
+		Title:   terraform.BuildCheckRunTitle(info.Root.Name),
+		State:   github.CheckRunActionRequired,
+		Repo:    info.Repo,
+		ID:      info.CheckRunID,
+		Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+		Actions: []github.CheckRunAction{
+			github.CreateUnlockAction(),
+		},
+	}
+
+	env.AssertNotCalled(t, "GithubUpdateCheckRun", mock.Anything, updateCheckRunRequest)
+	env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+
+	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
+		Queue: []terraform.DeploymentInfo{info},
+		Lock: queue.LockState{
+			Status:   queue.LockedStatus,
+			Revision: "1234",
+		},
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title:   terraform.BuildCheckRunTitle(info.Root.Name),
+			State:   github.CheckRunActionRequired,
+			Repo:    info.Repo,
+			Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+			Actions: []github.CheckRunAction{
+				github.CreateUnlockAction(),
+			},
+		},
+		ExpectedDeploymentID: info.ID.String(),
+		ExpectedT:            t,
+	})
+
+	err := env.GetWorkflowResult(nil)
+	env.AssertExpectations(t)
+
+	assert.NoError(t, err)
+}
+
 type updaterReq struct {
-	Queue []terraform.DeploymentInfo
-	Lock  queue.LockState
+	Queue                []terraform.DeploymentInfo
+	Lock                 queue.LockState
+	ExpectedRequest      notifier.GithubCheckRunRequest
+	ExpectedDeploymentID string
+	ExpectedT            *testing.T
 }
 
 func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
@@ -125,6 +251,11 @@ func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
 	var a *testDeployActivity
 	subject := &queue.LockStateUpdater{
 		Activities: a,
+		GithubCheckRunCache: &testCheckRunClient{
+			expectedRequest:      r.ExpectedRequest,
+			expectedDeploymentID: r.ExpectedDeploymentID,
+			expectedT:            r.ExpectedT,
+		},
 	}
 
 	q := queue.NewQueue(noopCallback, metrics.NewNullableScope())

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -164,6 +164,7 @@ func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
 			Title: terraform.BuildCheckRunTitle(info.Root.Name),
 			State: github.CheckRunQueued,
 			Repo:  info.Repo,
+			Sha:   info.Revision,
 		},
 		ExpectedDeploymentID: info.ID.String(),
 		ExpectedT:            t,
@@ -223,6 +224,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 			Actions: []github.CheckRunAction{
 				github.CreateUnlockAction(),
 			},
+			Sha: info.Revision,
 		},
 		ExpectedDeploymentID: info.ID.String(),
 		ExpectedT:            t,

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -86,11 +86,13 @@ func NewWorker(
 	a workerActivities,
 	tfWorkflow terraform.Workflow,
 	repoName, rootName string,
+	githubCheckRunCache CheckRunClient,
 ) (*Worker, error) {
-	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow)
+	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow, githubCheckRunCache)
 	deployer := &Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,
+		GithubCheckRunCache:     githubCheckRunCache,
 	}
 
 	latestDeployment, err := deployer.FetchLatestDeployment(ctx, repoName, rootName)

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -391,7 +391,7 @@ func TestNewWorker(t *testing.T) {
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
-		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root")
+		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root", &testCheckRunClient{})
 		return res{
 			Lock: q.GetLockState(),
 		}, err

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request/converter"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
@@ -24,6 +25,10 @@ const (
 	// signals
 	NewRevisionSignalID = "new-revision"
 )
+
+type CheckRunClient interface {
+	CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error)
+}
 
 type idGenerator func(ctx workflow.Context) (uuid.UUID, error)
 
@@ -50,22 +55,22 @@ type Activities interface {
 	GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error)
 }
 
-func NewReceiver(ctx workflow.Context, queue Queue, activities Activities, generator idGenerator, worker DeploymentStore) *Receiver {
+func NewReceiver(ctx workflow.Context, queue Queue, checkRunClient CheckRunClient, generator idGenerator, worker DeploymentStore) *Receiver {
 	return &Receiver{
-		queue:       queue,
-		ctx:         ctx,
-		activities:  activities,
-		idGenerator: generator,
-		worker:      worker,
+		queue:          queue,
+		ctx:            ctx,
+		idGenerator:    generator,
+		worker:         worker,
+		checkRunClient: checkRunClient,
 	}
 }
 
 type Receiver struct {
-	queue       Queue
-	ctx         workflow.Context
-	activities  Activities
-	idGenerator idGenerator
-	worker      DeploymentStore
+	queue          Queue
+	ctx            workflow.Context
+	idGenerator    idGenerator
+	worker         DeploymentStore
+	checkRunClient CheckRunClient
 }
 
 func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
@@ -103,7 +108,7 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		return
 	}
 
-	resp := n.createCheckRun(ctx, id.String(), request.Revision, root, repo)
+	checkRunID := n.createCheckRun(ctx, id.String(), request.Revision, root, repo)
 
 	// lock the queue on a manual deployment
 	if root.Trigger == activity.ManualTrigger {
@@ -117,14 +122,14 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 		ID:             id,
 		Root:           root,
 		Revision:       request.Revision,
-		CheckRunID:     resp.ID,
+		CheckRunID:     checkRunID,
 		Repo:           repo,
 		InitiatingUser: initiatingUser,
 		Tags:           request.Tags,
 	})
 }
 
-func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, root activity.Root, repo github.Repo) activities.CreateCheckRunResponse {
+func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, root activity.Root, repo github.Repo) int64 {
 	lock := n.queue.GetLockState()
 	var actions []github.CheckRunAction
 	var summary string
@@ -136,8 +141,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
 	}
 
-	var resp activities.CreateCheckRunResponse
-	err := workflow.ExecuteActivity(ctx, n.activities.GithubCreateCheckRun, activities.CreateCheckRunRequest{
+	cid, err := n.checkRunClient.CreateOrUpdate(ctx, id, notifier.GithubCheckRunRequest{
 		Title:      terraform.BuildCheckRunTitle(root.Name),
 		Sha:        revision,
 		Repo:       repo,
@@ -145,14 +149,14 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 		Summary:    summary,
 		Actions:    actions,
 		State:      state,
-	}).Get(ctx, &resp)
+	})
 
 	// don't block on error here, we'll just try again later when we have our result.
 	if err != nil {
 		logger.Error(ctx, err.Error())
 	}
 
-	return resp
+	return cid
 }
 
 func (n *Receiver) isInProgress(revision string) bool {

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -142,13 +142,12 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	}
 
 	cid, err := n.checkRunClient.CreateOrUpdate(ctx, id, notifier.GithubCheckRunRequest{
-		Title:      terraform.BuildCheckRunTitle(root.Name),
-		Sha:        revision,
-		Repo:       repo,
-		ExternalID: id,
-		Summary:    summary,
-		Actions:    actions,
-		State:      state,
+		Title:   terraform.BuildCheckRunTitle(root.Name),
+		Sha:     revision,
+		Repo:    repo,
+		Summary: summary,
+		Actions: actions,
+		State:   state,
 	})
 
 	// don't block on error here, we'll just try again later when we have our result.

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -134,11 +134,10 @@ func TestEnqueue(t *testing.T) {
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:      "atlantis/deploy: root",
-			Sha:        rev,
-			Repo:       github.Repo{Name: "nish"},
-			ExternalID: id.String(),
-			State:      github.CheckRunQueued,
+			Title: "atlantis/deploy: root",
+			Sha:   rev,
+			Repo:  github.Repo{Name: "nish"},
+			State: github.CheckRunQueued,
 		},
 		ExpectedT: t,
 	})
@@ -186,11 +185,10 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:      "atlantis/deploy: root",
-			Sha:        rev,
-			Repo:       github.Repo{Name: "nish"},
-			ExternalID: id.String(),
-			State:      github.CheckRunQueued,
+			Title: "atlantis/deploy: root",
+			Sha:   rev,
+			Repo:  github.Repo{Name: "nish"},
+			State: github.CheckRunQueued,
 		},
 		ExpectedT: t,
 	})
@@ -244,11 +242,10 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 			Revision: "123334444555",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:      "atlantis/deploy: root",
-			Sha:        rev,
-			Repo:       github.Repo{Name: "nish"},
-			ExternalID: id.String(),
-			State:      github.CheckRunQueued,
+			Title: "atlantis/deploy: root",
+			Sha:   rev,
+			Repo:  github.Repo{Name: "nish"},
+			State: github.CheckRunQueued,
 		},
 		ExpectedT: t,
 	})
@@ -302,13 +299,12 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Revision: "123334444555",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:      "atlantis/deploy: root",
-			Sha:        rev,
-			Repo:       github.Repo{Name: "nish"},
-			ExternalID: id.String(),
-			Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
-			Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
-			State:      github.CheckRunActionRequired,
+			Title:   "atlantis/deploy: root",
+			Sha:     rev,
+			Repo:    github.Repo{Name: "nish"},
+			Summary: "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
+			Actions: []github.CheckRunAction{github.CreateUnlockAction()},
+			State:   github.CheckRunActionRequired,
 		},
 		ExpectedT: t,
 	})

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -1,23 +1,32 @@
 package revision_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
+
+type testCheckRunClient struct {
+	expectedRequest notifier.GithubCheckRunRequest
+	expectedT       *testing.T
+}
+
+func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error) {
+	assert.Equal(t.expectedT, t.expectedRequest, request)
+
+	return 1, nil
+}
 
 type testQueue struct {
 	Queue []terraformWorkflow.DeploymentInfo
@@ -53,18 +62,14 @@ type req struct {
 	Lock            queue.LockState
 	Current         queue.CurrentDeployment
 	InitialElements []terraformWorkflow.DeploymentInfo
+	ExpectedRequest notifier.GithubCheckRunRequest
+	ExpectedT       *testing.T
 }
 
 type response struct {
 	Queue   []terraformWorkflow.DeploymentInfo
 	Lock    queue.LockState
 	Timeout bool
-}
-
-type testActivities struct{}
-
-func (a *testActivities) GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
-	return activities.CreateCheckRunResponse{}, nil
 }
 
 func testWorkflow(ctx workflow.Context, r req) (response, error) {
@@ -82,9 +87,10 @@ func testWorkflow(ctx workflow.Context, r req) (response, error) {
 		Current: r.Current,
 	}
 
-	var a *testActivities
-
-	receiver := revision.NewReceiver(ctx, queue, a, func(ctx workflow.Context) (uuid.UUID, error) {
+	receiver := revision.NewReceiver(ctx, queue, &testCheckRunClient{
+		expectedRequest: r.ExpectedRequest,
+		expectedT:       r.ExpectedT,
+	}, func(ctx workflow.Context) (uuid.UUID, error) {
 		return r.ID, nil
 	}, worker)
 	selector := workflow.NewSelector(ctx)
@@ -123,22 +129,18 @@ func TestEnqueue(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-
-	env.RegisterActivity(a)
-
 	id := uuid.Must(uuid.NewUUID())
-
-	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
-		Title:      "atlantis/deploy: root",
-		Sha:        rev,
-		Repo:       github.Repo{Name: "nish"},
-		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
-	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title:      "atlantis/deploy: root",
+			Sha:        rev,
+			Repo:       github.Repo{Name: "nish"},
+			ExternalID: id.String(),
+			State:      github.CheckRunQueued,
+		},
+		ExpectedT: t,
 	})
 	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
@@ -179,22 +181,18 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-
-	env.RegisterActivity(a)
-
 	id := uuid.Must(uuid.NewUUID())
-
-	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
-		Title:      "atlantis/deploy: root",
-		Sha:        rev,
-		Repo:       github.Repo{Name: "nish"},
-		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
-	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title:      "atlantis/deploy: root",
+			Sha:        rev,
+			Repo:       github.Repo{Name: "nish"},
+			ExternalID: id.String(),
+			State:      github.CheckRunQueued,
+		},
+		ExpectedT: t,
 	})
 	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
@@ -236,19 +234,7 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-
-	env.RegisterActivity(a)
-
 	id := uuid.Must(uuid.NewUUID())
-
-	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
-		Title:      "atlantis/deploy: root",
-		Sha:        rev,
-		Repo:       github.Repo{Name: "nish"},
-		ExternalID: id.String(),
-		State:      github.CheckRunQueued,
-	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
@@ -257,6 +243,14 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 			Status:   queue.LockedStatus,
 			Revision: "123334444555",
 		},
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title:      "atlantis/deploy: root",
+			Sha:        rev,
+			Repo:       github.Repo{Name: "nish"},
+			ExternalID: id.String(),
+			State:      github.CheckRunQueued,
+		},
+		ExpectedT: t,
 	})
 	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
@@ -298,21 +292,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-
-	env.RegisterActivity(a)
-
 	id := uuid.Must(uuid.NewUUID())
-
-	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
-		Title:      "atlantis/deploy: root",
-		Sha:        rev,
-		Repo:       github.Repo{Name: "nish"},
-		ExternalID: id.String(),
-		Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
-		Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
-		State:      github.CheckRunActionRequired,
-	}).Return(activities.CreateCheckRunResponse{ID: 1}, nil)
 
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
@@ -321,6 +301,16 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Status:   queue.LockedStatus,
 			Revision: "123334444555",
 		},
+		ExpectedRequest: notifier.GithubCheckRunRequest{
+			Title:      "atlantis/deploy: root",
+			Sha:        rev,
+			Repo:       github.Repo{Name: "nish"},
+			ExternalID: id.String(),
+			Summary:    "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
+			Actions:    []github.CheckRunAction{github.CreateUnlockAction()},
+			State:      github.CheckRunActionRequired,
+		},
+		ExpectedT: t,
 	})
 	env.AssertExpectations(t)
 	assert.True(t, env.IsWorkflowCompleted())
@@ -362,8 +352,6 @@ func TestEnqueue_ManualTrigger_RequestAlreadyInQueue(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-	env.RegisterActivity(a)
 	id := uuid.Must(uuid.NewUUID())
 
 	deploymentInfo := terraformWorkflow.DeploymentInfo{
@@ -404,8 +392,6 @@ func TestEnqueue_ManualTrigger_RequestAlreadyInProgress(t *testing.T) {
 		})
 	}, 0)
 
-	a := &testActivities{}
-	env.RegisterActivity(a)
 	id := uuid.Must(uuid.NewUUID())
 
 	deploymentInfo := terraformWorkflow.DeploymentInfo{

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -11,7 +11,8 @@ import (
 )
 
 type DeploymentInfo struct {
-	ID             uuid.UUID
+	ID uuid.UUID
+	//Deprecated: Use GithubCheckRunCache instead
 	CheckRunID     int64
 	Revision       string
 	InitiatingUser github.User

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -11,8 +11,7 @@ import (
 )
 
 type DeploymentInfo struct {
-	ID uuid.UUID
-	//Deprecated: Use GithubCheckRunCache instead
+	ID             uuid.UUID
 	CheckRunID     int64
 	Revision       string
 	InitiatingUser github.User

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -86,7 +86,7 @@ func (r *WorkflowRunner) buildRequestRoot(root terraformActivities.Root, diffDir
 	var approvalType terraformActivities.PlanApprovalType
 	var reasons []string
 
-	if diffDirection == activities.DirectionDiverged || (root.Trigger == terraformActivities.ManualTrigger && !root.Rerun) {
+	if diffDirection == activities.DirectionDiverged || root.Trigger == terraformActivities.ManualTrigger {
 		approvalType = terraformActivities.ManualApproval
 	}
 
@@ -98,7 +98,7 @@ func (r *WorkflowRunner) buildRequestRoot(root terraformActivities.Root, diffDir
 		reasons = append(reasons, ":warning: Requested Revision is not ahead of deployed revision, please confirm the changes described in the plan.")
 	}
 
-	if root.Trigger == terraformActivities.ManualTrigger && !root.Rerun {
+	if root.Trigger == terraformActivities.ManualTrigger {
 		reasons = append(reasons, ":warning: Manually Triggered Deploys must be confirmed before proceeding.")
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -7,6 +7,7 @@ import (
 	constants "github.com/runatlantis/atlantis/server/events/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
@@ -30,17 +31,22 @@ func (e PlanRejectionError) Error() string {
 	return e.msg
 }
 
+type CheckRunClient interface {
+	CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error)
+}
+
 type Workflow func(ctx workflow.Context, request terraform.Request) error
 
 type stateReceiver interface {
 	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)
 }
 
-func NewWorkflowRunner(a receiverActivities, w Workflow) *WorkflowRunner {
+func NewWorkflowRunner(a receiverActivities, w Workflow, githubCheckRunCache CheckRunClient) *WorkflowRunner {
 	return &WorkflowRunner{
 		Workflow: w,
 		StateReceiver: &StateReceiver{
-			Activity: a,
+			Activity:             a,
+			CheckRunSessionCache: githubCheckRunCache,
 		},
 	}
 }

--- a/server/neptune/workflows/internal/deploy/terraform/runner_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner_test.go
@@ -211,47 +211,6 @@ func TestWorkflowRunner_RunWithManuallyTriggeredRoot(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWorkflowRunner_RunWithRootWithRerunEnabled(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	env.RegisterWorkflow(testTerraformWorkflow)
-
-	r := request{
-		Info:          buildDeploymentInfo(t),
-		DiffDirection: activities.DirectionAhead,
-	}
-
-	r.Info.Root.Trigger = terraform.ManualTrigger
-	r.Info.Root.Rerun = true
-
-	env.OnWorkflow(testTerraformWorkflow, mock.Anything, terraformWorkflow.Request{
-		Root: terraform.Root{
-			Name:    r.Info.Root.Name,
-			Trigger: terraform.ManualTrigger,
-			Plan: terraform.PlanJob{
-				Approval: terraform.PlanApproval{
-					Type: terraform.AutoApproval,
-				},
-			},
-			Rerun: true,
-		},
-		Repo:         r.Info.Repo,
-		DeploymentID: r.Info.ID.String(),
-		Revision:     r.Info.Revision,
-	}).Return(func(ctx workflow.Context, request terraformWorkflow.Request) error {
-		return nil
-	})
-
-	env.ExecuteWorkflow(parentWorkflow, r)
-
-	env.AssertExpectations(t)
-
-	var resp response
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-}
-
 func TestWorkflowRunner_PlanRejected(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/metrics"
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 
-	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/config/logger"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -28,7 +30,8 @@ type receiverActivities interface {
 }
 
 type StateReceiver struct {
-	Activity receiverActivities
+	Activity             receiverActivities
+	CheckRunSessionCache CheckRunClient
 }
 
 func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo) {
@@ -61,11 +64,10 @@ func (n *StateReceiver) updateCheckRun(ctx workflow.Context, workflowState *stat
 	summary := markdown.RenderWorkflowStateTmpl(workflowState)
 	checkRunState := determineCheckRunState(workflowState)
 
-	request := activities.UpdateCheckRunRequest{
+	request := notifier.GithubCheckRunRequest{
 		Title:   BuildCheckRunTitle(deploymentInfo.Root.Name),
 		State:   checkRunState,
 		Repo:    deploymentInfo.Repo,
-		ID:      deploymentInfo.CheckRunID,
 		Summary: summary,
 	}
 
@@ -83,8 +85,21 @@ func (n *StateReceiver) updateCheckRun(ctx workflow.Context, workflowState *stat
 		})
 	}
 
-	// TODO: should we block here? maybe we can just make this async
-	return workflow.ExecuteActivity(ctx, n.Activity.GithubUpdateCheckRun, request).Get(ctx, nil)
+	version := workflow.GetVersion(ctx, version.CacheCheckRunSessions, workflow.DefaultVersion, 1)
+
+	if version == workflow.DefaultVersion {
+		return workflow.ExecuteActivity(ctx, n.Activity.GithubUpdateCheckRun, activities.UpdateCheckRunRequest{
+			Title:   request.Title,
+			State:   request.State,
+			Repo:    request.Repo,
+			ID:      deploymentInfo.CheckRunID,
+			Summary: request.Summary,
+			Actions: request.Actions,
+		}).Get(ctx, nil)
+	}
+
+	_, err := n.CheckRunSessionCache.CreateOrUpdate(ctx, deploymentInfo.ID.String(), request)
+	return err
 }
 
 func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Job, deploymentInfo DeploymentInfo) error {

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -66,6 +66,7 @@ func (n *StateReceiver) updateCheckRun(ctx workflow.Context, workflowState *stat
 
 	request := notifier.GithubCheckRunRequest{
 		Title:   BuildCheckRunTitle(deploymentInfo.Root.Name),
+		Sha:     deploymentInfo.Revision,
 		State:   checkRunState,
 		Repo:    deploymentInfo.Repo,
 		Summary: summary,

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -194,6 +194,7 @@ func TestStateReceive(t *testing.T) {
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
 				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Revision,
 				State:        activities.AtlantisJobStateRunning,
 				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
 				IsForceApply: false,
@@ -216,6 +217,7 @@ func TestStateReceive(t *testing.T) {
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
 				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Revision,
 				State:        activities.AtlantisJobStateFailure,
 				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
 				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
@@ -243,6 +245,7 @@ func TestStateReceive(t *testing.T) {
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
 				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Revision,
 				State:        activities.AtlantisJobStateFailure,
 				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
 				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
@@ -270,6 +273,7 @@ func TestStateReceive(t *testing.T) {
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
 				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Revision,
 				State:        activities.AtlantisJobStateFailure,
 				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
 				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
@@ -297,6 +301,7 @@ func TestStateReceive(t *testing.T) {
 			ExpectedAuditJobRequest: &activities.AuditJobRequest{
 				Root:         internalDeploymentInfo.Root,
 				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Revision,
 				State:        activities.AtlantisJobStateSuccess,
 				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
 				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
@@ -327,14 +332,7 @@ func TestStateReceive(t *testing.T) {
 			}).Return(activities.UpdateCheckRunResponse{}, nil)
 
 			if c.ExpectedAuditJobRequest != nil {
-				env.OnActivity(a.AuditJob, mock.Anything, activities.AuditJobRequest{
-					Root:         c.ExpectedAuditJobRequest.Root,
-					Repo:         c.ExpectedAuditJobRequest.Repo,
-					State:        c.ExpectedAuditJobRequest.State,
-					StartTime:    c.ExpectedAuditJobRequest.StartTime,
-					EndTime:      c.ExpectedAuditJobRequest.EndTime,
-					IsForceApply: c.ExpectedAuditJobRequest.IsForceApply,
-				}).Return(nil)
+				env.OnActivity(a.AuditJob, mock.Anything, *c.ExpectedAuditJobRequest).Return(nil)
 			}
 
 			env.ExecuteWorkflow(testStateReceiveWorkflow, stateReceiveRequest{
@@ -370,14 +368,7 @@ func TestStateReceive(t *testing.T) {
 			env.OnGetVersion(version.CacheCheckRunSessions, workflow.DefaultVersion, 1).Return(workflow.Version(1))
 
 			if c.ExpectedAuditJobRequest != nil {
-				env.OnActivity(a.AuditJob, mock.Anything, activities.AuditJobRequest{
-					Root:         c.ExpectedAuditJobRequest.Root,
-					Repo:         c.ExpectedAuditJobRequest.Repo,
-					State:        c.ExpectedAuditJobRequest.State,
-					StartTime:    c.ExpectedAuditJobRequest.StartTime,
-					EndTime:      c.ExpectedAuditJobRequest.EndTime,
-					IsForceApply: c.ExpectedAuditJobRequest.IsForceApply,
-				}).Return(nil)
+				env.OnActivity(a.AuditJob, mock.Anything, *c.ExpectedAuditJobRequest).Return(nil)
 			}
 
 			env.ExecuteWorkflow(testStateReceiveWorkflow, stateReceiveRequest{

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -47,10 +47,10 @@ func (a *testActivities) AuditJob(ctx context.Context, request activities.AuditJ
 }
 
 type stateReceiveRequest struct {
-	StatesToSend   []*state.Workflow
-	DeploymentInfo internalTerraform.DeploymentInfo
+	StatesToSend    []*state.Workflow
+	DeploymentInfo  internalTerraform.DeploymentInfo
 	ExpectedRequest notifier.GithubCheckRunRequest
-	T *testing.T
+	T               *testing.T
 }
 
 func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) error {
@@ -63,7 +63,7 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) error
 		Activity: &testActivities{},
 		CheckRunSessionCache: &testCheckRunClient{
 			expectedRequest: r.ExpectedRequest,
-			expectedT: r.T,
+			expectedT:       r.T,
 		},
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -93,6 +93,7 @@ func TestStateReceive(t *testing.T) {
 		ID:         uuid.New(),
 		Root:       terraform.Root{Name: "root"},
 		Repo:       github.Repo{Name: "hello"},
+		Revision:   "12345",
 	}
 
 	cases := []struct {
@@ -384,6 +385,7 @@ func TestStateReceive(t *testing.T) {
 				DeploymentInfo: internalDeploymentInfo,
 				ExpectedRequest: notifier.GithubCheckRunRequest{
 					Title: "atlantis/deploy: root",
+					Sha:   internalDeploymentInfo.Revision,
 					State: c.ExpectedCheckRunState,
 					Repo: github.Repo{
 						Name: "hello",

--- a/server/neptune/workflows/internal/deploy/version/checkrun.go
+++ b/server/neptune/workflows/internal/deploy/version/checkrun.go
@@ -1,0 +1,3 @@
+package version
+
+const CacheCheckRunSessions = "cache-check-run-sessions"


### PR DESCRIPTION
Currently, we pass around the check run id after creating it for the first time when we get a signal for a new revision.  This worked fine until we started completing the check runs when changing the state to "Action Required", once this happens, successive updates to pending, do not reset the state of the check run so we need to create a new one.  It's not feasible for us to be able to predict where we might need to create this or update this at any given point in addition to mutating the check run id that's being passed around everywhere.

Instead it makes more sense to create a central check run cache that handles creation or update depending on if a check run is complete or not.  This means we know have to cache this data and clean it up ourselves however we clean it up as soon as we update with a completion status successfully.  

**Note: I've had this in the works for a week or so so i might have missed something, definitely review thoroughly.**

Additionally: As part of this change i flipped reruns to require confirmation of the plan, this was what we wanted in the first place and now that we have this fix + notifications enabled we should be good.