### PR TITLE
Lower concurrency for PR Revision Workflow

### DIFF
--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -54,7 +54,7 @@ const (
 
 	// 5 minutes to allow cleaning up the job store
 	StreamHandlerTimeout                   = 5 * time.Minute
-	PRRevisionTaskQueueActivitiesPerSecond = 3
+	PRRevisionTaskQueueActivitiesPerSecond = 2
 )
 
 type Server struct {
@@ -343,8 +343,8 @@ func (s Server) buildPRRevisionWorker() worker.Worker {
 
 		// Num Activity Executions in PR Revision Setter ~ Num Open PRs + Num PRs modifing root
 		// Assuming half of open PRs need to be rebased, Num Activity Executions = 1.5*(Num Open PRs) = 1.5*(Num GH API Calls)
-		// Allocating a budget of 7200 GH API calls per hour which is well within our current API usage gives us 7200*1.5 = 10800 activity executions per hour
-		// 10800 activity executions per hour -> 10800/60/60 -> 3 activities per second
+		// Allocating a budget of 4800 GH API calls per hour which is well within our current API usage gives us 4800*1.5 = 7200 activity executions per hour
+		// 7200 activity executions per hour -> 7200/60/60 -> 2 activities per second
 		TaskQueueActivitiesPerSecond: PRRevisionTaskQueueActivitiesPerSecond,
 	})
 	worker.RegisterWorkflow(workflows.PRRevision)


### PR DESCRIPTION
Configuring `PRRevisionTaskQueueActivitiesPerSecond` to 2 to ensure we don't hit our GH API ratelimit 