### PR TITLE
Don't create gateway pending checkrun on comment events when PR is closed

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -92,7 +92,7 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 }
 
 func (p *CommentEventWorkerProxy) handleLegacyComment(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
-	if cmd.Name == command.Plan || cmd.Name == command.Apply {
+	if event.Pull.State != models.ClosedPullState && (cmd.Name == command.Plan || cmd.Name == command.Apply) {
 		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Request received. Adding to the queue..."); err != nil {
 			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
 		}


### PR DESCRIPTION
Note: this won't be an issue for pull events since we only create the check run on an Open/Update PR event.