### PR TITLE
Start PR Revision Workflow after a deployment is complete

### DIFF
--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -229,6 +229,10 @@ func NewRevisionSetter(cfg valid.RevisionSetter) (*RevsionSetter, error) {
 		client = &http.Client{}
 	}
 
+	return NewRevisionSetterWithClient(client, cfg)
+}
+
+func NewRevisionSetterWithClient(client revisionSetterClient, cfg valid.RevisionSetter) (*RevsionSetter, error) {
 	return &RevsionSetter{
 		prRevisionSetterActivities: &prRevisionSetterActivities{
 			client:    client,

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -37,5 +37,5 @@ var DeployTaskQueue = deploy.TaskQueue
 var DeployNewRevisionSignalID = revision.NewRevisionSignalID
 
 func Deploy(ctx workflow.Context, request DeployRequest) error {
-	return deploy.Workflow(ctx, request, Terraform)
+	return deploy.Workflow(ctx, request, Terraform, PRRevision)
 }

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -197,12 +197,12 @@ func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironm
 	assert.NoError(t, err)
 
 	githubClient := &testGithubClient{}
-
 	githubActivities, err := activities.NewGithubWithClient(
 		githubClient,
 		cfg.DataDir,
 		GetLocalTestRoot,
 	)
+	assert.NoError(t, err)
 
 	revSetterClient := &testRevSetterClient{}
 	revisionSetterActivities, err := activities.NewRevisionSetterWithClient(

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	internalGithub "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -48,7 +47,7 @@ func TestDeployWorkflow(t *testing.T) {
 
 	env.RegisterWorkflow(workflows.Deploy)
 	env.RegisterWorkflow(workflows.Terraform)
-	env.RegisterWorkflow(prrevision.Workflow)
+	env.RegisterWorkflow(workflows.PRRevision)
 
 	env.RegisterDelayedCallback(func() {
 		signalWorkflow(env)

--- a/server/neptune/workflows/internal/deploy/request/converter/root.go
+++ b/server/neptune/workflows/internal/deploy/request/converter/root.go
@@ -20,10 +20,11 @@ func Root(external request.Root) terraform.Root {
 				Type: terraform.PlanApprovalType(external.PlanApproval.Type),
 			},
 		},
-		Path:      external.RepoRelPath,
-		TfVersion: external.TfVersion,
-		Trigger:   terraform.Trigger(external.Trigger),
-		Rerun:     external.Rerun,
+		Path:         external.RepoRelPath,
+		TfVersion:    external.TfVersion,
+		Trigger:      terraform.Trigger(external.Trigger),
+		Rerun:        external.Rerun,
+		TrackedFiles: external.TrackedFiles,
 	}
 
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -140,8 +140,8 @@ func (p *Deployer) startPRRevisionWorkflow(ctx workflow.Context, deployment terr
 	})
 
 	var childWE workflow.Execution
-	if err := future.GetChildWorkflowExecution().Get(ctx, &childWE); err == nil {
-		scope.Counter("start_pr_rev_wf_err").Inc(1)
+	if err := future.GetChildWorkflowExecution().Get(ctx, &childWE); err != nil {
+		scope.SubScope("prrevision").Counter("start_wf_err").Inc(1)
 		return err
 	}
 	return nil

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -98,7 +98,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWor
 	}
 
 	// log error and continue deploy if setting revision for open PRs modifying this root fails since it's not critical to the deploy
-	if prRevErr := startPRRevisionWorkflow(ctx, requestedDeployment); prRevErr != nil {
+	if prRevErr := p.startPRRevisionWorkflow(ctx, requestedDeployment); prRevErr != nil {
 		logger.Error(ctx, "unable to start PR Revision workflow", key.ErrKey, prRevErr)
 	}
 
@@ -108,7 +108,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWor
 	return latestDeployment, err
 }
 
-func startPRRevisionWorkflow(ctx workflow.Context, deployment terraform.DeploymentInfo) error {
+func (p *Deployer) startPRRevisionWorkflow(ctx workflow.Context, deployment terraform.DeploymentInfo) error {
 	version := workflow.GetVersion(ctx, version.SetPRRevision, workflow.DefaultVersion, 1)
 	if version == workflow.DefaultVersion {
 		return nil
@@ -126,7 +126,7 @@ func startPRRevisionWorkflow(ctx workflow.Context, deployment terraform.Deployme
 		ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 	})
 
-	future := workflow.ExecuteChildWorkflow(ctx, prrevision.Workflow, prrevision.Request{
+	future := workflow.ExecuteChildWorkflow(ctx, p.PRRevisionWorkflow, prrevision.Request{
 		Repo:     deployment.Repo,
 		Root:     deployment.Root,
 		Revision: deployment.Revision,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -22,8 +22,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-const PRRevisionWorkflowRetryCount = 3
-
 type ValidationError struct {
 	error
 }
@@ -94,7 +92,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraformWor
 
 	// log error and continue deploys if any of the post deploy task fails
 	if err := p.runPostDeployTasks(ctx, requestedDeployment, scope); err != nil {
-		logger.Error(ctx, "error running post deploy task", key.ErrKey, err)
+		logger.Error(ctx, "error running post deploy tasks", key.ErrKey, err)
 	}
 
 	// Count this as deployment as latest if it's not a PlanRejectionError which means it is a TerraformClientError

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -124,9 +124,7 @@ func (p *Deployer) startPRRevisionWorkflow(ctx workflow.Context, deployment terr
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		TaskQueue: prrevision.TaskQueue,
 		RetryPolicy: &temporal.RetryPolicy{
-
-			// starting pr revision wf shouldn't take more than 3 tries unless the worker is down, which we'll get alarmed on to fix
-			MaximumAttempts: PRRevisionWorkflowRetryCount,
+			MaximumAttempts: 1,
 		},
 
 		// configuring this ensures the child workflow will continue execution when the parent workflow terminates

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -55,7 +55,10 @@ type Deployer struct {
 	Activities              deployerActivities
 	TerraformWorkflowRunner terraformWorkflowRunner
 	GithubCheckRunCache     CheckRunClient
+	PRRevisionWorkflow      Workflow
 }
+
+type Workflow func(ctx workflow.Context, request prrevision.Request) error
 
 const (
 	DirectionBehindSummary   = "This revision is behind the current revision and will not be deployed.  If this is intentional, revert the default branch to this revision to trigger a new deployment."

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -76,6 +76,10 @@ type deployerRequest struct {
 	ExpectedT         *testing.T
 }
 
+func testPRRevWorkflow(ctx workflow.Context, request prrevision.Request) error {
+	return nil
+}
+
 func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.Info, error) {
 	options := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
@@ -95,6 +99,7 @@ func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.
 			expectedT:            r.ExpectedT,
 			expectedDeploymentID: r.Info.ID.String(),
 		},
+		PRRevisionWorkflow: testPRRevWorkflow,
 	}
 
 	return deployer.Deploy(ctx, r.Info, r.LatestDeploy, metrics.NewNullableScope())
@@ -140,8 +145,8 @@ func TestDeployer_FirstDeploy(t *testing.T) {
 			}
 
 			if c.setPRRevision {
-				env.RegisterWorkflow(prrevision.Workflow)
-				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+				env.RegisterWorkflow(testPRRevWorkflow)
+				env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
 					Repo:     repo,
 					Root:     root,
 					Revision: deploymentInfo.Revision,
@@ -236,8 +241,8 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 			}
 
 			if c.setPRRevision {
-				env.RegisterWorkflow(prrevision.Workflow)
-				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+				env.RegisterWorkflow(testPRRevWorkflow)
+				env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
 					Repo:     repo,
 					Root:     root,
 					Revision: deploymentInfo.Revision,
@@ -364,8 +369,8 @@ func TestDeployer_CompareCommit_Identical(t *testing.T) {
 			env := ts.NewTestWorkflowEnvironment()
 
 			if c.setPRRevision {
-				env.RegisterWorkflow(prrevision.Workflow)
-				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+				env.RegisterWorkflow(testPRRevWorkflow)
+				env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
 					Repo:     repo,
 					Root:     root,
 					Revision: deploymentInfo.Revision,
@@ -683,8 +688,8 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 			}
 
 			if c.setPRRevision {
-				env.RegisterWorkflow(prrevision.Workflow)
-				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+				env.RegisterWorkflow(testPRRevWorkflow)
+				env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
 					Repo:     repo,
 					Root:     root,
 					Revision: deploymentInfo.Revision,
@@ -873,8 +878,8 @@ func TestDeployer_TerraformClientError_UpdateLatestDeployment(t *testing.T) {
 			}
 
 			if c.setPRRevision {
-				env.RegisterWorkflow(prrevision.Workflow)
-				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+				env.RegisterWorkflow(testPRRevWorkflow)
+				env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
 					Repo:     repo,
 					Root:     root,
 					Revision: deploymentInfo.Revision,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/temporal"
@@ -100,227 +101,314 @@ func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.
 }
 
 func TestDeployer_FirstDeploy(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	da := &testDeployActivity{}
-	env.RegisterActivity(da)
-
-	repo := github.Repo{
-		Owner: "owner",
-		Name:  "test",
-	}
-
-	root := model.Root{
-		Name: "root_1",
-	}
-
-	deploymentInfo := terraform.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "3455",
-		CheckRunID: 1234,
-		Root:       root,
-		Repo:       repo,
-	}
-
-	latestDeployedRevision := &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3455",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
+	cases := []struct {
+		description   string
+		setPRRevision bool
+	}{
+		{
+			description:   "start PR Revision workflow",
+			setPRRevision: true,
 		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
+		{
+			description:   "not start PR Revision workflow",
+			setPRRevision: false,
 		},
 	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
 
-	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:  deployment.InfoSchemaVersion,
-			ID:       deploymentInfo.ID.String(),
-			Revision: deploymentInfo.Revision,
-			Root: deployment.Root{
-				Name: deploymentInfo.Root.Name,
-			},
-			Repo: deployment.Repo{
-				Owner: deploymentInfo.Repo.Owner,
-				Name:  deploymentInfo.Repo.Name,
-			},
-		},
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+
+			repo := github.Repo{
+				Owner: "owner",
+				Name:  "test",
+			}
+
+			root := model.Root{
+				Name: "root_1",
+			}
+
+			deploymentInfo := terraform.DeploymentInfo{
+				ID:         uuid.UUID{},
+				Revision:   "3455",
+				CheckRunID: 1234,
+				Root:       root,
+				Repo:       repo,
+			}
+
+			if c.setPRRevision {
+				env.RegisterWorkflow(prrevision.Workflow)
+				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+					Repo:     repo,
+					Root:     root,
+					Revision: deploymentInfo.Revision,
+				}).Return(nil)
+			} else {
+				env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+			}
+
+			latestDeployedRevision := &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3455",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}
+
+			storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+				DeploymentInfo: &deployment.Info{
+					Version:  deployment.InfoSchemaVersion,
+					ID:       deploymentInfo.ID.String(),
+					Revision: deploymentInfo.Revision,
+					Root: deployment.Root{
+						Name: deploymentInfo.Root.Name,
+					},
+					Repo: deployment.Repo{
+						Owner: deploymentInfo.Repo.Owner,
+						Name:  deploymentInfo.Repo.Name,
+					},
+				},
+			}
+
+			env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info: deploymentInfo,
+			})
+
+			env.AssertExpectations(t)
+
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, latestDeployedRevision, resp)
+		})
 	}
-
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
-
-	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
-		Info: deploymentInfo,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, latestDeployedRevision, resp)
 }
 
 func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	da := &testDeployActivity{}
-	env.RegisterActivity(da)
-
-	repo := github.Repo{
-		Owner: "owner",
-		Name:  "test",
-	}
-
-	root := model.Root{
-		Name: "root_1",
-	}
-
-	deploymentInfo := terraform.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "3455",
-		CheckRunID: 1234,
-		Root:       root,
-		Repo:       repo,
-	}
-
-	latestDeployedRevision := &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3255",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
+	cases := []struct {
+		description   string
+		setPRRevision bool
+	}{
+		{
+			description:   "start PR Revision workflow",
+			setPRRevision: true,
 		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
+		{
+			description:   "not start PR Revision workflow",
+			setPRRevision: false,
 		},
 	}
 
-	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:  deployment.InfoSchemaVersion,
-			ID:       deploymentInfo.ID.String(),
-			Revision: deploymentInfo.Revision,
-			Root: deployment.Root{
-				Name: deploymentInfo.Root.Name,
-			},
-			Repo: deployment.Repo{
-				Owner: deploymentInfo.Repo.Owner,
-				Name:  deploymentInfo.Repo.Name,
-			},
-		},
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
+
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+
+			repo := github.Repo{
+				Owner: "owner",
+				Name:  "test",
+			}
+
+			root := model.Root{
+				Name: "root_1",
+			}
+
+			deploymentInfo := terraform.DeploymentInfo{
+				ID:         uuid.UUID{},
+				Revision:   "3455",
+				CheckRunID: 1234,
+				Root:       root,
+				Repo:       repo,
+			}
+
+			if c.setPRRevision {
+				env.RegisterWorkflow(prrevision.Workflow)
+				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+					Repo:     repo,
+					Root:     root,
+					Revision: deploymentInfo.Revision,
+				}).Return(nil)
+			} else {
+				env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+			}
+
+			latestDeployedRevision := &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3255",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}
+
+			storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+				DeploymentInfo: &deployment.Info{
+					Version:  deployment.InfoSchemaVersion,
+					ID:       deploymentInfo.ID.String(),
+					Revision: deploymentInfo.Revision,
+					Root: deployment.Root{
+						Name: deploymentInfo.Root.Name,
+					},
+					Repo: deployment.Repo{
+						Owner: deploymentInfo.Repo.Owner,
+						Name:  deploymentInfo.Repo.Name,
+					},
+				},
+			}
+
+			compareCommitRequest := activities.CompareCommitRequest{
+				Repo:                   repo,
+				DeployRequestRevision:  deploymentInfo.Revision,
+				LatestDeployedRevision: latestDeployedRevision.Revision,
+			}
+
+			compareCommitResponse := activities.CompareCommitResponse{
+				CommitComparison: activities.DirectionAhead,
+			}
+
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+			env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info:         deploymentInfo,
+				LatestDeploy: latestDeployedRevision,
+			})
+
+			env.AssertExpectations(t)
+
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3455",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}, resp)
+		})
 	}
 
-	compareCommitRequest := activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfo.Revision,
-		LatestDeployedRevision: latestDeployedRevision.Revision,
-	}
-
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionAhead,
-	}
-
-	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
-
-	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
-		Info:         deploymentInfo,
-		LatestDeploy: latestDeployedRevision,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3455",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
-		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
-		},
-	}, resp)
 }
 
 func TestDeployer_CompareCommit_Identical(t *testing.T) {
-	repo := github.Repo{
-		Owner: "owner",
-		Name:  "test",
-	}
-	root := model.Root{
-		Name:  "root_1",
-		Rerun: true,
-	}
-	deploymentInfo := terraform.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "3455",
-		CheckRunID: 1234,
-		Root:       root,
-		Repo:       repo,
-	}
-
-	latestDeployedRevision := &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3255",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
+	cases := []struct {
+		description   string
+		setPRRevision bool
+	}{
+		{
+			description:   "start PR Revision workflow",
+			setPRRevision: true,
 		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
+		{
+			description:   "not start PR Revision workflow",
+			setPRRevision: false,
 		},
 	}
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
 
-	da := &testDeployActivity{}
-	env.RegisterActivity(da)
-	compareCommitRequest := activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfo.Revision,
-		LatestDeployedRevision: latestDeployedRevision.Revision,
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			repo := github.Repo{
+				Owner: "owner",
+				Name:  "test",
+			}
+			root := model.Root{
+				Name:  "root_1",
+				Rerun: true,
+			}
+			deploymentInfo := terraform.DeploymentInfo{
+				ID:         uuid.UUID{},
+				Revision:   "3455",
+				CheckRunID: 1234,
+				Root:       root,
+				Repo:       repo,
+			}
+
+			latestDeployedRevision := &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3255",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
+
+			if c.setPRRevision {
+				env.RegisterWorkflow(prrevision.Workflow)
+				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+					Repo:     repo,
+					Root:     root,
+					Revision: deploymentInfo.Revision,
+				}).Return(nil)
+			} else {
+				env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+			}
+
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+			compareCommitRequest := activities.CompareCommitRequest{
+				Repo:                   repo,
+				DeployRequestRevision:  deploymentInfo.Revision,
+				LatestDeployedRevision: latestDeployedRevision.Revision,
+			}
+
+			compareCommitResponse := activities.CompareCommitResponse{
+				CommitComparison: activities.DirectionIdentical,
+			}
+
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info:         deploymentInfo,
+				LatestDeploy: latestDeployedRevision,
+			})
+			env.AssertExpectations(t)
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+			assert.NoError(t, err)
+			assert.Equal(t, &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3455",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}, resp)
+		})
 	}
-
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionIdentical,
-	}
-
-	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
-		Info:         deploymentInfo,
-		LatestDeploy: latestDeployedRevision,
-	})
-	env.AssertExpectations(t)
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-	assert.Equal(t, &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3455",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
-		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
-		},
-	}, resp)
 
 }
 
@@ -556,93 +644,122 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 }
 
 func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	da := &testDeployActivity{}
-	env.RegisterActivity(da)
-
-	repo := github.Repo{
-		Owner: "owner",
-		Name:  "test",
-	}
-
-	root := model.Root{
-		Name: "root_1",
-	}
-
-	deploymentInfo := terraform.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "3455",
-		CheckRunID: 1234,
-		Root:       root,
-		Repo:       repo,
-	}
-
-	latestDeployedRevision := &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3255",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
+	cases := []struct {
+		description   string
+		setPRRevision bool
+	}{
+		{
+			description:   "start PR Revision workflow",
+			setPRRevision: true,
 		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
+		{
+			description:   "not start PR Revision workflow",
+			setPRRevision: false,
 		},
 	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
 
-	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:  deployment.InfoSchemaVersion,
-			ID:       deploymentInfo.ID.String(),
-			Revision: deploymentInfo.Revision,
-			Root: deployment.Root{
-				Name: deploymentInfo.Root.Name,
-			},
-			Repo: deployment.Repo{
-				Owner: deploymentInfo.Repo.Owner,
-				Name:  deploymentInfo.Repo.Name,
-			},
-		},
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+
+			repo := github.Repo{
+				Owner: "owner",
+				Name:  "test",
+			}
+
+			root := model.Root{
+				Name: "root_1",
+			}
+
+			deploymentInfo := terraform.DeploymentInfo{
+				ID:         uuid.UUID{},
+				Revision:   "3455",
+				CheckRunID: 1234,
+				Root:       root,
+				Repo:       repo,
+			}
+
+			if c.setPRRevision {
+				env.RegisterWorkflow(prrevision.Workflow)
+				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+					Repo:     repo,
+					Root:     root,
+					Revision: deploymentInfo.Revision,
+				}).Return(nil)
+			} else {
+				env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+			}
+
+			latestDeployedRevision := &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3255",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}
+
+			storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+				DeploymentInfo: &deployment.Info{
+					Version:  deployment.InfoSchemaVersion,
+					ID:       deploymentInfo.ID.String(),
+					Revision: deploymentInfo.Revision,
+					Root: deployment.Root{
+						Name: deploymentInfo.Root.Name,
+					},
+					Repo: deployment.Repo{
+						Owner: deploymentInfo.Repo.Owner,
+						Name:  deploymentInfo.Repo.Name,
+					},
+				},
+			}
+
+			compareCommitRequest := activities.CompareCommitRequest{
+				Repo:                   repo,
+				DeployRequestRevision:  deploymentInfo.Revision,
+				LatestDeployedRevision: latestDeployedRevision.Revision,
+			}
+
+			compareCommitResponse := activities.CompareCommitResponse{
+				CommitComparison: activities.DirectionDiverged,
+			}
+
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+			env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info:         deploymentInfo,
+				LatestDeploy: latestDeployedRevision,
+			})
+
+			env.AssertExpectations(t)
+
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3455",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}, resp)
+		})
 	}
 
-	compareCommitRequest := activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfo.Revision,
-		LatestDeployedRevision: latestDeployedRevision.Revision,
-	}
-
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionDiverged,
-	}
-
-	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
-
-	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
-		Info:         deploymentInfo,
-		LatestDeploy: latestDeployedRevision,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
-	assert.NoError(t, err)
-
-	assert.Equal(t, &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3455",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
-		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
-		},
-	}, resp)
 }
 
 func TestDeployer_WorkflowFailure_PlanRejection_SkipUpdateLatestDeployment(t *testing.T) {
@@ -717,86 +834,115 @@ func TestDeployer_WorkflowFailure_PlanRejection_SkipUpdateLatestDeployment(t *te
 }
 
 func TestDeployer_TerraformClientError_UpdateLatestDeployment(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	da := &testDeployActivity{}
-	env.RegisterActivity(da)
-
-	repo := github.Repo{
-		Owner: "owner",
-		Name:  "test",
-	}
-
-	root := model.Root{
-		Name: "root_1",
-	}
-
-	deploymentInfo := terraform.DeploymentInfo{
-		ID:         uuid.UUID{},
-		Revision:   "3455",
-		CheckRunID: 1234,
-		Root:       root,
-		Repo:       repo,
-	}
-
-	latestDeployedRevision := &deployment.Info{
-		ID:       deploymentInfo.ID.String(),
-		Version:  1.0,
-		Revision: "3255",
-		Root: deployment.Root{
-			Name: deploymentInfo.Root.Name,
+	cases := []struct {
+		description   string
+		setPRRevision bool
+	}{
+		{
+			description:   "start PR Revision workflow",
+			setPRRevision: true,
 		},
-		Repo: deployment.Repo{
-			Owner: deploymentInfo.Repo.Owner,
-			Name:  deploymentInfo.Repo.Name,
+		{
+			description:   "not start PR Revision workflow",
+			setPRRevision: false,
 		},
 	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
 
-	compareCommitRequest := activities.CompareCommitRequest{
-		Repo:                   repo,
-		DeployRequestRevision:  deploymentInfo.Revision,
-		LatestDeployedRevision: latestDeployedRevision.Revision,
+			da := &testDeployActivity{}
+			env.RegisterActivity(da)
+
+			repo := github.Repo{
+				Owner: "owner",
+				Name:  "test",
+			}
+
+			root := model.Root{
+				Name: "root_1",
+			}
+
+			deploymentInfo := terraform.DeploymentInfo{
+				ID:         uuid.UUID{},
+				Revision:   "3455",
+				CheckRunID: 1234,
+				Root:       root,
+				Repo:       repo,
+			}
+
+			if c.setPRRevision {
+				env.RegisterWorkflow(prrevision.Workflow)
+				env.OnWorkflow(prrevision.Workflow, mock.Anything, prrevision.Request{
+					Repo:     repo,
+					Root:     root,
+					Revision: deploymentInfo.Revision,
+				}).Return(nil)
+			} else {
+				env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
+			}
+
+			latestDeployedRevision := &deployment.Info{
+				ID:       deploymentInfo.ID.String(),
+				Version:  1.0,
+				Revision: "3255",
+				Root: deployment.Root{
+					Name: deploymentInfo.Root.Name,
+				},
+				Repo: deployment.Repo{
+					Owner: deploymentInfo.Repo.Owner,
+					Name:  deploymentInfo.Repo.Name,
+				},
+			}
+
+			compareCommitRequest := activities.CompareCommitRequest{
+				Repo:                   repo,
+				DeployRequestRevision:  deploymentInfo.Revision,
+				LatestDeployedRevision: latestDeployedRevision.Revision,
+			}
+
+			compareCommitResponse := activities.CompareCommitResponse{
+				CommitComparison: activities.DirectionAhead,
+			}
+
+			storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
+				DeploymentInfo: &deployment.Info{
+					Version:  deployment.InfoSchemaVersion,
+					ID:       deploymentInfo.ID.String(),
+					Revision: deploymentInfo.Revision,
+					Root: deployment.Root{
+						Name: deploymentInfo.Root.Name,
+					},
+					Repo: deployment.Repo{
+						Owner: deploymentInfo.Repo.Owner,
+						Name:  deploymentInfo.Repo.Name,
+					},
+				},
+			}
+
+			env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
+			env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
+
+			env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
+				Info:         deploymentInfo,
+				LatestDeploy: latestDeployedRevision,
+				ErrType:      TerraformClientError,
+			})
+
+			env.AssertExpectations(t)
+
+			var resp *deployment.Info
+			err := env.GetWorkflowResult(&resp)
+
+			wfErr, ok := err.(*temporal.WorkflowExecutionError)
+			assert.True(t, ok)
+
+			appErr, ok := wfErr.Unwrap().(*temporal.ApplicationError)
+			assert.True(t, ok)
+
+			assert.Equal(t, "TerraformClientError", appErr.Type())
+		})
 	}
 
-	compareCommitResponse := activities.CompareCommitResponse{
-		CommitComparison: activities.DirectionAhead,
-	}
-
-	storeDeploymentRequest := activities.StoreLatestDeploymentRequest{
-		DeploymentInfo: &deployment.Info{
-			Version:  deployment.InfoSchemaVersion,
-			ID:       deploymentInfo.ID.String(),
-			Revision: deploymentInfo.Revision,
-			Root: deployment.Root{
-				Name: deploymentInfo.Root.Name,
-			},
-			Repo: deployment.Repo{
-				Owner: deploymentInfo.Repo.Owner,
-				Name:  deploymentInfo.Repo.Name,
-			},
-		},
-	}
-
-	env.OnActivity(da.GithubCompareCommit, mock.Anything, compareCommitRequest).Return(compareCommitResponse, nil)
-	env.OnActivity(da.StoreLatestDeployment, mock.Anything, storeDeploymentRequest).Return(nil)
-
-	env.ExecuteWorkflow(testDeployerWorkflow, deployerRequest{
-		Info:         deploymentInfo,
-		LatestDeploy: latestDeployedRevision,
-		ErrType:      TerraformClientError,
-	})
-
-	env.AssertExpectations(t)
-
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
-
-	wfErr, ok := err.(*temporal.WorkflowExecutionError)
-	assert.True(t, ok)
-
-	appErr, ok := wfErr.Unwrap().(*temporal.ApplicationError)
-	assert.True(t, ok)
-
-	assert.Equal(t, "TerraformClientError", appErr.Type())
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -85,6 +85,7 @@ func NewWorker(
 	q queue,
 	a workerActivities,
 	tfWorkflow terraform.Workflow,
+	prRevWorkflow Workflow,
 	repoName, rootName string,
 	githubCheckRunCache CheckRunClient,
 ) (*Worker, error) {
@@ -93,6 +94,7 @@ func NewWorker(
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,
 		GithubCheckRunCache:     githubCheckRunCache,
+		PRRevisionWorkflow:      prRevWorkflow,
 	}
 
 	latestDeployment, err := deployer.FetchLatestDeployment(ctx, repoName, rootName)

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -382,6 +383,10 @@ func TestNewWorker(t *testing.T) {
 		return nil
 	}
 
+	emptyPRRevWorkflow := func(ctx workflow.Context, request prrevision.Request) error {
+		return nil
+	}
+
 	type res struct {
 		Lock queue.LockState
 	}
@@ -391,7 +396,7 @@ func TestNewWorker(t *testing.T) {
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
-		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, "nish/repo", "root", &testCheckRunClient{})
+		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, emptyPRRevWorkflow, "nish/repo", "root", &testCheckRunClient{})
 		return res{
 			Lock: q.GetLockState(),
 		}, err

--- a/server/neptune/workflows/internal/deploy/version/pr_revision.go
+++ b/server/neptune/workflows/internal/deploy/version/pr_revision.go
@@ -1,0 +1,3 @@
+package version
+
+const SetPRRevision = "set-pr-revision"


### PR DESCRIPTION
This PR adds support to start `PRRevisionWorkflow` with versioning restriction once a deployment has been successfully completed. 

**Note**: This PR enables the PR Revision workflow. 