### PR TITLE
Add middleware for logging and remove negroni usage.

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1098,6 +1098,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 				ghClient,
 			),
 		},
+		Logger: ctxLogger,
 	}
 
 	ctrl := events_controllers.VCSEventsController{

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -126,6 +126,7 @@ func NewVCSEventsController(
 
 	router := &events_controllers.RequestRouter{
 		Resolvers: events_controllers.NewRequestResolvers(providerResolverInitializer, supportedVCSProviders),
+		Logger:    logger,
 	}
 
 	return &VCSEventsController{

--- a/server/neptune/gateway/api/middleware/auth.go
+++ b/server/neptune/gateway/api/middleware/auth.go
@@ -17,17 +17,17 @@ const (
 	UsernameContextKey RequestContextKey = "username"
 )
 
-// AdminAuthMiddleware is a somewhat hacky approach to provide authentication by requiring
+// AdminAuth is a somewhat hacky approach to provide authentication by requiring
 // a github token is passed in.  Using this token we fetch the authenticated user and validate
 // the login against a blessed list of admins.
 // There are a couple reasons for this method:
 // 1. we need the github username for auditing purposes
 // 2. APIs we currently support are clunky and are not GA.
-type AdminAuthMiddleware struct {
+type AdminAuth struct {
 	Admin valid.Admin
 }
 
-func (m *AdminAuthMiddleware) Middleware(next http.Handler) http.Handler {
+func (m *AdminAuth) Middleware(next http.Handler) http.Handler {
 	return &adminAuthHandler{
 		next:  next,
 		admin: m.Admin,

--- a/server/neptune/gateway/event/deployer.go
+++ b/server/neptune/gateway/event/deployer.go
@@ -74,7 +74,7 @@ func (d *RootDeployer) Deploy(ctx context.Context, deployOptions RootDeployOptio
 	for _, rootCfg := range rootCfgs {
 		c := context.WithValue(ctx, contextInternal.ProjectKey, rootCfg.Name)
 		if rootCfg.WorkflowMode != valid.PlatformWorkflowMode {
-			d.Logger.DebugContext(c, "root is not configured for platform mode, skipping...")
+			d.Logger.WarnContext(c, "root is not configured for platform mode, skipping...")
 			continue
 		}
 		run, err := d.DeploySignaler.SignalWithStartWorkflow(c, rootCfg, deployOptions)

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -55,12 +55,12 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 	}
 
 	if !shouldAllocate {
-		p.Logger.DebugContext(ctx, "handler not configured for allocation")
+		p.Logger.ErrorContext(ctx, "handler not configured for allocation")
 		return nil
 	}
 
 	if event.Ref.Type != vcs.BranchRef || event.Ref.Name != event.Repo.DefaultBranch {
-		p.Logger.DebugContext(ctx, "dropping event for unexpected ref")
+		p.Logger.WarnContext(ctx, "dropping event for unexpected ref")
 		return nil
 	}
 

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -55,7 +55,7 @@ func (p *PushHandler) Handle(ctx context.Context, event Push) error {
 	}
 
 	if !shouldAllocate {
-		p.Logger.ErrorContext(ctx, "handler not configured for allocation")
+		p.Logger.InfoContext(ctx, "handler not configured for allocation")
 		return nil
 	}
 

--- a/server/neptune/gateway/middleware/logging.go
+++ b/server/neptune/gateway/middleware/logging.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/urfave/negroni"
+)
+
+// Logger logs request properties in addition to the response
+type Logger struct {
+	Logger logging.Logger
+}
+
+func (l *Logger) Middleware(next http.Handler) http.Handler {
+	return &loggerHandler{
+		logger: l.Logger,
+		next:   next,
+	}
+
+}
+
+type loggerHandler struct {
+	logger logging.Logger
+	next   http.Handler
+}
+
+func (h *loggerHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	wrappedRW := negroni.NewResponseWriter(rw)
+
+	defer func() {
+		status := wrappedRW.Status()
+		duration := time.Since(start)
+
+		h.logger.InfoContext(r.Context(), fmt.Sprintf("%s %s %s request complete", r.Method, r.Host, r.URL.Path), map[string]interface{}{
+			"start-time": start,
+			"duration":   duration,
+			"status":     status,
+		})
+	}()
+
+	h.next.ServeHTTP(wrappedRW, r)
+}

--- a/server/neptune/gateway/middleware/recovery.go
+++ b/server/neptune/gateway/middleware/recovery.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+// Recovery is middleware that recovers from any panics and writes a 500 if there was one.
+type Recovery struct {
+	Logger logging.Logger
+}
+
+func (m *Recovery) Middleware(next http.Handler) http.Handler {
+	return &recoveryHandler{
+		logger: m.Logger,
+	}
+}
+
+type recoveryHandler struct {
+	logger logging.Logger
+	next   http.Handler
+}
+
+func (h *recoveryHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+
+			// this value was taken from negroni, unsure why we use this specifically though
+			stack := make([]byte, 1024*8)
+			stack = stack[:runtime.Stack(stack, false)]
+
+			h.logger.ErrorContext(r.Context(), fmt.Sprintf("PANIC: %s\n%s", err, stack))
+		}
+	}()
+
+	h.next.ServeHTTP(rw, r)
+}

--- a/server/neptune/gateway/middleware/request_id.go
+++ b/server/neptune/gateway/middleware/request_id.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	key "github.com/runatlantis/atlantis/server/neptune/context"
+)
+
+const ghRequestIDHeader = "X-Github-Delivery"
+
+// RequestID is responsible for extract various types of request IDs from request headers
+// and plumbing those through the context
+type RequestID struct{}
+
+func (m *RequestID) Middleware(next http.Handler) http.Handler {
+	return &recoveryHandler{
+		next: next,
+	}
+}
+
+type requestIDExtractor struct {
+	next http.Handler
+}
+
+func (e *requestIDExtractor) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if id, ok := r.Header[ghRequestIDHeader]; ok {
+		ctx := context.WithValue(
+			r.Context(),
+			key.RequestIDKey,
+			id,
+		)
+
+		e.next.ServeHTTP(rw, r.WithContext(ctx))
+		return
+	}
+
+	e.next.ServeHTTP(rw, r)
+}

--- a/server/neptune/gateway/middleware/request_id.go
+++ b/server/neptune/gateway/middleware/request_id.go
@@ -14,7 +14,7 @@ const ghRequestIDHeader = "X-Github-Delivery"
 type RequestID struct{}
 
 func (m *RequestID) Middleware(next http.Handler) http.Handler {
-	return &recoveryHandler{
+	return &requestIDExtractor{
 		next: next,
 	}
 }

--- a/server/neptune/gateway/router.go
+++ b/server/neptune/gateway/router.go
@@ -1,0 +1,48 @@
+package gateway
+
+import (
+	"net/http/pprof"
+
+	"github.com/gorilla/mux"
+	"github.com/runatlantis/atlantis/server/controllers"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/logging"
+	lyft_gateway "github.com/runatlantis/atlantis/server/lyft/gateway"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/api"
+	apiMiddleware "github.com/runatlantis/atlantis/server/neptune/gateway/api/middleware"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/api/request"
+	commonMiddleware "github.com/runatlantis/atlantis/server/neptune/gateway/middleware"
+)
+
+func newRouter(
+	logger logging.Logger,
+	eventsController *lyft_gateway.VCSEventsController,
+	statusController *controllers.StatusController,
+	deployController *api.Controller[request.Deploy],
+	globalCfg valid.GlobalCfg,
+) *mux.Router {
+	recovery := &commonMiddleware.Recovery{
+		Logger: logger,
+	}
+	logging := &commonMiddleware.Logger{
+		Logger: logger,
+	}
+	requestID := &commonMiddleware.RequestID{}
+
+	router := mux.NewRouter()
+	router.Use(requestID.Middleware, logging.Middleware, recovery.Middleware)
+	router.HandleFunc("/healthz", Healthz).Methods("GET")
+	router.HandleFunc("/status", statusController.Get).Methods("GET")
+	router.HandleFunc("/events", eventsController.Post).Methods("POST")
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+
+	apiSubrouter := router.PathPrefix("/api/admin").Subrouter()
+	auth := &apiMiddleware.AdminAuth{
+		Admin: globalCfg.Admin,
+	}
+
+	apiSubrouter.Use(auth.Middleware)
+	apiSubrouter.HandleFunc("/deploy", deployController.Handle).Methods("POST")
+
+	return router
+}

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -5,15 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/controllers"
@@ -32,7 +29,6 @@ import (
 	lyft_gateway "github.com/runatlantis/atlantis/server/lyft/gateway"
 	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/api"
-	"github.com/runatlantis/atlantis/server/neptune/gateway/api/middleware"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/api/request"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event/preworkflow"
@@ -47,7 +43,6 @@ import (
 	github_converter "github.com/runatlantis/atlantis/server/vcs/provider/github/converter"
 	"github.com/runatlantis/atlantis/server/wrappers"
 	"github.com/urfave/cli"
-	"github.com/urfave/negroni"
 	"go.temporal.io/sdk/client"
 	"golang.org/x/sync/errgroup"
 )
@@ -349,6 +344,7 @@ func NewServer(config Config) (*Server, error) {
 
 	repoRetriever := &github.RepoRetriever{
 		ClientCreator: clientCreator,
+		RepoConverter: repoConverter,
 	}
 
 	branchRetriever := &github.BranchRetriever{
@@ -359,7 +355,7 @@ func NewServer(config Config) (*Server, error) {
 		ClientCreator: clientCreator,
 	}
 
-	deployController := api.Controller[request.Deploy]{
+	deployController := &api.Controller[request.Deploy]{
 		RequestConverter: request.NewDeployConverter(
 			repoRetriever, branchRetriever, installationRetriever,
 		),
@@ -370,32 +366,18 @@ func NewServer(config Config) (*Server, error) {
 		},
 	}
 
-	router := mux.NewRouter()
-	router.HandleFunc("/healthz", Healthz).Methods("GET")
-	router.HandleFunc("/status", statusController.Get).Methods("GET")
-	router.HandleFunc("/events", gatewayEventsController.Post).Methods("POST")
-	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
-
-	apiSubrouter := router.PathPrefix("/api/admin").Subrouter()
-	authMiddleware := &middleware.AdminAuthMiddleware{
-		Admin: globalCfg.Admin,
-	}
-
-	apiSubrouter.Use(authMiddleware.Middleware)
-	apiSubrouter.HandleFunc("/deploy", deployController.Handle).Methods("POST")
-
-	n := negroni.New(&negroni.Recovery{
-		Logger:     log.New(os.Stdout, "", log.LstdFlags),
-		PrintStack: false,
-		StackAll:   false,
-		StackSize:  1024 * 8,
-	})
-	n.UseHandler(router)
+	router := newRouter(
+		ctxLogger, 
+		gatewayEventsController, 
+		statusController, 
+		deployController, 
+		globalCfg,
+	)
 
 	s := httpInternal.ServerProxy{
 		Server: &http.Server{
 			Addr:              fmt.Sprintf(":%d", config.Port),
-			Handler:           n,
+			Handler:           router,
 			ReadHeaderTimeout: time.Second * 10,
 		},
 		SSLCertFile: config.SSLCertFile,

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -367,10 +367,10 @@ func NewServer(config Config) (*Server, error) {
 	}
 
 	router := newRouter(
-		ctxLogger, 
-		gatewayEventsController, 
-		statusController, 
-		deployController, 
+		ctxLogger,
+		gatewayEventsController,
+		statusController,
+		deployController,
 		globalCfg,
 	)
 

--- a/server/vcs/provider/github/converter/repo.go
+++ b/server/vcs/provider/github/converter/repo.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 )
 
 // RepoConverter converts a github repository to our internal model.
@@ -10,15 +11,9 @@ type RepoConverter struct {
 	GithubToken string
 }
 
-type externalRepo interface {
-	GetFullName() string
-	GetCloneURL() string
-	GetDefaultBranch() string
-}
-
 // ParseGithubRepo parses the response from the GitHub API endpoint that
 // returns a repo into the Atlantis model.
-func (c *RepoConverter) Convert(ghRepo externalRepo) (models.Repo, error) {
+func (c RepoConverter) Convert(ghRepo github.ExternalRepo) (models.Repo, error) {
 	repo, err := models.NewRepo(models.Github, ghRepo.GetFullName(), ghRepo.GetCloneURL(), c.GithubUser, c.GithubToken)
 
 	if err != nil {

--- a/server/vcs/provider/github/repo.go
+++ b/server/vcs/provider/github/repo.go
@@ -3,15 +3,20 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v45/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
 )
 
+type ExternalRepo interface {
+	GetFullName() string
+	GetCloneURL() string
+	GetDefaultBranch() string
+}
+
 // without this we have an import cycle
 type repoConverter interface {
-	Convert(*github.Repository) (models.Repo, error)
+	Convert(r ExternalRepo) (models.Repo, error)
 }
 
 type RepoRetriever struct {

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -163,10 +163,6 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 
 	ctx := r.GetRequest().Context()
 
-	h.logger.InfoContext(ctx, "validated event payload", map[string]interface{}{
-		"payload": payload,
-	})
-
 	scope := h.scope.SubScope("github.event")
 
 	event, err := h.parser.Parse(r, payload)

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	githubHeader    = "X-Github-Event"
+	githubHeader = "X-Github-Event"
 )
 
 // interfaces used in Handler

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -164,7 +164,7 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 	ctx := r.GetRequest().Context()
 
 	h.logger.InfoContext(ctx, "validated event payload", map[string]interface{}{
-		"event": payload,
+		"payload": payload,
 	})
 
 	scope := h.scope.SubScope("github.event")

--- a/server/vcs/provider/github/request/handler.go
+++ b/server/vcs/provider/github/request/handler.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	githubHeader    = "X-Github-Event"
-	requestIDHeader = "X-Github-Delivery"
 )
 
 // interfaces used in Handler
@@ -162,11 +161,11 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 		return &errors.RequestValidationError{Err: err}
 	}
 
-	ctx := context.WithValue(
-		r.GetRequest().Context(),
-		contextInternal.RequestIDKey,
-		r.GetHeader(requestIDHeader),
-	)
+	ctx := r.GetRequest().Context()
+
+	h.logger.InfoContext(ctx, "validated event payload", map[string]interface{}{
+		"event": payload,
+	})
 
 	scope := h.scope.SubScope("github.event")
 
@@ -179,7 +178,7 @@ func (h *Handler) Handle(r *http.BufferedRequest) error {
 	installationSource, ok := event.(githubapp.InstallationSource)
 
 	if !ok {
-		return fmt.Errorf("unable to get installation id from request %s", r.GetHeader(requestIDHeader))
+		return fmt.Errorf("unable to get installation id from request")
 	}
 
 	installationID := githubapp.GetInstallationIDFromEvent(installationSource)


### PR DESCRIPTION
* Created logging middleware which logs certain aspects of the request with the response status (we can add more things to this as necessary)
* Moved request id extraction to a middleware to ensure that logging middleware logs are tagged with request id
* Logging the event payload now as well
* Ensured that our push event handler logs when we filter things out.
* moved routes to a new function
* Removed negroni handler usage to keep things a bit more simple and have our recovery middleware actually use our own logger.