### PR TITLE
Add ScheduleToStartTimeout support to detect worker death.

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -195,6 +195,9 @@ func getCheckStateAndConclusion(internalState internal.CheckRunState) (string, s
 	case internal.CheckRunSuccess:
 		state = "completed"
 		conclusion = "success"
+	case internal.CheckRunTimeout:
+		state = "completed"
+		conclusion = "timed_out"
 	case internal.CheckRunActionRequired:
 		state = "completed"
 		conclusion = "action_required"

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -16,13 +16,16 @@ var checkrunTemplateStr string
 var checkrunTemplate = template.Must(template.New("").Parse(checkrunTemplateStr))
 
 type checkrunTemplateData struct {
-	ApplyActionsSummary string
-	PlanStatus          string
-	PlanLogURL          string
-	ApplyStatus         string
-	ApplyLogURL         string
-	InternalError       bool
-	TimedOut            bool
+	ApplyActionsSummary     string
+	PlanStatus              string
+	PlanLogURL              string
+	ApplyStatus             string
+	ApplyLogURL             string
+	InternalError           bool
+	TimedOut                bool
+	ActivityDurationTimeout bool
+	SchedulingTimeout       bool
+	HeartbeatTimeout        bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -32,7 +35,10 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	// we can probably pass in the completion reason but i like doing all the boolean
 	// checking here if we can instead of in the template.
 	internalError := workflowState.Result.Reason == state.InternalServiceError
-	timedOut := workflowState.Result.Reason == state.TimedOutError
+	timedOut := workflowState.Result.Reason == state.TimeoutError
+	activityDurationTimeout := workflowState.Result.Reason == state.ActivityDurationTimeoutError
+	schedulingTimeout := workflowState.Result.Reason == state.SchedulingTimeoutError
+	hearbeatTimeout := workflowState.Result.Reason == state.HeartbeatTimeoutError
 
 	var applyActionsSummary string
 
@@ -40,13 +46,16 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 		applyActionsSummary = workflowState.Apply.GetActions().Summary
 	}
 	return renderTemplate(checkrunTemplate, checkrunTemplateData{
-		PlanStatus:          planStatus,
-		PlanLogURL:          planLogURL,
-		ApplyStatus:         applyStatus,
-		ApplyLogURL:         applyLogURL,
-		InternalError:       internalError,
-		TimedOut:            timedOut,
-		ApplyActionsSummary: applyActionsSummary,
+		PlanStatus:              planStatus,
+		PlanLogURL:              planLogURL,
+		ApplyStatus:             applyStatus,
+		ApplyLogURL:             applyLogURL,
+		InternalError:           internalError,
+		TimedOut:                timedOut,
+		ActivityDurationTimeout: activityDurationTimeout,
+		SchedulingTimeout:       schedulingTimeout,
+		HeartbeatTimeout:        hearbeatTimeout,
+		ApplyActionsSummary:     applyActionsSummary,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -26,6 +26,22 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 {{end}}
 {{if .TimedOut }}
 ## Timeout :clock1:
-:point_right: One or more operations has timed out. It's possible that a terraform operation is still making progress, this can be confirmed by checking the logs above. However,
-this deployment will need to be retried for this check to go green.
+:point_right: We've hit an unknown timeout.  Please retry the deployment. If this persists this is most likely a bug, please contact the owners of atlantis so they can diagnose it.
+{{end}}
+
+{{if .ActivityDurationTimeout }}
+## Timeout :clock1:
+:point_right: An operation has taken longer than 60 minutes and has timed out.  Please look at the logs and determine if this is intentional or not.
+To increase this timeout value beyond 60 minutes, please contact the owners of atlantis.
+{{end}}
+
+{{if .SchedulingTimeout }}
+## Timeout :clock1:
+:point_right: An operation has failed to be scheduled. Terraform operations need to be scheduled on the same worker so this is indicative of a worker process dying.  Hang tight while 
+we reschedule the workflow on another worker.  This check run will be updated with the new results.
+{{end}}
+
+{{if .HeartbeatTimeout }}
+## Timeout :clock1:
+:point_right: A long running operation has been lost. Please retry the deployment by hitting the "re-run" button.
 {{end}}

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	constants "github.com/runatlantis/atlantis/server/events/metrics"
@@ -60,6 +61,10 @@ func (r *WorkflowRunner) Run(ctx workflow.Context, deploymentInfo DeploymentInfo
 	id := deploymentInfo.ID
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID: id.String(),
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+			InitialInterval: 1 * time.Minute,
+		},
 
 		// allows all signals to be received even in a cancellation state
 		WaitForCancellation: true,

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -152,8 +152,17 @@ func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState 
 		return github.CheckRunSuccess
 	}
 
-	if workflowState.Result.Reason == state.TimedOutError {
-		return github.CheckRunTimeout
+	timeouts := []state.WorkflowCompletionReason{
+		state.TimeoutError,
+		state.ActivityDurationTimeoutError,
+		state.HeartbeatTimeoutError,
+		state.SchedulingTimeoutError,
+	}
+
+	for _, t := range timeouts {
+		if workflowState.Result.Reason == t {
+			return github.CheckRunTimeout
+		}
 	}
 
 	return github.CheckRunFailure

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -266,7 +266,7 @@ func TestStateReceive(t *testing.T) {
 				},
 				Result: state.WorkflowResult{
 					Status: state.CompleteWorkflowStatus,
-					Reason: state.TimedOutError,
+					Reason: state.TimeoutError,
 				},
 			},
 			ExpectedCheckRunState: github.CheckRunTimeout,

--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -18,6 +18,8 @@ type Request struct {
 const (
 	PlanRejectedErrorType = "PlanRejectedError"
 	UpdateJobErrorType    = "UpdateJobError"
+	UnknownErrorType      = "UnknownError"
+	SchedulingError       = "SchedulingError"
 )
 
 type ExternalError struct {

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -32,7 +32,10 @@ const (
 	UnknownCompletionReason WorkflowCompletionReason = iota
 	SuccessfulCompletionReason
 	InternalServiceError
-	TimedOutError
+	TimeoutError
+	SchedulingTimeoutError
+	HeartbeatTimeoutError
+	ActivityDurationTimeoutError
 )
 
 type JobOutput struct {


### PR DESCRIPTION
**To recap, the core problem is:**
When we are deploying to a temporal worker, the worker will drain all existing requests before shutting down and starting up and no new work can get scheduled on that worker.
**Why is this a problem?**
Well this means that any users that need to apply their plan, now have to wait until the worker is back up before they can do so (since we store the planfile on disk).  It’s rare but terraform operations can be long lived and can therefore block users.
This is unfortunate because we have multiple workers, and new terraform plans will have no problem being scheduled on other workers that are available.

**How does this PR solve this issue?**
We are using temporal’s `ScheduleToStartTimeout` which tracks the time between when work is scheduled and when it actually starts on a worker. When this timeout is hit, we fail our child workflow with a retryable error, therefore it gets rescheduled in its entirety on a new available worker.

**Failure Scenarios**
1. A rolling deploy just keeps rescheduling your workflow from the beginning on each single worker (like a domino effect) this is a worst case though and is unlikely.
AI: Monitor retries and alarm when we've hit the limit.  

2. If our fleet of workers, isn’t capable of handling a large load of work we could hit this timeout a lot and essentially just keep trying to reschedule HOWEVER, we do have exponential backoff which should help with that situation and we’d alarm on scheduling latencies so we’d be able to scale up our stateful set manually to mitigate.

3. If we are hard down for a period of time all in progress workflows could be rescheduled at once from the beginning again.  So we could blow out our disk once we come back up since we would basically clone all at once, HOWEVER we have precautions in place to rate limit work being pulled from the task queue for situations like that so we should be ok.