### PR TITLE
Emit Age of Open PRs in PR Revision Workflow

### DIFF
--- a/server/neptune/workflows/internal/prrevision/workflow.go
+++ b/server/neptune/workflows/internal/prrevision/workflow.go
@@ -216,7 +216,6 @@ func isRootModified(root terraform.Root, modifiedFiles []string) (bool, error) {
 
 // emits metrics for past 12 weeks in less than_x_days & more_than_x_days format
 func (r *Runner) emitOpenPRAgeMetrics(ctx workflow.Context, prs []github.PullRequest, numWeeks int) {
-
 	// track open PRs older than x weeks
 	moreThanXWeeksOld := make([]int, numWeeks)
 	for _, pr := range prs {

--- a/server/neptune/workflows/internal/prrevision/workflow.go
+++ b/server/neptune/workflows/internal/prrevision/workflow.go
@@ -225,7 +225,7 @@ func (r *Runner) emitOpenPRsAgeInWeeks(ctx workflow.Context, prs []github.PullRe
 	}
 
 	for i := range ageInWeeks {
-		r.Scope.SubScope("open_prs").Gauge(fmt.Sprintf("%d_weeks", i)).Update(float64(ageInWeeks[i]))
+		r.Scope.SubScope("open_prs").Gauge(fmt.Sprintf("%d_weeks", i+1)).Update(float64(ageInWeeks[i]))
 	}
 }
 

--- a/server/neptune/workflows/internal/prrevision/workflow.go
+++ b/server/neptune/workflows/internal/prrevision/workflow.go
@@ -82,7 +82,7 @@ func (r *Runner) Run(ctx workflow.Context, request Request) error {
 	// [CS-4575] TODO: Tune our workflow by analyzing the age of open PRs
 	r.emitOpenPRsAgeInWeeks(ctx, prs, NumLookBackWeeks)
 
-	r.Scope.Counter("open_prs").Inc(int64(len(prs)))
+	r.Scope.Gauge("open_prs").Update(float64(len(prs)))
 	if err := r.setRevision(ctx, request, prs); err != nil {
 		return errors.Wrap(err, "setting minimum revision for pr modifiying root")
 	}

--- a/server/neptune/workflows/internal/prrevision/workflow.go
+++ b/server/neptune/workflows/internal/prrevision/workflow.go
@@ -217,19 +217,16 @@ func isRootModified(root terraform.Root, modifiedFiles []string) (bool, error) {
 
 func (r *Runner) emitOpenPRsAgeInWeeks(ctx workflow.Context, prs []github.PullRequest, numWeeks int) {
 	ageInWeeks := make([]int, numWeeks)
-	olderThanNumWeeks := 0
 	for _, pr := range prs {
-		if age := calculateAgeInWeeks(ctx, pr); age < len(ageInWeeks) {
+		if age := calculateAgeInWeeks(ctx, pr); age < numWeeks {
 			ageInWeeks[age]++
 			continue
 		}
-		olderThanNumWeeks++
 	}
 
 	for i := range ageInWeeks {
-		r.Scope.SubScope("open_prs").Counter(fmt.Sprintf("%d_weeks", i)).Inc(int64(ageInWeeks[i]))
+		r.Scope.SubScope("open_prs").Gauge(fmt.Sprintf("%d_weeks", i)).Update(float64(ageInWeeks[i]))
 	}
-	r.Scope.SubScope("open_prs").Counter(fmt.Sprintf("more_than_%d_weeks", numWeeks)).Inc(int64(olderThanNumWeeks))
 }
 
 func calculateAgeInWeeks(ctx workflow.Context, pr github.PullRequest) int {

--- a/server/neptune/workflows/internal/prrevision/workflow_test.go
+++ b/server/neptune/workflows/internal/prrevision/workflow_test.go
@@ -460,40 +460,38 @@ func TestIsPrUpdatedWithinDays_After(t *testing.T) {
 	assert.True(t, isUpdated)
 }
 
-func testPrEmitMetricsWorkflow(ctx workflow.Context, pr github.PullRequest, week int) (bool, error) {
-	return isOlderThanXWeeks(ctx, week, pr), nil
+func testCalculateAgeWorkflow(ctx workflow.Context, prs []github.PullRequest) ([]int, error) {
+	results := []int{}
+	for _, pr := range prs {
+		results = append(results, calculateAgeInWeeks(ctx, pr))
+	}
+	return results, nil
 }
 
-func TestIsOlderThanXWeeks_Old(t *testing.T) {
+func TestCalculateAgeInWeeks(t *testing.T) {
 	now := time.Now().UTC()
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	pr := github.PullRequest{
-		UpdatedAt: now.AddDate(0, 0, -10),
+	prs := []github.PullRequest{
+		// less than 1
+		{
+			UpdatedAt: now.AddDate(0, 0, -5),
+		},
+		// 1 week
+		{
+			UpdatedAt: now.AddDate(0, 0, -9),
+		},
+		// 6 weeks
+		{
+			UpdatedAt: now.AddDate(0, 0, -43),
+		},
 	}
 
-	var isOld bool
-	env.ExecuteWorkflow(testPrEmitMetricsWorkflow, pr, 1)
-	err := env.GetWorkflowResult(&isOld)
+	var results []int
+	env.ExecuteWorkflow(testCalculateAgeWorkflow, prs)
+	err := env.GetWorkflowResult(&results)
 	assert.NoError(t, err)
 
-	assert.True(t, isOld)
-}
-
-func TestIsOlderThanXWeeks_New(t *testing.T) {
-	now := time.Now().UTC()
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	pr := github.PullRequest{
-		UpdatedAt: now.AddDate(0, 0, -3),
-	}
-
-	var isOld bool
-	env.ExecuteWorkflow(testPrEmitMetricsWorkflow, pr, 1)
-	err := env.GetWorkflowResult(&isOld)
-	assert.NoError(t, err)
-
-	assert.False(t, isOld)
+	assert.Equal(t, []int{0, 1, 6}, results)
 }

--- a/server/neptune/workflows/internal/prrevision/workflow_test.go
+++ b/server/neptune/workflows/internal/prrevision/workflow_test.go
@@ -459,3 +459,41 @@ func TestIsPrUpdatedWithinDays_After(t *testing.T) {
 
 	assert.True(t, isUpdated)
 }
+
+func testPrEmitMetricsWorkflow(ctx workflow.Context, pr github.PullRequest, week int) (bool, error) {
+	return isOlderThanXWeeks(ctx, week, pr), nil
+}
+
+func TestIsOlderThanXWeeks_Old(t *testing.T) {
+	now := time.Now().UTC()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	pr := github.PullRequest{
+		UpdatedAt: now.AddDate(0, 0, -10),
+	}
+
+	var isOld bool
+	env.ExecuteWorkflow(testPrEmitMetricsWorkflow, pr, 1)
+	err := env.GetWorkflowResult(&isOld)
+	assert.NoError(t, err)
+
+	assert.True(t, isOld)
+}
+
+func TestIsOlderThanXWeeks_New(t *testing.T) {
+	now := time.Now().UTC()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	pr := github.PullRequest{
+		UpdatedAt: now.AddDate(0, 0, -3),
+	}
+
+	var isOld bool
+	env.ExecuteWorkflow(testPrEmitMetricsWorkflow, pr, 1)
+	err := env.GetWorkflowResult(&isOld)
+	assert.NoError(t, err)
+
+	assert.False(t, isOld)
+}

--- a/server/neptune/workflows/pr_revision.go
+++ b/server/neptune/workflows/pr_revision.go
@@ -10,7 +10,7 @@ type PRRevisionRevisionRequest = prrevision.Request
 var PRRevisionTaskQueue = prrevision.TaskQueue
 var PRRevisionSlowTaskQueue = prrevision.SlowTaskQueue
 
-const SlowProcessingCutOffDays = 30
+const SlowProcessingCutOffDays = 14
 
 func PRRevision(ctx workflow.Context, request PRRevisionRevisionRequest) error {
 	return prrevision.Workflow(ctx, request, SlowProcessingCutOffDays)


### PR DESCRIPTION
Changes:
- Emit Open PRs age metric for the last 12 weeks
- Change `SlowProcessingCutOffDays` to 14 days (i.e 2 weeks)