### PR TITLE
Generate revision link in check runs

### DIFF
--- a/server/neptune/workflows/activities/github/revision_link.go
+++ b/server/neptune/workflows/activities/github/revision_link.go
@@ -1,0 +1,7 @@
+package github
+
+import "fmt"
+
+func BuildRevisionLink(repoName string, revision string) string {
+	return fmt.Sprintf("https://github.com/%s/commit/%s", repoName, revision)
+}

--- a/server/neptune/workflows/activities/github/revision_link.go
+++ b/server/neptune/workflows/activities/github/revision_link.go
@@ -2,6 +2,6 @@ package github
 
 import "fmt"
 
-func BuildRevisionLink(repoName string, revision string) string {
-	return fmt.Sprintf("https://github.com/%s/commit/%s", repoName, revision)
+func BuildRevisionLink(repoFullName string, revision string) string {
+	return fmt.Sprintf("https://github.com/%s/commit/%s", repoFullName, revision)
 }

--- a/server/neptune/workflows/activities/github/revision_link.go
+++ b/server/neptune/workflows/activities/github/revision_link.go
@@ -3,5 +3,6 @@ package github
 import "fmt"
 
 func BuildRevisionLink(repoFullName string, revision string) string {
-	return fmt.Sprintf("https://github.com/%s/commit/%s", repoFullName, revision)
+	// uses Markdown formatting to generate the link on GH
+	return fmt.Sprintf("[%s](https://github.com/%s/commit/%s)", revision, repoFullName, revision)
 }

--- a/server/neptune/workflows/activities/github/revision_url_markdown.go
+++ b/server/neptune/workflows/activities/github/revision_url_markdown.go
@@ -2,7 +2,7 @@ package github
 
 import "fmt"
 
-func BuildRevisionLink(repoFullName string, revision string) string {
+func BuildRevisionURLMarkdown(repoFullName string, revision string) string {
 	// uses Markdown formatting to generate the link on GH
 	return fmt.Sprintf("[%s](https://github.com/%s/commit/%s)", revision, repoFullName, revision)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"fmt"
-
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
@@ -22,7 +21,7 @@ type LockStateUpdater struct {
 	GithubCheckRunCache CheckRunClient
 }
 
-func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy) {
+func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy, repoName string) {
 	lock := queue.GetLockState()
 	infos := queue.GetOrderedMergedItems()
 
@@ -32,7 +31,8 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	if lock.Status == LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
+		revisionLink := github.BuildRevisionLink(repoName, lock.Revision)
+		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
 	}
 
 	for _, i := range infos {
@@ -65,4 +65,8 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 			workflow.GetLogger(ctx).Debug(fmt.Sprintf("updating check run for revision %s", i.Commit.Revision), key.ErrKey, err)
 		}
 	}
+}
+
+func CreateRevisionLink(repoName string, revision string) string {
+	return fmt.Sprintf("https://github.com/%s/commit/%s", repoName, revision)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -66,7 +66,3 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 		}
 	}
 }
-
-func CreateRevisionLink(repoName string, revision string) string {
-	return fmt.Sprintf("https://github.com/%s/commit/%s", repoName, revision)
-}

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -21,7 +21,7 @@ type LockStateUpdater struct {
 	GithubCheckRunCache CheckRunClient
 }
 
-func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy, repoName string) {
+func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy, repoFullName string) {
 	lock := queue.GetLockState()
 	infos := queue.GetOrderedMergedItems()
 
@@ -31,7 +31,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	if lock.Status == LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		revisionLink := github.BuildRevisionLink(repoName, lock.Revision)
+		revisionLink := github.BuildRevisionLink(repoFullName, lock.Revision)
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -31,7 +31,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 	if lock.Status == LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		revisionLink := github.BuildRevisionLink(repoFullName, lock.Revision)
+		revisionLink := github.BuildRevisionURLMarkdown(repoFullName, lock.Revision)
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -105,7 +105,7 @@ func TestLockStateUpdater_locked_old_version(t *testing.T) {
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
-		Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+		Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
 		Actions: []github.CheckRunAction{
 			github.CreateUnlockAction(),
 		},
@@ -209,7 +209,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
-		Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+		Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
 		Actions: []github.CheckRunAction{
 			github.CreateUnlockAction(),
 		},
@@ -228,7 +228,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 			Title:   terraform.BuildCheckRunTitle(info.Root.Name),
 			State:   github.CheckRunActionRequired,
 			Repo:    info.Repo,
-			Summary: "This deploy is locked from a manual deployment for revision 1234.  Unlock to proceed.",
+			Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
 			Actions: []github.CheckRunAction{
 				github.CreateUnlockAction(),
 			},
@@ -274,7 +274,7 @@ func testUpdaterWorkflow(ctx workflow.Context, r updaterReq) error {
 	}
 
 	q.SetLockForMergedItems(ctx, r.Lock)
-	subject.UpdateQueuedRevisions(ctx, q)
+	subject.UpdateQueuedRevisions(ctx, q, "some-org/some-repo")
 
 	return nil
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -105,7 +105,7 @@ func TestLockStateUpdater_locked_old_version(t *testing.T) {
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
-		Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
+		Summary: "This deploy is locked from a manual deployment for revision [1234](https://github.com/some-org/some-repo/commit/1234).  Unlock to proceed.",
 		Actions: []github.CheckRunAction{
 			github.CreateUnlockAction(),
 		},
@@ -209,7 +209,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
-		Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
+		Summary: "This deploy is locked from a manual deployment for revision [1234](https://github.com/some-org/some-repo/commit/1234).  Unlock to proceed.",
 		Actions: []github.CheckRunAction{
 			github.CreateUnlockAction(),
 		},
@@ -228,7 +228,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 			Title:   terraform.BuildCheckRunTitle(info.Root.Name),
 			State:   github.CheckRunActionRequired,
 			Repo:    info.Repo,
-			Summary: "This deploy is locked from a manual deployment for revision https://github.com/some-org/some-repo/commit/1234.  Unlock to proceed.",
+			Summary: "This deploy is locked from a manual deployment for revision [1234](https://github.com/some-org/some-repo/commit/1234).  Unlock to proceed.",
 			Actions: []github.CheckRunAction{
 				github.CreateUnlockAction(),
 			},

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -141,7 +141,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	if lock.Status == queue.LockedStatus && (root.Trigger == activity.MergeTrigger) {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		revisionLink := github.BuildRevisionLink(repo.GetFullName(), lock.Revision)
+		revisionLink := github.BuildRevisionURLMarkdown(repo.GetFullName(), lock.Revision)
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -141,7 +141,8 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	if lock.Status == queue.LockedStatus && (root.Trigger == activity.MergeTrigger) {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", lock.Revision)
+		revisionLink := github.BuildRevisionLink(repo.GetFullName(), lock.Revision)
+		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
 	}
 
 	cid, err := n.checkRunClient.CreateOrUpdate(ctx, id, notifier.GithubCheckRunRequest{

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -318,7 +318,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Title:   "atlantis/deploy: root",
 			Sha:     rev,
 			Repo:    github.Repo{Name: "nish"},
-			Summary: "This deploy is locked from a manual deployment for revision 123334444555.  Unlock to proceed.",
+			Summary: "This deploy is locked from a manual deployment for revision https://github.com//nish/commit/123334444555.  Unlock to proceed.",
 			Actions: []github.CheckRunAction{github.CreateUnlockAction()},
 			State:   github.CheckRunActionRequired,
 		},

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -318,7 +318,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Title:   "atlantis/deploy: root",
 			Sha:     rev,
 			Repo:    github.Repo{Name: "nish"},
-			Summary: "This deploy is locked from a manual deployment for revision https://github.com//nish/commit/123334444555.  Unlock to proceed.",
+			Summary: "This deploy is locked from a manual deployment for revision [123334444555](https://github.com//nish/commit/123334444555).  Unlock to proceed.",
 			Actions: []github.CheckRunAction{github.CreateUnlockAction()},
 			State:   github.CheckRunActionRequired,
 		},

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -91,7 +91,7 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 		GithubCheckRunCache: checkRunCache,
 	}
 	revisionQueue := queue.NewQueue(func(ctx workflow.Context, d *queue.Deploy) {
-		lockStateUpdater.UpdateQueuedRevisions(ctx, d)
+		lockStateUpdater.UpdateQueuedRevisions(ctx, d, request.Repo.FullName)
 	}, scope)
 
 	worker, err := queue.NewWorker(ctx, revisionQueue, a, tfWorkflow, prRevWorkflow, request.Repo.FullName, request.Root.Name, checkRunCache)


### PR DESCRIPTION
We want to generate links to the revision locking a deploy queue in the check run UI. Be default, GH does not do this unless the SHA is written in a [comment](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links), so we need to do it ourselves.