### PR TITLE
Fix GH checkrun handler prefix check

### DIFF
--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -62,7 +62,7 @@ type CheckRunHandler struct {
 
 func (h *CheckRunHandler) Handle(ctx context.Context, event CheckRun) error {
 	// first let's make sure this is an atlantis check run
-	if !strings.HasPrefix(event.Name, "atlantis") {
+	if !strings.HasPrefix(event.Name, "atlantis/deploy") {
 		h.Logger.DebugContext(ctx, "Ignoring non-atlantis checks event")
 		return nil
 	}

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -210,7 +210,7 @@ func TestCheckRunHandler(t *testing.T) {
 		assert.True(t, signaler.called)
 	})
 
-	t.Run("invalid root name", func(t *testing.T) {
+	t.Run("non-deploy atlantis check run", func(t *testing.T) {
 		user := models.User{Username: "nish"}
 		workflowID := "testrepo||testroot"
 		subject := event.CheckRunHandler{
@@ -223,7 +223,7 @@ func TestCheckRunHandler(t *testing.T) {
 			ExternalID: workflowID,
 			User:       user,
 			Repo:       models.Repo{FullName: "testrepo"},
-			Name:       "atlantis/invalid: testroot",
+			Name:       "atlantis/plan: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
 		assert.NoError(t, err)

--- a/server/neptune/gateway/event/check_run_handler_test.go
+++ b/server/neptune/gateway/event/check_run_handler_test.go
@@ -226,7 +226,7 @@ func TestCheckRunHandler(t *testing.T) {
 			Name:       "atlantis/invalid: testroot",
 		}
 		err := subject.Handle(context.Background(), e)
-		assert.ErrorContains(t, err, "unable to determine root name")
+		assert.NoError(t, err)
 	})
 
 	t.Run("signal error", func(t *testing.T) {


### PR DESCRIPTION
We shouldn't error when the check run prefix handler receives a non-deploy atlantis check run (ex: `atlantis/plan`). Instead we should silently skip filter those out.