### PR TITLE
Support deploying explicit roots.

### DIFF
--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -88,11 +88,11 @@ func NewVCSEventsController(
 	}
 
 	checkRunHandler := &gateway_handlers.CheckRunHandler{
-		Logger:            logger,
-		RootConfigBuilder: rootConfigBuilder,
-		SyncScheduler:     syncScheduler,
-		AsyncScheduler:    asyncScheduler,
-		DeploySignaler:    deploySignaler,
+		Logger:         logger,
+		RootDeployer:   rootDeployer,
+		SyncScheduler:  syncScheduler,
+		AsyncScheduler: asyncScheduler,
+		DeploySignaler: deploySignaler,
 	}
 
 	checkSuiteHandler := &gateway_handlers.CheckSuiteHandler{

--- a/server/neptune/gateway/event/check_suite_handler.go
+++ b/server/neptune/gateway/event/check_suite_handler.go
@@ -5,7 +5,6 @@ import (
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
-	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 )
 
 type CheckSuite struct {
@@ -39,19 +38,12 @@ func (h *CheckSuiteHandler) Handle(ctx context.Context, event CheckSuite) error 
 }
 
 func (h *CheckSuiteHandler) handle(ctx context.Context, event CheckSuite) error {
-	builderOptions := BuilderOptions{
-		RepoFetcherOptions: github.RepoFetcherOptions{},
-		FileFetcherOptions: github.FileFetcherOptions{
-			Sha: event.HeadSha,
-		},
-	}
 	rootDeployOptions := RootDeployOptions{
 		Repo:              event.Repo,
 		Branch:            event.Branch,
 		Revision:          event.HeadSha,
 		Sender:            event.Sender,
 		InstallationToken: event.InstallationToken,
-		BuilderOptions:    builderOptions,
 		Trigger:           workflows.ManualTrigger,
 		Rerun:             true,
 	}

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
-	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/command"
@@ -144,19 +143,13 @@ func (p *CommentEventWorkerProxy) forwardToSns(ctx context.Context, request *htt
 }
 
 func (p *CommentEventWorkerProxy) forceApply(ctx context.Context, event Comment) error {
-	// TODO: consider supporting shallow cloning for comment based events too
-	builderOptions := BuilderOptions{
-		FileFetcherOptions: github.FileFetcherOptions{
-			PRNum: event.PullNum,
-		},
-	}
 	rootDeployOptions := RootDeployOptions{
 		Repo:              event.HeadRepo,
 		Branch:            event.Pull.HeadBranch,
 		Revision:          event.Pull.HeadCommit,
+		OptionalPullNum:   event.Pull.Num,
 		Sender:            event.User,
 		InstallationToken: event.InstallationToken,
-		BuilderOptions:    builderOptions,
 		Trigger:           workflows.ManualTrigger,
 	}
 	return p.rootDeployer.Deploy(ctx, rootDeployOptions)

--- a/server/neptune/gateway/event/deployer.go
+++ b/server/neptune/gateway/event/deployer.go
@@ -39,7 +39,7 @@ type RootDeployOptions struct {
 	Revision  string
 
 	// By Specifying this, consumers can trigger deploys for all the roots modified in a PR if no roots are specified.
-	// By default, computed roots are only based on the different between the provided revision and revision - 1.
+	// By default, computed roots are only based on the difference between the provided revision and revision - 1.
 	OptionalPullNum int
 
 	// User to attribute this deploy to

--- a/server/neptune/gateway/event/deployer.go
+++ b/server/neptune/gateway/event/deployer.go
@@ -2,12 +2,14 @@ package event
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
 	contextInternal "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"go.temporal.io/sdk/client"
 )
 
@@ -17,7 +19,7 @@ type deploySignaler interface {
 }
 
 type rootConfigBuilder interface {
-	Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64, builderOptions BuilderOptions) ([]*valid.MergedProjectCfg, error)
+	Build(ctx context.Context, commit *RepoCommit, installationToken int64, opts ...BuilderOptions) ([]*valid.MergedProjectCfg, error)
 }
 
 type RootDeployer struct {
@@ -26,19 +28,46 @@ type RootDeployer struct {
 	DeploySignaler    deploySignaler
 }
 
+// RootDeployOptions is basically a modeled request for RootDeployer, options isn't really the right word here
 type RootDeployOptions struct {
-	Repo              models.Repo
-	Branch            string
-	Revision          string
+	Repo models.Repo
+
+	// RootNames specify an optional list of roots to deploy for, if this is not provided, the roots are computed
+	// via the configured fallback strategy.
+	RootNames []string
+	Branch    string
+	Revision  string
+
+	// By Specifying this, consumers can trigger deploys for all the roots modified in a PR if no roots are specified.
+	// By default, computed roots are only based on the different between the provided revision and revision - 1.
+	OptionalPullNum int
+
+	// User to attribute this deploy to
 	Sender            models.User
 	InstallationToken int64
-	BuilderOptions    BuilderOptions
-	Trigger           workflows.Trigger
-	Rerun             bool
+
+	// TODO: Remove this from this struct, consumers shouldn't need to know about this
+	// instead we should just inject implementations of RepoFetcher to handle different scenarios
+	RepoFetcherOptions *github.RepoFetcherOptions
+	Trigger            workflows.Trigger
+	Rerun              bool
 }
 
 func (d *RootDeployer) Deploy(ctx context.Context, deployOptions RootDeployOptions) error {
-	rootCfgs, err := d.RootConfigBuilder.Build(ctx, deployOptions.Repo, deployOptions.Branch, deployOptions.Revision, deployOptions.InstallationToken, deployOptions.BuilderOptions)
+
+	commit := &RepoCommit{
+		Repo:          deployOptions.Repo,
+		Branch:        deployOptions.Branch,
+		Sha:           deployOptions.Revision,
+		OptionalPRNum: deployOptions.OptionalPullNum,
+	}
+
+	opts := BuilderOptions{
+		RootNames:          deployOptions.RootNames,
+		RepoFetcherOptions: deployOptions.RepoFetcherOptions,
+	}
+
+	rootCfgs, err := d.RootConfigBuilder.Build(ctx, commit, deployOptions.InstallationToken, opts)
 	if err != nil {
 		return errors.Wrap(err, "generating roots")
 	}

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -75,22 +75,16 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 }
 
 func (p *PushHandler) handle(ctx context.Context, event Push) error {
-	builderOptions := BuilderOptions{
-		RepoFetcherOptions: github.RepoFetcherOptions{
-			CloneDepth: 5,
-		},
-		FileFetcherOptions: github.FileFetcherOptions{
-			Sha: event.Sha,
-		},
-	}
 	rootDeployOptions := RootDeployOptions{
 		Repo:              event.Repo,
 		Branch:            event.Ref.Name,
 		Revision:          event.Sha,
 		Sender:            event.Sender,
 		InstallationToken: event.InstallationToken,
-		BuilderOptions:    builderOptions,
-		Trigger:           workflows.MergeTrigger,
+		RepoFetcherOptions: &github.RepoFetcherOptions{
+			CloneDepth: 5,
+		},
+		Trigger: workflows.MergeTrigger,
 	}
 	return p.RootDeployer.Deploy(ctx, rootDeployOptions)
 }

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -158,7 +158,7 @@ func (b *RootConfigBuilder) build(ctx context.Context, commit *RepoCommit, insta
 	return mergedRootCfgs, nil
 }
 
-func (b *RootConfigBuilder) getMatchingRoots(ctx context.Context, config valid.RepoCfg, repo *LocalRepo, installationToken int64, rootNames[]string) ([]valid.Project, error) {
+func (b *RootConfigBuilder) getMatchingRoots(ctx context.Context, config valid.RepoCfg, repo *LocalRepo, installationToken int64, rootNames []string) ([]valid.Project, error) {
 	if len(rootNames) > 0 {
 		return b.validateAndGetRoots(ctx, config, rootNames)
 	}

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -3,6 +3,8 @@ package event
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -40,24 +42,58 @@ type parserValidator interface {
 	ParseRepoCfg(absRepoDir string, repoID string) (valid.RepoCfg, error)
 }
 
+type ModifiedRootsStrategy struct {
+	FileFetcher fileFetcher
+	RootFinder  rootFinder
+}
+
+func (s *ModifiedRootsStrategy) FindMatches(ctx context.Context, config valid.RepoCfg, repo *LocalRepo, installationToken int64) ([]valid.Project, error) {
+	// Fetch files modified in commit
+	modifiedFiles, err := s.FileFetcher.GetModifiedFiles(ctx, repo.RepoCommit.Repo, installationToken, github.FileFetcherOptions{
+		PRNum: repo.RepoCommit.OptionalPRNum,
+		Sha:   repo.RepoCommit.Sha,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding modified files: %s", modifiedFiles)
+	}
+
+	matchingRoots, err := s.RootFinder.FindRoots(ctx, config, repo.Dir, modifiedFiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "determining roots")
+	}
+
+	return matchingRoots, nil
+}
+
+type RepoCommit struct {
+	Repo          models.Repo
+	Branch        string
+	Sha           string
+	OptionalPRNum int
+}
+
+type LocalRepo struct {
+	*RepoCommit
+	Dir string
+}
+
 type RootConfigBuilder struct {
 	RepoFetcher     repoFetcher
 	HooksRunner     hooksRunner
 	ParserValidator parserValidator
-	RootFinder      rootFinder
-	FileFetcher     fileFetcher
+	Strategy        *ModifiedRootsStrategy
 	GlobalCfg       valid.GlobalCfg
 	Logger          logging.Logger
 	Scope           tally.Scope
 }
 
 type BuilderOptions struct {
-	RepoFetcherOptions github.RepoFetcherOptions
-	FileFetcherOptions github.FileFetcherOptions
+	RepoFetcherOptions *github.RepoFetcherOptions
+	RootNames          []string
 }
 
-func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64, builderOptions BuilderOptions) ([]*valid.MergedProjectCfg, error) {
-	mergedRootCfgs, err := b.build(ctx, repo, branch, sha, installationToken, builderOptions)
+func (b *RootConfigBuilder) Build(ctx context.Context, commit *RepoCommit, installationToken int64, opts ...BuilderOptions) ([]*valid.MergedProjectCfg, error) {
+	mergedRootCfgs, err := b.build(ctx, commit, installationToken, opts...)
 	if err != nil {
 		b.Scope.Counter(metrics.FilterErrorMetric).Inc(1)
 		return nil, err
@@ -70,40 +106,89 @@ func (b *RootConfigBuilder) Build(ctx context.Context, repo models.Repo, branch 
 	return mergedRootCfgs, nil
 }
 
-func (b *RootConfigBuilder) build(ctx context.Context, repo models.Repo, branch string, sha string, installationToken int64, builderOptions BuilderOptions) ([]*valid.MergedProjectCfg, error) {
+func (b *RootConfigBuilder) build(ctx context.Context, commit *RepoCommit, installationToken int64, opts ...BuilderOptions) ([]*valid.MergedProjectCfg, error) {
+	var repoOptions github.RepoFetcherOptions
+	var rootNames []string
+	for _, o := range opts {
+		if o.RepoFetcherOptions != nil {
+			repoOptions = *o.RepoFetcherOptions
+		}
+
+		if len(o.RootNames) > 0 {
+			rootNames = o.RootNames
+		}
+	}
+
 	// Generate a new filepath location and clone repo into it
-	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, repo, branch, sha, builderOptions.RepoFetcherOptions)
+	repoDir, cleanup, err := b.RepoFetcher.Fetch(ctx, commit.Repo, commit.Branch, commit.Sha, repoOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("creating temporary clone at path: %s", repoDir))
 	}
 	defer cleanup(ctx, repoDir)
 
-	// Run pre-workflow hooks
-	err = b.HooksRunner.Run(ctx, repo, repoDir)
-	if err != nil {
-		return nil, errors.Wrap(err, "running pre-workflow hooks")
+	// ideally we should pass this around instead of repoDir separately
+	localRepo := &LocalRepo{
+		RepoCommit: commit,
+		Dir:        repoDir,
 	}
 
-	// Fetch files modified in commit
-	modifiedFiles, err := b.FileFetcher.GetModifiedFiles(ctx, repo, installationToken, builderOptions.FileFetcherOptions)
+	// Run pre-workflow hooks
+	err = b.HooksRunner.Run(ctx, localRepo.Repo, localRepo.Dir)
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding modified files: %s", modifiedFiles)
+		return nil, errors.Wrap(err, "running pre-workflow hooks")
 	}
 
 	// Parse repo configs into specific root configs (i.e. roots)
 	// TODO: rename project to roots
 	var mergedRootCfgs []*valid.MergedProjectCfg
-	repoCfg, err := b.ParserValidator.ParseRepoCfg(repoDir, repo.ID())
+	repoCfg, err := b.ParserValidator.ParseRepoCfg(repoDir, localRepo.Repo.ID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", config.AtlantisYAMLFilename)
 	}
-	matchingRoots, err := b.RootFinder.FindRoots(ctx, repoCfg, repoDir, modifiedFiles)
+
+	matchingRoots, err := b.getMatchingRoots(ctx, repoCfg, localRepo, installationToken, rootNames)
 	if err != nil {
-		return nil, errors.Wrap(err, "determining roots")
+		return nil, errors.Wrap(err, "getting matching roots")
 	}
+
 	for _, mr := range matchingRoots {
-		mergedRootCfg := b.GlobalCfg.MergeProjectCfg(repo.ID(), mr, repoCfg)
+		mergedRootCfg := b.GlobalCfg.MergeProjectCfg(localRepo.Repo.ID(), mr, repoCfg)
 		mergedRootCfgs = append(mergedRootCfgs, &mergedRootCfg)
 	}
 	return mergedRootCfgs, nil
+}
+
+func (b *RootConfigBuilder) getMatchingRoots(ctx context.Context, config valid.RepoCfg, repo *LocalRepo, installationToken int64, rootNames[]string) ([]valid.Project, error) {
+	if len(rootNames) > 0 {
+		return b.validateAndGetRoots(ctx, config, rootNames)
+	}
+
+	return b.Strategy.FindMatches(ctx, config, repo, installationToken)
+}
+
+func (b *RootConfigBuilder) validateAndGetRoots(ctx context.Context, config valid.RepoCfg, rootNames []string) ([]valid.Project, error) {
+	rootSet := make(map[string]valid.Project)
+
+	for _, p := range config.Projects {
+
+		// Project Name is not guaranteed in upstream atlantis but is guaranteed in ours so its OK to dereference
+		rootSet[*p.Name] = p
+	}
+
+	var results []valid.Project
+	var invalidRootNames []string
+	for _, n := range rootNames {
+		if p, ok := rootSet[n]; ok {
+			results = append(results, p)
+			continue
+		}
+
+		invalidRootNames = append(invalidRootNames, n)
+	}
+
+	if len(invalidRootNames) > 0 {
+		return results, fmt.Errorf("%s are invalid root names", strings.Join(invalidRootNames, ", "))
+	}
+
+	return results, nil
 }

--- a/server/neptune/gateway/event/root_config_builder.go
+++ b/server/neptune/gateway/event/root_config_builder.go
@@ -141,7 +141,7 @@ func (b *RootConfigBuilder) build(ctx context.Context, commit *RepoCommit, insta
 	// Parse repo configs into specific root configs (i.e. roots)
 	// TODO: rename project to roots
 	var mergedRootCfgs []*valid.MergedProjectCfg
-	repoCfg, err := b.ParserValidator.ParseRepoCfg(repoDir, localRepo.Repo.ID())
+	repoCfg, err := b.ParserValidator.ParseRepoCfg(localRepo.Dir, localRepo.Repo.ID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing %s", config.AtlantisYAMLFilename)
 	}
@@ -160,13 +160,13 @@ func (b *RootConfigBuilder) build(ctx context.Context, commit *RepoCommit, insta
 
 func (b *RootConfigBuilder) getMatchingRoots(ctx context.Context, config valid.RepoCfg, repo *LocalRepo, installationToken int64, rootNames []string) ([]valid.Project, error) {
 	if len(rootNames) > 0 {
-		return b.validateAndGetRoots(ctx, config, rootNames)
+		return b.validateAndGetRoots(config, rootNames)
 	}
 
 	return b.Strategy.FindMatches(ctx, config, repo, installationToken)
 }
 
-func (b *RootConfigBuilder) validateAndGetRoots(ctx context.Context, config valid.RepoCfg, rootNames []string) ([]valid.Project, error) {
+func (b *RootConfigBuilder) validateAndGetRoots(config valid.RepoCfg, rootNames []string) ([]valid.Project, error) {
 	rootSet := make(map[string]valid.Project)
 
 	for _, p := range config.Projects {

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -296,11 +296,13 @@ func NewServer(config Config) (*Server, error) {
 		RepoFetcher:     repoFetcher,
 		HooksRunner:     hooksRunner,
 		ParserValidator: &event.ParserValidator{GlobalCfg: globalCfg},
-		RootFinder:      &event.RepoRootFinder{Logger: ctxLogger},
-		FileFetcher:     &github.RemoteFileFetcher{ClientCreator: clientCreator},
-		GlobalCfg:       globalCfg,
-		Logger:          ctxLogger,
-		Scope:           statsScope.SubScope("event.filters.root"),
+		Strategy: &event.ModifiedRootsStrategy{
+			RootFinder:  &event.RepoRootFinder{Logger: ctxLogger},
+			FileFetcher: &github.RemoteFileFetcher{ClientCreator: clientCreator},
+		},
+		GlobalCfg: globalCfg,
+		Logger:    ctxLogger,
+		Scope:     statsScope.SubScope("event.filters.root"),
 	}
 
 	checkRunFetcher := &github.CheckRunsFetcher{

--- a/server/vcs/provider/github/file_fetcher.go
+++ b/server/vcs/provider/github/file_fetcher.go
@@ -12,6 +12,10 @@ type RemoteFileFetcher struct {
 	ClientCreator githubapp.ClientCreator
 }
 
+// FileFetcherOptions dictates the context of fetching modified files.
+// If a sha is provided, we get the modified files within the context of said sha
+// If a PR number is provided, we get the modified files for the whole PR
+// If both, we prioritize PR number
 type FileFetcherOptions struct {
 	Sha   string
 	PRNum int
@@ -24,10 +28,10 @@ func (r *RemoteFileFetcher) GetModifiedFiles(ctx context.Context, repo models.Re
 	}
 
 	var run func(ctx context.Context, nextPage int) ([]*gh.CommitFile, *gh.Response, error)
-	if fileFetcherOptions.Sha != "" {
-		run = GetCommit(client, repo, fileFetcherOptions)
-	} else if fileFetcherOptions.PRNum != 0 {
+	if fileFetcherOptions.PRNum != 0 {
 		run = ListFiles(client, repo, fileFetcherOptions)
+	} else if fileFetcherOptions.Sha != "" {
+		run = GetCommit(client, repo, fileFetcherOptions)
 	} else {
 		return nil, errors.New("invalid fileFetcherOptions")
 	}


### PR DESCRIPTION
Slight refactor to support deploying explicit roots and also allowing our check run handler to bypass some gh calls by using the specified root directly.