### PR TITLE
Build out policy check ui

### DIFF
--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -29,6 +29,7 @@ type checkrunTemplateData struct {
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
+	// TODO: handle policy check state updates
 	planStatus, planLogURL := getJobStatusAndOutput(workflowState.Plan)
 	applyStatus, applyLogURL := getJobStatusAndOutput(workflowState.Apply)
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -10,7 +10,11 @@ Github Actions are blocking this deployment from proceeding.
 | Operation | **Status** | **Logs** |  
 | - | - | - |
 | Plan | {{ if .PlanStatus }}`{{.PlanStatus}}`{{else}}N/A{{end}} |{{ if .PlanLogURL }}[Click Here]({{.PlanLogURL}}){{else}}N/A{{end}} |
+{{ if .PRMode }}
+| Policy Check | {{ if .PolicyCheckStatus }}`{{.PolicyCheckStatus}}`{{else}}N/A{{end}} |{{ if .PolicyCheckLogURL }}[Click Here]({{.PolicyCheckLogURL}}){{else}}N/A{{end}} |
+{{else}}
 | Apply | {{ if .ApplyStatus }}`{{.ApplyStatus}}`{{else}}N/A{{end}} |{{ if .ApplyLogURL }}[Click Here]({{.ApplyLogURL}}){{else}}N/A{{end}} |
+{{end}}
 
 {{if .InternalError }}
 ## Deployment Error :boom:

--- a/server/neptune/workflows/activities/terraform/root.go
+++ b/server/neptune/workflows/activities/terraform/root.go
@@ -20,6 +20,7 @@ type Root struct {
 	Trigger      Trigger
 	Rerun        bool
 	TrackedFiles []string
+	WorkflowMode WorkflowMode
 }
 
 func (r Root) GetTrackedFilesRelativeToRepo() []string {

--- a/server/neptune/workflows/internal/deploy/notifier/github.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github.go
@@ -135,6 +135,7 @@ func (n *CheckRunNotifier) Notify(ctx workflow.Context, deploymentInfo terraform
 }
 
 func (n *CheckRunNotifier) updateCheckRun(ctx workflow.Context, workflowState *state.Workflow, deploymentInfo terraform.DeploymentInfo) error {
+	// TODO: handle policy check state updates
 	summary := markdown.RenderWorkflowStateTmpl(workflowState)
 	checkRunState := determineCheckRunState(workflowState)
 

--- a/server/neptune/workflows/internal/deploy/notifier/github.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github.go
@@ -135,8 +135,7 @@ func (n *CheckRunNotifier) Notify(ctx workflow.Context, deploymentInfo terraform
 }
 
 func (n *CheckRunNotifier) updateCheckRun(ctx workflow.Context, workflowState *state.Workflow, deploymentInfo terraform.DeploymentInfo) error {
-	// TODO: handle policy check state updates
-	summary := markdown.RenderWorkflowStateTmpl(workflowState)
+	summary := markdown.RenderWorkflowStateTmpl(workflowState, deploymentInfo.Root.WorkflowMode)
 	checkRunState := determineCheckRunState(workflowState)
 
 	request := GithubCheckRunRequest{

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -79,7 +79,7 @@ func (r *JobRunner) Plan(ctx workflow.Context, localRoot *terraform.LocalRoot, j
 		case "init":
 			err = r.init(jobCtx, localRoot, step)
 		case "plan":
-			resp, err = r.plan(jobCtx, localRoot.Root.Plan.Mode, step.ExtraArgs)
+			resp, err = r.plan(jobCtx, localRoot.Root.Plan.Mode, localRoot.Root.WorkflowMode, step.ExtraArgs)
 		}
 		if err != nil {
 			return resp, errors.Wrapf(err, "running step %s", step.StepName)
@@ -93,6 +93,11 @@ func (r *JobRunner) Plan(ctx workflow.Context, localRoot *terraform.LocalRoot, j
 	}
 
 	return resp, nil
+}
+
+func (r *JobRunner) PolicyCheck(ctx workflow.Context, localRoot *terraform.LocalRoot, jobID string, showFile string) error {
+	// TODO: implement policy check job
+	return nil
 }
 
 func (r *JobRunner) Apply(ctx workflow.Context, localRoot *terraform.LocalRoot, jobID string, planFile string) error {
@@ -158,7 +163,7 @@ func (r *JobRunner) apply(executionCtx *ExecutionContext, planFile string, step 
 	return nil
 }
 
-func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, extraArgs []string) (activities.TerraformPlanResponse, error) {
+func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, workflowMode terraform.WorkflowMode, extraArgs []string) (activities.TerraformPlanResponse, error) {
 	var resp activities.TerraformPlanResponse
 
 	args, err := terraform.NewArgumentList(extraArgs)
@@ -170,12 +175,13 @@ func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, extraA
 		envs = append(envs, e.ToActivityEnvVar())
 	}
 	err = workflow.ExecuteActivity(ctx, r.Activity.TerraformPlan, activities.TerraformPlanRequest{
-		Args:        args,
-		DynamicEnvs: envs,
-		TfVersion:   ctx.TfVersion,
-		JobID:       ctx.JobID,
-		Path:        ctx.Path,
-		PlanMode:    mode,
+		Args:         args,
+		DynamicEnvs:  envs,
+		TfVersion:    ctx.TfVersion,
+		JobID:        ctx.JobID,
+		Path:         ctx.Path,
+		PlanMode:     mode,
+		WorkflowMode: workflowMode,
 	}).Get(ctx, &resp)
 	if err != nil {
 		return resp, errors.Wrap(err, "running terraform plan activity")

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -89,7 +89,8 @@ type WorkflowResult struct {
 }
 
 type Workflow struct {
-	Plan   *Job
-	Apply  *Job
-	Result WorkflowResult
+	Plan        *Job
+	PolicyCheck *Job
+	Apply       *Job
+	Result      WorkflowResult
 }


### PR DESCRIPTION
Using policy check workflow state data, build out the policy check run UI. Note that we will be reusing the existing table to consolidate all root steps into one check run. The policy check row should only appear when we are in PR Mode.

In the future, we will look into adding a plan/policy/apply summary within the GH UI instead of just passing all logs into the atlantis log UI.


Next step: Implement the Policy Check runner + underlying policy check activity that will generate this state