### PR TITLE
PR workflow skeleton

### DIFF
--- a/server/neptune/workflows/internal/pr/request.go
+++ b/server/neptune/workflows/internal/pr/request.go
@@ -1,0 +1,6 @@
+package pr
+
+type Request struct {
+	RepoFullName string
+	PRNum        int
+}

--- a/server/neptune/workflows/internal/pr/workflow.go
+++ b/server/neptune/workflows/internal/pr/workflow.go
@@ -1,0 +1,8 @@
+package pr
+
+import "go.temporal.io/sdk/workflow"
+
+func Workflow(ctx workflow.Context, request Request) error {
+	// TODO: implement workflow
+	return nil
+}

--- a/server/neptune/workflows/pr.go
+++ b/server/neptune/workflows/pr.go
@@ -1,0 +1,12 @@
+package workflows
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr"
+	"go.temporal.io/sdk/workflow"
+)
+
+type PRRequest = pr.Request
+
+func PR(ctx workflow.Context, request PRRequest) error {
+	return pr.Workflow(ctx, request)
+}


### PR DESCRIPTION
Creates base workflow definition subsequent PRs will reference as we implement the temporal clients on the gateway side. Won't set up the worker until we being to actually implement the workflow.

Also, am open to suggestions on a better name than PR workflow. I feel like this name may get confusing over time.