### PR TITLE
Fix log streaming UI search bar width

### DIFF
--- a/server/controllers/templates/web_templates.go
+++ b/server/controllers/templates/web_templates.go
@@ -399,7 +399,7 @@ var ProjectJobsTemplate = template.Must(template.New("blank.html.tmpl").Parse(`
       }
 
       .xterm-search-bar__addon .search-bar__input {
-        width: 100%;
+        width: 100% !important;
         padding: 5px;
         font-size: 14px;
       }


### PR DESCRIPTION
**Before**
<img width="1586" alt="image" src="https://user-images.githubusercontent.com/43479002/228914101-6b518fc9-d7c5-4239-93d2-290b67042752.png">

**After**
<img width="1683" alt="image" src="https://user-images.githubusercontent.com/43479002/228914295-d51390fe-73f7-4308-9e50-af22e2c0b397.png">
