### PR TITLE
Change GH rate limit metric to use gauge instead of counter

### DIFF
--- a/server/lyft/scheduled/executor_service.go
+++ b/server/lyft/scheduled/executor_service.go
@@ -153,7 +153,7 @@ type RateLimitStatsPublisher struct {
 
 func (r *RateLimitStatsPublisher) Run() {
 	errCounter := r.stats.Counter(metrics.ExecutionErrorMetric)
-	rateLimitRemainingCounter := r.stats.Counter("ratelimitremaining")
+	rateLimitRemainingCounter := r.stats.Gauge("ratelimitremaining")
 
 	rateLimits, err := r.client.GetRateLimits()
 
@@ -162,7 +162,7 @@ func (r *RateLimitStatsPublisher) Run() {
 		return
 	}
 
-	rateLimitRemainingCounter.Inc(int64(rateLimits.GetCore().Remaining))
+	rateLimitRemainingCounter.Update(float64(rateLimits.GetCore().Remaining))
 }
 
 var gcStaleClosedPullTemplate = template.Must(template.New("").Parse(


### PR DESCRIPTION
Since we're only monitoring the value provided by Github, we should be using a gauge instead of a counter. 