### PR TITLE
Remove unused env fields

### DIFF
--- a/server/neptune/workflows/activities/execute.go
+++ b/server/neptune/workflows/activities/execute.go
@@ -20,7 +20,6 @@ type ExecuteCommandResponse struct {
 type ExecuteCommandRequest struct {
 	Step           execute.Step
 	Path           string
-	EnvVars        map[string]string
 	DynamicEnvVars []EnvVar
 }
 
@@ -30,7 +29,7 @@ func (t *executeCommandActivities) ExecuteCommand(ctx context.Context, request E
 
 	finalEnvVars := os.Environ()
 
-	requestEnvVars, err := getEnvs(request.EnvVars, request.DynamicEnvVars)
+	requestEnvVars, err := getEnvs(request.DynamicEnvVars)
 	if err != nil {
 		return ExecuteCommandResponse{}, err
 	}

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -99,13 +99,8 @@ func NewTerraformActivities(
 	}
 }
 
-func getEnvs(directEnvs map[string]string, dynamicEnvs []EnvVar) (map[string]string, error) {
+func getEnvs(dynamicEnvs []EnvVar) (map[string]string, error) {
 	envs := make(map[string]string)
-
-	for k, v := range directEnvs {
-		envs[k] = v
-	}
-
 	for _, e := range dynamicEnvs {
 		v, err := e.GetValue()
 
@@ -121,10 +116,7 @@ func getEnvs(directEnvs map[string]string, dynamicEnvs []EnvVar) (map[string]str
 
 // Terraform Init
 type TerraformInitRequest struct {
-	Args []terraform.Argument
-	// deprecated: Use DynamicEnvs instead
-	// remove once we are sure this isn't used
-	Envs                 map[string]string
+	Args                 []terraform.Argument
 	DynamicEnvs          []EnvVar
 	JobID                string
 	TfVersion            string
@@ -151,7 +143,7 @@ func (t *terraformActivities) TerraformInit(ctx context.Context, request Terrafo
 	}
 	args = append(args, request.Args...)
 
-	envs, err := getEnvs(request.Envs, request.DynamicEnvs)
+	envs, err := getEnvs(request.DynamicEnvs)
 
 	if err != nil {
 		return TerraformInitResponse{}, err
@@ -186,10 +178,7 @@ func (t *terraformActivities) TerraformInit(ctx context.Context, request Terrafo
 // Terraform Plan
 
 type TerraformPlanRequest struct {
-	Args []terraform.Argument
-	// deprecated: Use DynamicEnvs instead
-	// remove once we are sure this isn't used
-	Envs        map[string]string
+	Args        []terraform.Argument
 	DynamicEnvs []EnvVar
 	JobID       string
 	TfVersion   string
@@ -227,7 +216,7 @@ func (t *terraformActivities) TerraformPlan(ctx context.Context, request Terrafo
 		flags = append(flags, request.Mode.ToFlag())
 	}
 
-	envs, err := getEnvs(request.Envs, request.DynamicEnvs)
+	envs, err := getEnvs(request.DynamicEnvs)
 
 	if err != nil {
 		return TerraformPlanResponse{}, err
@@ -284,10 +273,7 @@ func (t *terraformActivities) TerraformPlan(ctx context.Context, request Terrafo
 // Terraform Apply
 
 type TerraformApplyRequest struct {
-	Args []terraform.Argument
-	// deprecated: Use DynamicEnvs instead
-	// remove once we are sure this isn't used
-	Envs        map[string]string
+	Args        []terraform.Argument
 	DynamicEnvs []EnvVar
 	JobID       string
 	TfVersion   string
@@ -311,7 +297,7 @@ func (t *terraformActivities) TerraformApply(ctx context.Context, request Terraf
 	args := []terraform.Argument{DisableInputArg}
 	args = append(args, request.Args...)
 
-	envs, err := getEnvs(request.Envs, request.DynamicEnvs)
+	envs, err := getEnvs(request.DynamicEnvs)
 
 	if err != nil {
 		return TerraformApplyResponse{}, err

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -116,7 +116,6 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 		RequestVersion  string
 		ExpectedVersion string
 		RequestArgs     []terraform.Argument
-		Envs            map[string]string
 		ExpectedEnvs    map[string]string
 		DynamicEnvs     []EnvVar
 		ExpectedArgs    []terraform.Argument
@@ -128,7 +127,6 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 
 			//defaults
 			ExpectedArgs: defaultArgs,
-			Envs:         map[string]string{},
 			ExpectedEnvs: map[string]string{},
 		},
 		{
@@ -148,12 +146,10 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 
 			// defaults
 			ExpectedVersion: defaultVersion,
-			Envs:            map[string]string{},
 			ExpectedEnvs:    map[string]string{},
 		},
 		{
 			// testing
-			Envs: map[string]string{"env1": "val1"},
 			DynamicEnvs: []EnvVar{
 				{
 					Name:  "env2",
@@ -161,7 +157,6 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 				},
 			},
 			ExpectedEnvs: map[string]string{
-				"env1": "val1",
 				"env2": "val2",
 			},
 
@@ -193,7 +188,6 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 			}
 
 			req := TerraformInitRequest{
-				Envs:                 c.Envs,
 				DynamicEnvs:          c.DynamicEnvs,
 				JobID:                jobID,
 				Path:                 path,
@@ -257,7 +251,6 @@ func TestTerraformInit_StreamsOutput(t *testing.T) {
 	}
 
 	req := TerraformInitRequest{
-		Envs:                 map[string]string{},
 		JobID:                jobID,
 		Path:                 path,
 		GithubInstallationID: 1235,
@@ -306,7 +299,6 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 		ExpectedArgs    []terraform.Argument
 		ExpectedFlags   []terraform.Flag
 		PlanMode        *terraform.PlanMode
-		Envs            map[string]string
 		ExpectedEnvs    map[string]string
 		DynamicEnvs     []EnvVar
 	}{
@@ -317,7 +309,6 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 
 			//default
 			ExpectedArgs: defaultArgs,
-			Envs:         map[string]string{},
 			ExpectedEnvs: map[string]string{},
 		},
 		{
@@ -342,7 +333,6 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 
 			// default
 			ExpectedVersion: defaultVersion,
-			Envs:            map[string]string{},
 			ExpectedEnvs:    map[string]string{},
 		},
 		{
@@ -357,12 +347,10 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 			// default
 			ExpectedArgs:    defaultArgs,
 			ExpectedVersion: defaultVersion,
-			Envs:            map[string]string{},
 			ExpectedEnvs:    map[string]string{},
 		},
 		{
 			// testing
-			Envs: map[string]string{"env1": "val1"},
 			DynamicEnvs: []EnvVar{
 				{
 					Name:  "env2",
@@ -370,7 +358,6 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 				},
 			},
 			ExpectedEnvs: map[string]string{
-				"env1": "val1",
 				"env2": "val2",
 			},
 
@@ -415,7 +402,6 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 			}
 
 			req := TerraformPlanRequest{
-				Envs:        c.Envs,
 				DynamicEnvs: c.DynamicEnvs,
 				JobID:       jobID,
 				Path:        path,
@@ -488,7 +474,6 @@ func TestTerraformPlan_ReturnsResponse(t *testing.T) {
 	}
 
 	req := TerraformPlanRequest{
-		Envs:  map[string]string{},
 		JobID: jobID,
 		Path:  path,
 	}
@@ -542,7 +527,6 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 		ExpectedVersion string
 		RequestArgs     []terraform.Argument
 		ExpectedArgs    []terraform.Argument
-		Envs            map[string]string
 		ExpectedEnvs    map[string]string
 		DynamicEnvs     []EnvVar
 	}{
@@ -553,7 +537,6 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 
 			//default
 			ExpectedArgs: defaultArgs,
-			Envs:         map[string]string{},
 			ExpectedEnvs: map[string]string{},
 		},
 		{
@@ -571,12 +554,10 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 			},
 			//default
 			ExpectedVersion: defaultVersion,
-			Envs:            map[string]string{},
 			ExpectedEnvs:    map[string]string{},
 		},
 		{
 			//testing
-			Envs: map[string]string{"env1": "val1"},
 			DynamicEnvs: []EnvVar{
 				{
 					Name:  "env2",
@@ -584,7 +565,6 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 				},
 			},
 			ExpectedEnvs: map[string]string{
-				"env1": "val1",
 				"env2": "val2",
 			},
 
@@ -616,7 +596,6 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 			}
 
 			req := TerraformApplyRequest{
-				Envs:        c.Envs,
 				DynamicEnvs: c.DynamicEnvs,
 				JobID:       jobID,
 				Path:        path,
@@ -668,7 +647,6 @@ func TestTerraformApply_StreamsOutput(t *testing.T) {
 	}
 
 	req := TerraformApplyRequest{
-		Envs:     map[string]string{},
 		JobID:    jobID,
 		Path:     path,
 		PlanFile: "some/path/output.tfplan",

--- a/server/neptune/workflows/internal/terraform/job/cmd_step_runner.go
+++ b/server/neptune/workflows/internal/terraform/job/cmd_step_runner.go
@@ -57,7 +57,6 @@ func (r *CmdStepRunner) Run(executionContext *ExecutionContext, localRoot *terra
 		Step:           step,
 		Path:           executionContext.Path,
 		DynamicEnvVars: toActivityEnvs(envs),
-		EnvVars:        map[string]string{},
 	}).Get(executionContext, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "executing activity")

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -145,7 +145,6 @@ func (r *JobRunner) apply(executionCtx *ExecutionContext, planFile string, step 
 	})
 	err = workflow.ExecuteActivity(ctx, r.Activity.TerraformApply, activities.TerraformApplyRequest{
 		Args:        args,
-		Envs:        map[string]string{},
 		DynamicEnvs: envs,
 		TfVersion:   executionCtx.TfVersion,
 		Path:        executionCtx.Path,
@@ -172,7 +171,6 @@ func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, extraA
 	}
 	err = workflow.ExecuteActivity(ctx, r.Activity.TerraformPlan, activities.TerraformPlanRequest{
 		Args:        args,
-		Envs:        map[string]string{},
 		DynamicEnvs: envs,
 		TfVersion:   ctx.TfVersion,
 		JobID:       ctx.JobID,
@@ -199,7 +197,6 @@ func (r *JobRunner) init(ctx *ExecutionContext, localRoot *terraform.LocalRoot, 
 	var resp activities.TerraformInitResponse
 	err = workflow.ExecuteActivity(ctx.Context, r.Activity.TerraformInit, activities.TerraformInitRequest{
 		Args:                 args,
-		Envs:                 map[string]string{},
 		DynamicEnvs:          envs,
 		TfVersion:            ctx.TfVersion,
 		Path:                 ctx.Path,

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -109,7 +109,6 @@ func TestJobRunner_Plan(t *testing.T) {
 				req: activities.TerraformPlanRequest{
 					JobID: JobID,
 					Args:  []terraform_model.Argument{},
-					Envs:  map[string]string{},
 					DynamicEnvs: []activities.EnvVar{
 						{
 							Name:  "env1",
@@ -156,7 +155,6 @@ func TestJobRunner_Apply(t *testing.T) {
 				req: activities.TerraformApplyRequest{
 					JobID: JobID,
 					Args:  []terraform_model.Argument{},
-					Envs:  map[string]string{},
 					DynamicEnvs: []activities.EnvVar{
 						{
 							Name:  "env1",

--- a/server/neptune/workflows/internal/terraform/version/name.go
+++ b/server/neptune/workflows/internal/terraform/version/name.go
@@ -1,5 +1,0 @@
-package version
-
-// This version removes an activity that computes env vars from commands and instead opts
-// for lazy loading within each of the following steps.
-const LazyLoadEnvVars = "lazy-load-env-vars"


### PR DESCRIPTION
Were deprecated in an older workflow version, we shouldn't need to persist code. I don't believe this change is [non-deterministic](https://legacy-documentation-sdks.temporal.io/go/versioning#sanity-checking) since we are only modifying activity inputs, not the name/workflow order itself.