### PR TITLE
Rename GH Activities in PR Revision Workflow

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -303,7 +303,7 @@ type ListPRsResponse struct {
 	PullRequests []internal.PullRequest
 }
 
-func (a *githubActivities) ListPRs(ctx context.Context, request ListPRsRequest) (ListPRsResponse, error) {
+func (a *githubActivities) GithubListPRs(ctx context.Context, request ListPRsRequest) (ListPRsResponse, error) {
 	prs, err := a.Client.ListPullRequests(
 		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
 		request.Repo.Owner,
@@ -336,7 +336,7 @@ type ListModifiedFilesResponse struct {
 	FilePaths []string
 }
 
-func (a *githubActivities) ListModifiedFiles(ctx context.Context, request ListModifiedFilesRequest) (ListModifiedFilesResponse, error) {
+func (a *githubActivities) GithubListModifiedFiles(ctx context.Context, request ListModifiedFilesRequest) (ListModifiedFilesResponse, error) {
 	files, err := a.Client.ListModifiedFiles(
 		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
 		request.Repo.Owner,

--- a/server/neptune/workflows/internal/prrevision/workflow.go
+++ b/server/neptune/workflows/internal/prrevision/workflow.go
@@ -34,8 +34,8 @@ type setterActivities interface {
 }
 
 type githubActivities interface {
-	ListPRs(ctx context.Context, request activities.ListPRsRequest) (activities.ListPRsResponse, error)
-	ListModifiedFiles(ctx context.Context, request activities.ListModifiedFilesRequest) (activities.ListModifiedFilesResponse, error)
+	GithubListPRs(ctx context.Context, request activities.ListPRsRequest) (activities.ListPRsResponse, error)
+	GithubListModifiedFiles(ctx context.Context, request activities.ListModifiedFilesRequest) (activities.ListModifiedFilesResponse, error)
 }
 
 func Workflow(ctx workflow.Context, request Request) error {
@@ -80,7 +80,7 @@ func (r *Runner) Run(ctx workflow.Context, request Request) error {
 
 func (r *Runner) listOpenPRs(ctx workflow.Context, repo github.Repo) ([]github.PullRequest, error) {
 	var resp activities.ListPRsResponse
-	err := workflow.ExecuteActivity(ctx, r.GithubActivities.ListPRs, activities.ListPRsRequest{
+	err := workflow.ExecuteActivity(ctx, r.GithubActivities.GithubListPRs, activities.ListPRsRequest{
 		Repo:  repo,
 		State: github.OpenPullRequest,
 	}).Get(ctx, &resp)
@@ -95,7 +95,7 @@ func (r *Runner) setRevision(ctx workflow.Context, req Request, prs []github.Pul
 	// spawn activities to list modified files in each open PR async
 	futuresByPullNum := map[github.PullRequest]workflow.Future{}
 	for _, pr := range prs {
-		futuresByPullNum[pr] = workflow.ExecuteActivity(ctx, r.GithubActivities.ListModifiedFiles, activities.ListModifiedFilesRequest{
+		futuresByPullNum[pr] = workflow.ExecuteActivity(ctx, r.GithubActivities.GithubListModifiedFiles, activities.ListModifiedFilesRequest{
 			Repo:        req.Repo,
 			PullRequest: pr,
 		})

--- a/server/neptune/workflows/internal/prrevision/workflow_test.go
+++ b/server/neptune/workflows/internal/prrevision/workflow_test.go
@@ -104,11 +104,11 @@ func (t *testRevisionSetterActivities) SetPRRevision(ctx context.Context, reques
 
 type testGithubActivities struct{}
 
-func (t *testGithubActivities) ListPRs(ctx context.Context, request activities.ListPRsRequest) (activities.ListPRsResponse, error) {
+func (t *testGithubActivities) GithubListPRs(ctx context.Context, request activities.ListPRsRequest) (activities.ListPRsResponse, error) {
 	return activities.ListPRsResponse{}, nil
 }
 
-func (t *testGithubActivities) ListModifiedFiles(ctx context.Context, request activities.ListModifiedFilesRequest) (activities.ListModifiedFilesResponse, error) {
+func (t *testGithubActivities) GithubListModifiedFiles(ctx context.Context, request activities.ListModifiedFilesRequest) (activities.ListModifiedFilesResponse, error) {
 	return activities.ListModifiedFilesResponse{}, nil
 }
 
@@ -143,7 +143,7 @@ func TestMinRevisionSetter_NoOpenPR(t *testing.T) {
 		},
 	}
 
-	env.OnActivity(ga.ListPRs, mock.Anything, activities.ListPRsRequest{
+	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
 		Repo:  req.Repo,
 		State: github.OpenPullRequest,
 	}).Return(activities.ListPRsResponse{
@@ -189,21 +189,21 @@ func TestMinRevisionSetter_OpenPR_SetMinRevision(t *testing.T) {
 	filesModifiedPr1 := []string{"test/dir2/rebase.tf"}
 	filesModifiedPr2 := []string{"test/dir1/no-rebase.tf"}
 
-	env.OnActivity(ga.ListPRs, mock.Anything, activities.ListPRsRequest{
+	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
 		Repo:  req.Repo,
 		State: github.OpenPullRequest,
 	}).Return(activities.ListPRsResponse{
 		PullRequests: pullRequests,
 	}, nil)
 
-	env.OnActivity(ga.ListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
+	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
 		Repo:        req.Repo,
 		PullRequest: pullRequests[0],
 	}).Return(activities.ListModifiedFilesResponse{
 		FilePaths: filesModifiedPr1,
 	}, nil)
 
-	env.OnActivity(ga.ListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
+	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
 		Repo:        req.Repo,
 		PullRequest: pullRequests[1],
 	}).Return(activities.ListModifiedFilesResponse{
@@ -248,14 +248,14 @@ func TestMinRevisionSetter_ListModifiedFilesErr(t *testing.T) {
 		},
 	}
 
-	env.OnActivity(ga.ListPRs, mock.Anything, activities.ListPRsRequest{
+	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
 		Repo:  req.Repo,
 		State: github.OpenPullRequest,
 	}).Return(activities.ListPRsResponse{
 		PullRequests: pullRequests,
 	}, nil)
 
-	env.OnActivity(ga.ListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
+	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
 		Repo:        req.Repo,
 		PullRequest: pullRequests[0],
 	}).Return(activities.ListModifiedFilesResponse{}, errors.New("error"))
@@ -297,7 +297,7 @@ func TestMinRevisionSetter_OpenPR_PatternMatchErr(t *testing.T) {
 		},
 	}
 
-	env.OnActivity(ga.ListPRs, mock.Anything, activities.ListPRsRequest{
+	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
 		Repo:  req.Repo,
 		State: github.OpenPullRequest,
 	}).Return(activities.ListPRsResponse{
@@ -305,7 +305,7 @@ func TestMinRevisionSetter_OpenPR_PatternMatchErr(t *testing.T) {
 	}, nil)
 
 	filesModifiedPr1 := []string{"test/dir2/rebase.tf"}
-	env.OnActivity(ga.ListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
+	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
 		Repo:        req.Repo,
 		PullRequest: pullRequests[0],
 	}).Return(activities.ListModifiedFilesResponse{


### PR DESCRIPTION
This PR prepends the GH activities in the pr revision workflow with `Github` keyword to allow grouping Github Activity Latency and Error metrics in the dashboard. 