### PR TITLE
Fix legacy apply comment for platform mode

### DIFF
--- a/server/lyft/command/feature_runner.go
+++ b/server/lyft/command/feature_runner.go
@@ -76,6 +76,15 @@ func (a *PlatformModeRunner) Run(ctx *command.Context, cmd *command.Comment) {
 	a.Runner.Run(ctx, cmd)
 }
 
+func allProjectInPlatformMode(cmds []command.ProjectContext) bool {
+	for _, cmd := range cmds {
+		if cmd.WorkflowModeType != valid.PlatformWorkflowMode {
+			return false
+		}
+	}
+	return true
+}
+
 // DefaultProjectCommandRunner implements ProjectCommandRunner.
 type PlatformModeProjectRunner struct { //create object and test
 	PlatformModeRunner events.ProjectCommandRunner

--- a/server/lyft/command/feature_runner.go
+++ b/server/lyft/command/feature_runner.go
@@ -59,7 +59,7 @@ func (a *PlatformModeRunner) Run(ctx *command.Context, cmd *command.Comment) {
 		return
 	}
 
-	if shouldAllocate && (projectCmds[0].WorkflowModeType == valid.PlatformWorkflowMode) {
+	if shouldAllocate && allProjectInPlatformMode(projectCmds) {
 		// return error if loading template fails since we should have default templates configured
 		comment, err := a.TemplateLoader.Load(template.LegacyApplyComment, ctx.Pull.BaseRepo, LegacyApplyCommentInput{})
 		if err != nil {

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -87,6 +87,22 @@ func (b *TestBuilder) BuildApplyCommands(ctx *command.Context, comment *command.
 	}, nil
 }
 
+type TestMultiBuilder struct {
+	called bool
+}
+
+func (b *TestMultiBuilder) BuildApplyCommands(ctx *command.Context, comment *command.Comment) ([]command.ProjectContext, error) {
+	b.called = true
+	return []command.ProjectContext{
+		{
+			WorkflowModeType: valid.DefaultWorkflowMode,
+		},
+		{
+			WorkflowModeType: valid.PlatformWorkflowMode,
+		},
+	}, nil
+}
+
 type TestCommenter struct {
 	expectedComment string
 	expectedPullNum int
@@ -136,6 +152,60 @@ func TestPlatformModeRunner_allocatesButNotPlatformMode(t *testing.T) {
 	builder := &TestBuilder{
 		Type: valid.DefaultWorkflowMode,
 	}
+	runner := &testCMDRunner{
+		t:           t,
+		expectedCmd: cmd,
+	}
+
+	subject := &lyftCommand.PlatformModeRunner{
+		Allocator: &testAllocator{
+			expectedFeatureName: feature.PlatformMode,
+			expectedT:           t,
+			expectedCtx:         feature.FeatureContext{RepoName: "owner/repo"},
+			expectedResult:      true,
+		},
+		Logger:  logging.NewNoopCtxLogger(t),
+		Builder: builder,
+		TemplateLoader: template.Loader[lyftCommand.LegacyApplyCommentInput]{
+			GlobalCfg: valid.GlobalCfg{},
+		},
+		VCSClient: commenter,
+		Runner:    runner,
+	}
+
+	subject.Run(ctx, cmd)
+
+	assert.True(t, runner.called)
+	assert.True(t, builder.called)
+	assert.False(t, commenter.called)
+}
+
+func TestPlatformModeRunner_allocatesButPartialPlatformMode(t *testing.T) {
+
+	ctx := &command.Context{
+		RequestCtx: context.Background(),
+		HeadRepo: models.Repo{
+			FullName: "owner/repo",
+		},
+		Pull: models.PullRequest{
+			Num: 1,
+			BaseRepo: models.Repo{
+				FullName: "owner/base",
+			},
+		},
+	}
+	cmd := &command.Comment{
+		Workspace: "hi",
+	}
+
+	commenter := &TestCommenter{
+		expectedT:       t,
+		expectedComment: "Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. ",
+		expectedPullNum: 1,
+		expectedRepo:    ctx.Pull.BaseRepo,
+	}
+
+	builder := &TestMultiBuilder{}
 	runner := &testCMDRunner{
 		t:           t,
 		expectedCmd: cmd,

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -95,10 +95,10 @@ func (b *TestMultiBuilder) BuildApplyCommands(ctx *command.Context, comment *com
 	b.called = true
 	return []command.ProjectContext{
 		{
-			WorkflowModeType: valid.DefaultWorkflowMode,
+			WorkflowModeType: valid.PlatformWorkflowMode,
 		},
 		{
-			WorkflowModeType: valid.PlatformWorkflowMode,
+			WorkflowModeType: valid.DefaultWorkflowMode,
 		},
 	}, nil
 }


### PR DESCRIPTION
Ensure legacy apply comment is created only when all project roots are in platform mode.