### PR TITLE
Create generic terraform workflow state notifier.

### DIFF
--- a/server/neptune/workflows/internal/deploy/notifier/github.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github.go
@@ -2,7 +2,6 @@ package notifier
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
@@ -132,11 +131,6 @@ type CheckRunNotifier struct {
 }
 
 func (n *CheckRunNotifier) Notify(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, workflowState *state.Workflow) error {
-	// TODO: if we never created a check run, there was likely some issue, we should attempt to create it again.
-	if deploymentInfo.CheckRunID == 0 {
-		return fmt.Errorf("check run id is 0, skipping update of check run")
-	}
-
 	return errors.Wrap(n.updateCheckRun(ctx, workflowState, deploymentInfo), "updating check run")
 }
 

--- a/server/neptune/workflows/internal/deploy/notifier/github_cache_test.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github_cache_test.go
@@ -1,0 +1,391 @@
+package notifier_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type request struct {
+	Requests []struct {
+		DeploymentID string
+		Request      notifier.GithubCheckRunRequest
+	}
+}
+
+type response struct {
+	IDs []int64
+}
+
+type testActivities struct{}
+
+func (a testActivities) GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error) {
+	return activities.UpdateCheckRunResponse{}, nil
+}
+
+func (a testActivities) GithubCreateCheckRun(ctx context.Context, request activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+	return activities.CreateCheckRunResponse{}, nil
+}
+
+func testWorkflow(ctx workflow.Context, workflowRequest request) (response, error) {
+	ctx = workflow.WithStartToCloseTimeout(ctx, 5*time.Second)
+	var a testActivities
+	c := notifier.NewGithubCheckRunCache(a)
+
+	var ids []int64
+	for _, r := range workflowRequest.Requests {
+		id, err := c.CreateOrUpdate(ctx, r.DeploymentID, r.Request)
+
+		if err != nil {
+			return response{}, err
+		}
+
+		ids = append(ids, id)
+	}
+	return response{
+		IDs: ids,
+	}, nil
+}
+
+func TestGithubCheckRunCache_CreatesThenUpdates(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State: github.CheckRunQueued,
+		Actions: []github.CheckRunAction{
+			github.CreatePlanReviewAction(github.Approve),
+		},
+		Summary: "some summary",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunSuccess,
+		Summary: "some summary 2",
+	}
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "1234",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil)
+
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
+		Title:      testRequest2.Title,
+		ID:         1,
+		Repo:       testRequest2.Repo,
+		State:      testRequest2.State,
+		Actions:    testRequest2.Actions,
+		Summary:    testRequest2.Summary,
+		ExternalID: "1234",
+	}).Return(activities.UpdateCheckRunResponse{
+		ID:     1,
+		Status: "completed",
+	}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r.IDs, []int64{1, 1})
+}
+
+func TestGithubCheckRunCache_CreatesAcrossDeploymentIDs(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
+	}
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "1234",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil).Once()
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "12345",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 2,
+	}, nil).Once()
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "12345",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 2}, r.IDs)
+}
+
+func TestGithubCheckRunCache_CreatesCompleted(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
+	}
+
+	var id int64
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "1234",
+	}).Return(func(ctx context.Context, r activities.CreateCheckRunRequest) (activities.CreateCheckRunResponse, error) {
+		id++
+		return activities.CreateCheckRunResponse{
+			ID:     id,
+			Status: "completed",
+		}, nil
+	}).Twice()
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 2}, r.IDs)
+}
+
+func TestGithubCheckRunCache_CreatesAfterCompleting(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	a := &testActivities{}
+
+	env.RegisterActivity(a)
+
+	testRequest1 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunQueued,
+		Summary: "some summary",
+	}
+
+	testRequest2 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		Actions: []github.CheckRunAction{
+			github.CreatePlanReviewAction(github.Approve),
+		},
+		State:   github.CheckRunActionRequired,
+		Summary: "some summary 2",
+	}
+
+	testRequest3 := notifier.GithubCheckRunRequest{
+		Title: "title",
+		Sha:   "alskdjf",
+		Repo: github.Repo{
+			Name: "repo",
+		},
+		State:   github.CheckRunPending,
+		Summary: "some summary",
+	}
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest1.Title,
+		Sha:        testRequest1.Sha,
+		Repo:       testRequest1.Repo,
+		State:      testRequest1.State,
+		Actions:    testRequest1.Actions,
+		Summary:    testRequest1.Summary,
+		ExternalID: "1234",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 1,
+	}, nil)
+
+	env.OnActivity(a.GithubUpdateCheckRun, mock.Anything, activities.UpdateCheckRunRequest{
+		Title:      testRequest2.Title,
+		ID:         1,
+		Repo:       testRequest2.Repo,
+		State:      testRequest2.State,
+		Actions:    testRequest2.Actions,
+		Summary:    testRequest2.Summary,
+		ExternalID: "1234",
+	}).Return(activities.UpdateCheckRunResponse{
+		ID:     1,
+		Status: "completed",
+	}, nil)
+
+	env.OnActivity(a.GithubCreateCheckRun, mock.Anything, activities.CreateCheckRunRequest{
+		Title:      testRequest3.Title,
+		Sha:        testRequest3.Sha,
+		Repo:       testRequest3.Repo,
+		State:      testRequest3.State,
+		Actions:    testRequest3.Actions,
+		Summary:    testRequest3.Summary,
+		ExternalID: "1234",
+	}).Return(activities.CreateCheckRunResponse{
+		ID: 2,
+	}, nil)
+
+	env.ExecuteWorkflow(testWorkflow, request{
+		Requests: []struct {
+			DeploymentID string
+			Request      notifier.GithubCheckRunRequest
+		}{
+			{
+				DeploymentID: "1234",
+				Request:      testRequest1,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest2,
+			},
+			{
+				DeploymentID: "1234",
+				Request:      testRequest3,
+			},
+		},
+	})
+
+	env.AssertExpectations(t)
+
+	var r response
+	err := env.GetWorkflowResult(&r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int64{1, 1, 2}, r.IDs)
+}

--- a/server/neptune/workflows/internal/deploy/notifier/sns.go
+++ b/server/neptune/workflows/internal/deploy/notifier/sns.go
@@ -1,0 +1,63 @@
+package notifier
+
+import (
+	"context"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	t "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"go.temporal.io/sdk/workflow"
+
+	"strconv"
+)
+
+type auditActivity interface {
+	AuditJob(ctx context.Context, request activities.AuditJobRequest) error
+}
+
+type SNSNotifier struct {
+	Activity auditActivity
+}
+
+func (n *SNSNotifier) Notify(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, workflowState *state.Workflow) error {
+	if workflowState.Apply == nil {
+		return nil
+	}
+
+	jobState := workflowState.Apply
+
+	var atlantisJobState activities.AtlantisJobState
+	startTime := strconv.FormatInt(jobState.StartTime.Unix(), 10)
+
+	var endTime string
+	switch jobState.Status {
+	case state.InProgressJobStatus:
+		atlantisJobState = activities.AtlantisJobStateRunning
+	case state.SuccessJobStatus:
+		atlantisJobState = activities.AtlantisJobStateSuccess
+		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
+	case state.FailedJobStatus:
+		atlantisJobState = activities.AtlantisJobStateFailure
+		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
+
+	// no need to emit events on other states
+	default:
+		return nil
+	}
+
+	auditJobReq := activities.AuditJobRequest{
+		Repo:           deploymentInfo.Repo,
+		Root:           deploymentInfo.Root,
+		JobID:          jobState.ID,
+		InitiatingUser: deploymentInfo.InitiatingUser,
+		Tags:           deploymentInfo.Tags,
+		Revision:       deploymentInfo.Commit.Revision,
+		State:          atlantisJobState,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		IsForceApply:   deploymentInfo.Root.Trigger == t.ManualTrigger && !deploymentInfo.Root.Rerun,
+	}
+
+	return workflow.ExecuteActivity(ctx, n.Activity.AuditJob, auditJobReq).Get(ctx, nil)
+}

--- a/server/neptune/workflows/internal/deploy/notifier/sns_test.go
+++ b/server/neptune/workflows/internal/deploy/notifier/sns_test.go
@@ -1,0 +1,275 @@
+package notifier_test
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
+	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type testSNSActivities struct {
+	ExpectedT       *testing.T
+	ExpectedRequest activities.AuditJobRequest
+	Called          bool
+}
+
+func (a *testSNSActivities) AuditJob(ctx context.Context, request activities.AuditJobRequest) error {
+	assert.Equal(a.ExpectedT, a.ExpectedRequest, request)
+
+	a.Called = true
+
+	return nil
+}
+
+type snsNotifierRequest struct {
+	StatesToSend   []*state.Workflow
+	DeploymentInfo internalTerraform.DeploymentInfo
+	T              *testing.T
+}
+
+func testSNSNotifierWorkflow(ctx workflow.Context, r snsNotifierRequest) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
+
+	var a *testSNSActivities
+	notifier := &notifier.SNSNotifier{
+		Activity: a,
+	}
+
+	for _, s := range r.StatesToSend {
+		if err := notifier.Notify(ctx, r.DeploymentInfo, s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestSNSNotifier_SendsMessage(t *testing.T) {
+	outputURL, err := url.Parse("www.nish.com")
+	assert.NoError(t, err)
+
+	jobOutput := &state.JobOutput{
+		URL: outputURL,
+	}
+
+	stTime := time.Now()
+	endTime := stTime.Add(time.Second * 5)
+	internalDeploymentInfo := internalTerraform.DeploymentInfo{
+		CheckRunID: 1,
+		ID:         uuid.New(),
+		Root:       terraform.Root{Name: "root"},
+		Repo:       github.Repo{Name: "hello"},
+		Commit: github.Commit{
+			Revision: "12345",
+		},
+	}
+
+	cases := []struct {
+		State                   *state.Workflow
+		ExpectedAuditJobRequest activities.AuditJobRequest
+	}{
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.InProgressJobStatus,
+					StartTime: stTime,
+				},
+			},
+			ExpectedAuditJobRequest: activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Commit.Revision,
+				State:        activities.AtlantisJobStateRunning,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.FailedJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+			},
+			ExpectedAuditJobRequest: activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Commit.Revision,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.FailedJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.InternalServiceError,
+				},
+			},
+			ExpectedAuditJobRequest: activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Commit.Revision,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.FailedJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.TimeoutError,
+				},
+			},
+			ExpectedAuditJobRequest: activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Commit.Revision,
+				State:        activities.AtlantisJobStateFailure,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output:    jobOutput,
+					Status:    state.SuccessJobStatus,
+					StartTime: stTime,
+					EndTime:   endTime,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.SuccessfulCompletionReason,
+				},
+			},
+			ExpectedAuditJobRequest: activities.AuditJobRequest{
+				Root:         internalDeploymentInfo.Root,
+				Repo:         internalDeploymentInfo.Repo,
+				Revision:     internalDeploymentInfo.Commit.Revision,
+				State:        activities.AtlantisJobStateSuccess,
+				StartTime:    strconv.FormatInt(stTime.Unix(), 10),
+				EndTime:      strconv.FormatInt(endTime.Unix(), 10),
+				IsForceApply: false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			ts := testsuite.WorkflowTestSuite{}
+			env := ts.NewTestWorkflowEnvironment()
+
+			var a = &testSNSActivities{
+				ExpectedT:       t,
+				ExpectedRequest: c.ExpectedAuditJobRequest,
+			}
+			env.RegisterActivity(a)
+
+			env.ExecuteWorkflow(testSNSNotifierWorkflow, snsNotifierRequest{
+				StatesToSend:   []*state.Workflow{c.State},
+				DeploymentInfo: internalDeploymentInfo,
+				T:              t,
+			})
+
+			err = env.GetWorkflowResult(nil)
+			assert.NoError(t, err)
+			assert.True(t, a.Called)
+		})
+	}
+}
+
+func TestSNSNotifier_IfApplyJobNil(t *testing.T) {
+	outputURL, err := url.Parse("www.nish.com")
+	assert.NoError(t, err)
+
+	jobOutput := &state.JobOutput{
+		URL: outputURL,
+	}
+
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	internalDeploymentInfo := internalTerraform.DeploymentInfo{
+		CheckRunID: 1,
+		ID:         uuid.New(),
+		Root:       terraform.Root{Name: "root"},
+		Repo:       github.Repo{Name: "hello"},
+		Commit: github.Commit{
+			Revision: "12345",
+		},
+	}
+
+	var a = &testSNSActivities{}
+	env.RegisterActivity(a)
+
+	env.ExecuteWorkflow(testSNSNotifierWorkflow, snsNotifierRequest{
+		StatesToSend: []*state.Workflow{
+			{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+			},
+		},
+		DeploymentInfo: internalDeploymentInfo,
+		T:              t,
+	})
+
+	err = env.GetWorkflowResult(nil)
+	assert.NoError(t, err)
+	assert.False(t, a.Called)
+}

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -36,7 +36,7 @@ type stateReceiver interface {
 	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)
 }
 
-func NewWorkflowRunner(a receiverActivities, w Workflow, notifiers ...TerraformWorkflowNotifier) *WorkflowRunner {
+func NewWorkflowRunner(a receiverActivities, w Workflow, notifiers ...WorkflowNotifier) *WorkflowRunner {
 	return &WorkflowRunner{
 		Workflow: w,
 		StateReceiver: &StateReceiver{

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -2,13 +2,11 @@ package terraform
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/metrics"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/workflow"
 )
@@ -44,40 +42,4 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
 		}
 	}
-}
-
-func (n *StateReceiver) emitApplyEvents(ctx workflow.Context, jobState *state.Job, deploymentInfo DeploymentInfo) error {
-	var atlantisJobState activities.AtlantisJobState
-	startTime := strconv.FormatInt(jobState.StartTime.Unix(), 10)
-
-	var endTime string
-	switch jobState.Status {
-	case state.InProgressJobStatus:
-		atlantisJobState = activities.AtlantisJobStateRunning
-	case state.SuccessJobStatus:
-		atlantisJobState = activities.AtlantisJobStateSuccess
-		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
-	case state.FailedJobStatus:
-		atlantisJobState = activities.AtlantisJobStateFailure
-		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
-
-	// no need to emit events on other states
-	default:
-		return nil
-	}
-
-	auditJobReq := activities.AuditJobRequest{
-		Repo:           deploymentInfo.Repo,
-		Root:           deploymentInfo.Root,
-		JobID:          jobState.ID,
-		InitiatingUser: deploymentInfo.InitiatingUser,
-		Tags:           deploymentInfo.Tags,
-		Revision:       deploymentInfo.Commit.Revision,
-		State:          atlantisJobState,
-		StartTime:      startTime,
-		EndTime:        endTime,
-		IsForceApply:   deploymentInfo.Root.Trigger == terraform.ManualTrigger && !deploymentInfo.Root.Rerun,
-	}
-
-	return workflow.ExecuteActivity(ctx, n.Activity.AuditJob, auditJobReq).Get(ctx, nil)
 }

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -1,42 +1,19 @@
 package terraform_test
 
 import (
-	"context"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
-
-type testCheckRunClient struct {
-	expectedRequest      notifier.GithubCheckRunRequest
-	expectedDeploymentID string
-	expectedT            *testing.T
-}
-
-func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error) {
-	assert.Equal(t.expectedT, t.expectedRequest, request)
-	assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID)
-
-	return 1, nil
-}
-
-type testActivities struct {
-}
-
-func (a *testActivities) AuditJob(ctx context.Context, request activities.AuditJobRequest) error {
-	return nil
-}
 
 type testNotifier struct {
 	expectedInfo  internalTerraform.DeploymentInfo
@@ -77,7 +54,7 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stat
 	}
 
 	receiver := &internalTerraform.StateReceiver{
-		Notifiers: []internalTerraform.TerraformWorkflowNotifier{
+		Notifiers: []internalTerraform.WorkflowNotifier{
 			notifier,
 		},
 	}


### PR DESCRIPTION
The goal here is to allow us to inject the sns notifier from our private repo since this is something that's lyft specific. For now I just moved it around internally.  

A followup PR will actually setup our server to allow for something like this. Just wanted to keep PRs small.