### PR TITLE
Add error log in check run handler

### DIFF
--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -68,6 +68,7 @@ func (h *CheckRunHandler) Handle(ctx context.Context, event CheckRun) error {
 	}
 	matches := checkRunRegex.FindStringSubmatch(event.Name)
 	if len(matches) != 2 {
+		h.Logger.ErrorContext(ctx, fmt.Sprintf("unable to determine root name: %s", event.Name))
 		return fmt.Errorf("unable to determine root name")
 	}
 	rootName := matches[checkRunRegex.SubexpIndex("name")]


### PR DESCRIPTION
We miss logging this error since it is not performed within the scheduler.