### PR TITLE
Increase clone depth to 5

### DIFF
--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -77,7 +77,7 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
 	builderOptions := BuilderOptions{
 		RepoFetcherOptions: github.RepoFetcherOptions{
-			CloneDepth: 3,
+			CloneDepth: 5,
 		},
 		FileFetcherOptions: github.FileFetcherOptions{
 			Sha: event.Sha,


### PR DESCRIPTION
Increasing clone depth to 5 for push events to capture more diffs from rapidly modified repos.