### PR TITLE
Avoid outputting check run results onto GH UI greater GH cap

### DIFF
--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -614,14 +614,14 @@ func (g *GithubClient) createCheckRunOutput(request types.UpdateStatusRequest) *
 	}
 
 	if request.Output != "" {
-		checkRunOutput.Text = g.processCheckRunOutput(request.Output)
+		checkRunOutput.Text = g.filterCheckRunOutput(request.Output)
 	}
 
 	return &checkRunOutput
 }
 
 // Send alternate message if output exceeds the max checks output length
-func (g *GithubClient) processCheckRunOutput(output string) *string {
+func (g *GithubClient) filterCheckRunOutput(output string) *string {
 	cappedOutput := output
 	if len(output) > maxChecksOutputLength {
 		cappedOutput = "Terraform output is too long for Github UI, please review the above link to view detailed logs."

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -620,7 +620,7 @@ func (g *GithubClient) createCheckRunOutput(request types.UpdateStatusRequest) *
 	return &checkRunOutput
 }
 
-// Send alternate message  string if actual output exceeds the max checks output length
+// Send alternate message if actual output exceeds the max checks output length
 func (g *GithubClient) processCheckRunOutput(output string) *string {
 	cappedOutput := output
 	if len(output) > maxChecksOutputLength {

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -614,17 +614,17 @@ func (g *GithubClient) createCheckRunOutput(request types.UpdateStatusRequest) *
 	}
 
 	if request.Output != "" {
-		checkRunOutput.Text = g.capCheckRunOutput(request.Output)
+		checkRunOutput.Text = g.processCheckRunOutput(request.Output)
 	}
 
 	return &checkRunOutput
 }
 
-// Cap the output string if it exceeds the max checks output length
-func (g *GithubClient) capCheckRunOutput(output string) *string {
+// Send alternate message  string if actual output exceeds the max checks output length
+func (g *GithubClient) processCheckRunOutput(output string) *string {
 	cappedOutput := output
 	if len(output) > maxChecksOutputLength {
-		cappedOutput = output[:maxChecksOutputLength]
+		cappedOutput = "Terraform output is too long for Github UI, please review the above link to view detailed logs."
 	}
 	return &cappedOutput
 }

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -613,20 +613,16 @@ func (g *GithubClient) createCheckRunOutput(request types.UpdateStatusRequest) *
 		Summary: &summary,
 	}
 
-	if request.Output != "" {
-		checkRunOutput.Text = g.filterCheckRunOutput(request.Output)
+	if request.Output == "" {
+		return &checkRunOutput
 	}
-
+	if len(request.Output) > maxChecksOutputLength {
+		terraformOutputTooLong := "Terraform output is too long for Github UI, please review the above link to view detailed logs."
+		checkRunOutput.Text = &terraformOutputTooLong
+	} else {
+		checkRunOutput.Text = &request.Output
+	}
 	return &checkRunOutput
-}
-
-// Send alternate message if output exceeds the max checks output length
-func (g *GithubClient) filterCheckRunOutput(output string) *string {
-	cappedOutput := output
-	if len(output) > maxChecksOutputLength {
-		cappedOutput = "Terraform output is too long for Github UI, please review the above link to view detailed logs."
-	}
-	return &cappedOutput
 }
 
 // Github Checks uses Status and Conclusion to report status of the check run. Need to map models.VcsStatus to Status and Conclusion

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -620,7 +620,7 @@ func (g *GithubClient) createCheckRunOutput(request types.UpdateStatusRequest) *
 	return &checkRunOutput
 }
 
-// Send alternate message if actual output exceeds the max checks output length
+// Send alternate message if output exceeds the max checks output length
 func (g *GithubClient) processCheckRunOutput(output string) *string {
 	cappedOutput := output
 	if len(output) > maxChecksOutputLength {


### PR DESCRIPTION
We can instead just output a string recommending users take a look at the Atlantis UI logs for the full detail. I'm assuming that we won't hit the cap in non-Terraform related errors (atlantis issues), so we should be safe on that end too.