### PR TITLE
[neptune] Ensure tf interrupts only happen on context cancellation.

### DIFF
--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/neptune/logger"
 )
 
 type StreamCloserFn func()

--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -81,12 +81,12 @@ func (s *StreamHandler) CloseJob(ctx context.Context, jobID string) error {
 }
 
 func (s *StreamHandler) CleanUp(ctx context.Context) error {
-	logger.Info(ctx, "waiting for jobs to finish")
+	s.Logger.InfoContext(ctx, "waiting for jobs to finish")
 	// Should we timeout here? We do risk a deadlock without this however adding a timeout also risks
 	// contention with the worker stop timeout and therefore dropped logs
 	s.wg.Wait()
 
-	logger.Info(ctx, "cleaning up receiver registry and persisting to store")
+	s.Logger.InfoContext(ctx, "cleaning up receiver registry and persisting to store")
 	s.ReceiverRegistry.CleanUp()
 	return s.Store.Cleanup(ctx)
 }

--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
 	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/logger"
 )
 
 type StreamCloserFn func()
@@ -80,9 +81,12 @@ func (s *StreamHandler) CloseJob(ctx context.Context, jobID string) error {
 }
 
 func (s *StreamHandler) CleanUp(ctx context.Context) error {
+	logger.Info(ctx, "waiting for jobs to finish")
 	// Should we timeout here? We do risk a deadlock without this however adding a timeout also risks
 	// contention with the worker stop timeout and therefore dropped logs
 	s.wg.Wait()
+
+	logger.Info(ctx, "cleaning up receiver registry and persisting to store")
 	s.ReceiverRegistry.CleanUp()
 	return s.Store.Cleanup(ctx)
 }

--- a/server/neptune/temporalworker/job/stream_handler.go
+++ b/server/neptune/temporalworker/job/stream_handler.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
@@ -16,11 +17,10 @@ type OutputLine struct {
 	Line  string
 }
 
-func NewTestStreamHandler(
+func NewStreamHandler(
 	jobStore Store,
 	receiverRegistry ReceiverRegistry,
 	logFilters valid.TerraformLogFilters,
-	streamChan chan *OutputLine,
 	logger logging.Logger,
 ) *StreamHandler {
 
@@ -29,78 +29,75 @@ func NewTestStreamHandler(
 	}
 
 	return &StreamHandler{
-		JobOutput:        streamChan,
 		Store:            jobStore,
 		ReceiverRegistry: receiverRegistry,
 		LogFilter:        logFilter,
 		Logger:           logger,
 	}
-}
-
-func NewStreamHandler(
-	jobStore Store,
-	receiverRegistry ReceiverRegistry,
-	logFilters valid.TerraformLogFilters,
-	logger logging.Logger,
-) (*StreamHandler, StreamCloserFn) {
-
-	logFilter := filter.LogFilter{
-		Regexes: logFilters.Regexes,
-	}
-
-	streamChan := make(chan *OutputLine)
-	streamCloserFn := func() {
-		close(streamChan)
-	}
-
-	return &StreamHandler{
-		JobOutput:        streamChan,
-		Store:            jobStore,
-		ReceiverRegistry: receiverRegistry,
-		LogFilter:        logFilter,
-		Logger:           logger,
-	}, streamCloserFn
 }
 
 type StreamHandler struct {
-	JobOutput        chan *OutputLine
 	Store            Store
+	wg               sync.WaitGroup
 	ReceiverRegistry ReceiverRegistry
 	LogFilter        filter.LogFilter
 	Logger           logging.Logger
 }
 
-func (s *StreamHandler) Stream(jobID string, msg string) {
-	s.JobOutput <- &OutputLine{
-		JobID: jobID,
-		Line:  msg,
-	}
+// RegisterJob returns a channel and creates a receiver go routine
+// that reads from the associated channel.
+//
+// New resources are created each time this is called so it is up to the consumer to ensure
+// this is not being called more than once per job id.
+//
+// Note: Cleanup will be blocked until these routines are complete, therefore
+// it is essential these channels are closed or we risk deadlock on shutdown
+func (s *StreamHandler) RegisterJob(id string) chan string {
+	jobOutput := make(chan string)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for line := range jobOutput {
+			s.handle(&OutputLine{
+				JobID: id,
+				Line:  line,
+			})
+		}
+	}()
+
+	return jobOutput
 }
 
-func (s *StreamHandler) Handle() {
-	for msg := range s.JobOutput {
-		// Filter out log lines from job output
-		if s.LogFilter.ShouldFilterLine(msg.Line) {
-			continue
-		}
-
-		s.ReceiverRegistry.Broadcast(*msg)
-
-		// Append new log to the output buffer for the job
-		err := s.Store.Write(context.Background(), msg.JobID, msg.Line)
-		if err != nil {
-			s.Logger.Warn(fmt.Sprintf("appending log: %s for job: %s: %v", msg.Line, msg.JobID, err))
-		}
-	}
-}
-
-// Activity context since it's called from within an activity
+// CloseJob closes any receivers within the registry, this exists outside of RegisterJob
+// because atm our definition of job is conflated.  In certain cases jobs are mapped to individual operations (ie. TerraformPlan/TerraformApply)
+// however, in other cases they represent a series of steps in a group (plan group -> [init, scripts, plan])
+// in order to support streaming all logs for a group to the same job id, we call this after all the activities of a group have occurred.
+// This actually is kind of broken because we don't checkpoint these across activities, so on shutdown we would lose logs for previous steps.
+// TODO: we need to rethink this a bit and create clear definitions for our data models.
 func (s *StreamHandler) CloseJob(ctx context.Context, jobID string) error {
 	s.ReceiverRegistry.Close(ctx, jobID)
 	return s.Store.Close(ctx, jobID, Complete)
 }
 
 func (s *StreamHandler) CleanUp(ctx context.Context) error {
+	// Should we timeout here? We do risk a deadlock without this however adding a timeout also risks
+	// contention with the worker stop timeout and therefore dropped logs
+	s.wg.Wait()
 	s.ReceiverRegistry.CleanUp()
 	return s.Store.Cleanup(ctx)
+}
+
+func (s *StreamHandler) handle(msg *OutputLine) {
+	// Filter out log lines from job output
+	if s.LogFilter.ShouldFilterLine(msg.Line) {
+		return
+	}
+
+	s.ReceiverRegistry.Broadcast(*msg)
+
+	// Append new log to the output buffer for the job
+	err := s.Store.Write(context.Background(), msg.JobID, msg.Line)
+	if err != nil {
+		s.Logger.Warn(fmt.Sprintf("appending log: %s for job: %s: %v", msg.Line, msg.JobID, err))
+	}
 }

--- a/server/neptune/temporalworker/job/stream_handler_test.go
+++ b/server/neptune/temporalworker/job/stream_handler_test.go
@@ -156,7 +156,7 @@ func TestStreamHandler_Cleanup(t *testing.T) {
 			testStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters{},
-			nil,
+			logging.NewNoopCtxLogger(t),
 		)
 		err := streamHandler.CleanUp(context.Background())
 		assert.NoError(t, err)

--- a/server/neptune/temporalworker/job/stream_handler_test.go
+++ b/server/neptune/temporalworker/job/stream_handler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/terraform/filter"
@@ -28,7 +27,6 @@ func TestStreamHandler_Handle(t *testing.T) {
 	outputMsg := "a"
 
 	t.Run("broadcasts and stores filtered logs", func(t *testing.T) {
-		outputCh := make(chan *job.OutputLine)
 		logs := []string{outputMsg, fmt.Sprintf("[%s] New Line", regexString)}
 		testJobStore := &strictTestStore{
 			t: t,
@@ -63,63 +61,19 @@ func TestStreamHandler_Handle(t *testing.T) {
 			},
 		}
 
-		streamHandler := job.NewTestStreamHandler(
+		streamHandler := job.NewStreamHandler(
 			testJobStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters(logFilter),
-			outputCh,
 			logging.NewNoopCtxLogger(t),
 		)
 
-		go streamHandler.Handle()
+		ch := streamHandler.RegisterJob(jobID)
 
 		for _, line := range logs {
-			outputCh <- &job.OutputLine{
-				JobID: jobID,
-				Line:  line,
-			}
+			ch <- line
 		}
-		close(outputCh)
-	})
-}
-
-func TestStreamHandler_Stream(t *testing.T) {
-	jobID := "1234"
-	outputMsg := "a"
-
-	t.Run("streams to main terraform channel", func(t *testing.T) {
-		logs := []string{outputMsg, outputMsg}
-
-		// Buffered channel to simplify testing since it's not blocking
-		mainTfCh := make(chan *job.OutputLine, len(logs))
-		streamHandler := job.NewTestStreamHandler(
-			&testStore{},
-			&testReceiverRegistry{},
-			valid.TerraformLogFilters{},
-			mainTfCh,
-			logging.NewNoopCtxLogger(t),
-		)
-		go func() {
-			for _, line := range logs {
-				streamHandler.Stream(jobID, line)
-			}
-		}()
-
-		gotLogs := []string{}
-
-		// Read main terraform output channel
-	outside:
-		for {
-			select {
-			case line := <-mainTfCh:
-				gotLogs = append(gotLogs, line.Line)
-
-			// give buffer time for logs to be streamed to main terraform channe;
-			case <-time.After(2 * time.Second):
-				break outside
-			}
-		}
-		assert.Equal(t, logs, gotLogs)
+		close(ch)
 	})
 }
 
@@ -157,11 +111,10 @@ func TestStreamHandler_Close(t *testing.T) {
 				},
 			},
 		}
-		streamHandler := job.NewTestStreamHandler(
+		streamHandler := job.NewStreamHandler(
 			testStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters{},
-			nil,
 			logging.NewNoopCtxLogger(t),
 		)
 		err := streamHandler.CloseJob(context.Background(), jobID)
@@ -199,12 +152,11 @@ func TestStreamHandler_Cleanup(t *testing.T) {
 				},
 			},
 		}
-		streamHandler := job.NewTestStreamHandler(
+		streamHandler := job.NewStreamHandler(
 			testStore,
 			testReceiverRegistry,
 			valid.TerraformLogFilters{},
 			nil,
-			logging.NewNoopCtxLogger(t),
 		)
 		err := streamHandler.CleanUp(context.Background())
 		assert.NoError(t, err)

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -40,8 +40,14 @@ import (
 const (
 	ProjectJobsViewRouteName = "project-jobs-detail"
 
-	// Equal to default terraform timeout
-	TemporalWorkerTimeout = 60 * time.Second
+	// to make this clear,
+	// time t     event
+	// 0 min      sigterm received from kube
+	// 50 min     activity ctx canceled
+	// 50 + x min sigkill received from kube
+	//
+	// Note: x must be configured outside atlantis and is the grace period effectively.
+	TemporalWorkerTimeout = 50 * time.Minute
 
 	// 5 minutes to allow cleaning up the job store
 	StreamHandlerTimeout = 5 * time.Minute

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -220,7 +220,7 @@ func (s Server) Start() error {
 			log.Fatalln("unable to start terraform worker", err)
 		}
 
-		s.Logger.InfoContext(ctx, "Shutting down deploy worker, resource clean up may still be occurring in the background")
+		s.Logger.InfoContext(ctx, "Shutting down terraform worker, resource clean up may still be occurring in the background")
 	}()
 
 	// Ensure server gracefully drains connections when stopped.

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -67,7 +67,7 @@ type TerraformClient interface {
 }
 
 type streamer interface {
-	Stream(jobID string, msg string)
+	RegisterJob(id string) chan string
 }
 
 type gitCredentialsRefresher interface {
@@ -359,13 +359,17 @@ func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jo
 	s.Buffer(buf, bufioScannerBufferSize)
 
 	var output strings.Builder
+	ch := t.StreamHandler.RegisterJob(jobID)
 	for s.Scan() {
 		_, err := output.WriteString(s.Text())
 		if err != nil {
 			logger.Warn(ctx, "unable to write tf output to buffer")
 		}
-		t.StreamHandler.Stream(jobID, s.Text())
+		ch <- s.Text()
+		// t.StreamHandler.Stream(jobID, s.Text())
 	}
+
+	close(ch)
 
 	wg.Wait()
 

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -366,7 +366,6 @@ func (t *terraformActivities) runCommandWithOutputStream(ctx context.Context, jo
 			logger.Warn(ctx, "unable to write tf output to buffer")
 		}
 		ch <- s.Text()
-		// t.StreamHandler.Stream(jobID, s.Text())
 	}
 
 	close(ch)

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -30,17 +31,24 @@ type testStreamHandler struct {
 	expectedJobID string
 	t             *testing.T
 	called        bool
+	wg            sync.WaitGroup
 }
 
 func (t *testStreamHandler) RegisterJob(id string) chan string {
 	ch := make(chan string)
+	t.wg.Add(1)
 	go func() {
+		defer t.wg.Done()
 		for s := range ch {
 			t.received = append(t.received, s)
 		}
 		t.called = true
 	}()
 	return ch
+}
+
+func (t *testStreamHandler) Wait() {
+	t.wg.Wait()
 }
 
 type multiCallTfClient struct {
@@ -273,6 +281,8 @@ func TestTerraformInit_StreamsOutput(t *testing.T) {
 	_, err = env.ExecuteActivity(tfActivity.TerraformInit, req)
 	assert.NoError(t, err)
 
+	// wait before we check called value otherwise we might race
+	streamHandler.Wait()
 	assert.True(t, streamHandler.called)
 }
 
@@ -514,6 +524,8 @@ func TestTerraformPlan_ReturnsResponse(t *testing.T) {
 		},
 	}, resp)
 
+	// wait before we check called value otherwise we might race
+	streamHandler.Wait()
 	assert.True(t, streamHandler.called)
 }
 
@@ -675,5 +687,7 @@ func TestTerraformApply_StreamsOutput(t *testing.T) {
 	_, err = env.ExecuteActivity(tfActivity.TerraformApply, req)
 	assert.NoError(t, err)
 
+	// wait before we check called value otherwise we might race
+	streamHandler.Wait()
 	assert.True(t, streamHandler.called)
 }

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -32,12 +32,15 @@ type testStreamHandler struct {
 	called        bool
 }
 
-func (t *testStreamHandler) Stream(jobID string, msg string) {
-	assert.Equal(t.t, t.expectedJobID, jobID)
-	t.received = append(t.received, msg)
-
-	t.called = true
-
+func (t *testStreamHandler) RegisterJob(id string) chan string {
+	ch := make(chan string)
+	go func() {
+		for s := range ch {
+			t.received = append(t.received, s)
+		}
+		t.called = true
+	}()
+	return ch
 }
 
 type multiCallTfClient struct {

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -218,16 +218,28 @@ type testStreamCloser struct {
 	CapturedJobOutput map[string][]string
 }
 
-func (sc *testStreamCloser) Stream(jobID string, msg string) {
-	v, ok := sc.CapturedJobOutput[jobID]
+// func (sc *testStreamCloser) Stream(jobID string, msg string) {
+// 	v, ok := sc.CapturedJobOutput[jobID]
 
-	if !ok {
-		v = []string{}
-	}
+// 	if !ok {
+// 		v = []string{}
+// 	}
 
-	v = append(v, msg)
+// 	v = append(v, msg)
 
-	sc.CapturedJobOutput[jobID] = v
+// 	sc.CapturedJobOutput[jobID] = v
+// }
+
+func (sc *testStreamCloser) RegisterJob(id string) chan string {
+	v := []string{}
+	ch := make(chan string)
+	go func() {
+		for s := range ch {
+			v = append(v, s)
+		}
+		sc.CapturedJobOutput[id] = v
+	}()
+	return ch
 }
 
 func (sc *testStreamCloser) CloseJob(ctx context.Context, jobID string) error {

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -218,18 +218,6 @@ type testStreamCloser struct {
 	CapturedJobOutput map[string][]string
 }
 
-// func (sc *testStreamCloser) Stream(jobID string, msg string) {
-// 	v, ok := sc.CapturedJobOutput[jobID]
-
-// 	if !ok {
-// 		v = []string{}
-// 	}
-
-// 	v = append(v, msg)
-
-// 	sc.CapturedJobOutput[jobID] = v
-// }
-
 func (sc *testStreamCloser) RegisterJob(id string) chan string {
 	v := []string{}
 	ch := make(chan string)


### PR DESCRIPTION
Atlantis graceful shutdown has not been working as intended since the beginning (ie. 2 years ago).  On the atlantis side, we wait for in-progress tf operations to resolve and go and update all the gh status checks accordingly before shutting down.
However, our tf subprocess actually immediately gets interrupted when a sigterm is received because of the way os.exec works in go by default.  

os exec processes listen to sigterms of their parents and there is a specific thing you need to do basically to prevent that from happening and that's by setting:
```
cmd.SysProcAttr = &syscall.SysProcAttr{
                Setpgid: true,
}
```

In fixing this, I unraveled a couple other issues with shutdown:
1. Having a global output channel doesn't work because we can't predict when to close it.  Previously we were just closing it when the worker returns but this is incorrect since activities can still be running at this point.  The worker doesn't wait for all resources to be cleaned up or all activities to be complete.
2. We can't just assume all our jobs are complete and close them since we drop logs in this case. Instead, we need to wait until all operations have complete before closing and uploading to s3.

Note: I also noticed here that we will drop init logs if we shutdown in between init and plan.  This is incorrect and we need to fix however, it's not critical atm since init logs aren't that useful anyways.