### PR TITLE
Add plugins to deploy workflow to support notifiers.

### DIFF
--- a/server/neptune/lyft/activities/audit.go
+++ b/server/neptune/lyft/activities/audit.go
@@ -105,7 +105,6 @@ func NewActivities(snsTopicArn string) (*Activities, error) {
 			SnsWriter: snsWriter,
 		},
 	}, nil
-
 }
 
 type Activities struct {

--- a/server/neptune/lyft/activities/audit.go
+++ b/server/neptune/lyft/activities/audit.go
@@ -5,7 +5,11 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+	awsSns "github.com/aws/aws-sdk-go/service/sns"
+
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/activities/sns"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 )
@@ -79,6 +83,33 @@ type AuditJobRequest struct {
 	EndTime        string
 	IsForceApply   bool
 	Tags           map[string]string
+}
+
+func NewActivities(snsTopicArn string) (*Activities, error) {
+	var snsWriter io.Writer
+	if snsTopicArn != "" {
+		session, err := session.NewSession()
+		if err != nil {
+			return nil, errors.Wrap(err, "initializing new aws session")
+		}
+		snsWriter = &sns.Writer{
+			Client:   awsSns.New(session),
+			TopicArn: snsTopicArn,
+		}
+	} else {
+		snsWriter = io.Discard
+	}
+
+	return &Activities{
+		auditActivities: &auditActivities{
+			SnsWriter: snsWriter,
+		},
+	}, nil
+
+}
+
+type Activities struct {
+	*auditActivities
 }
 
 type auditActivities struct {

--- a/server/neptune/lyft/activities/sns/writer.go
+++ b/server/neptune/lyft/activities/sns/writer.go
@@ -12,13 +12,13 @@ type snsPublisher interface {
 
 type Writer struct {
 	Client   snsPublisher
-	TopicArn *string
+	TopicArn string
 }
 
 func (w *Writer) Write(payload []byte) (int, error) {
 	if _, err := w.Client.Publish(&awsSns.PublishInput{
 		Message:  aws.String(string(payload)),
-		TopicArn: w.TopicArn,
+		TopicArn: aws.String(w.TopicArn),
 	}); err != nil {
 		return 0, err
 	}

--- a/server/neptune/lyft/notifier/sns.go
+++ b/server/neptune/lyft/notifier/sns.go
@@ -3,10 +3,9 @@ package notifier
 import (
 	"context"
 
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/activities"
 	t "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"go.temporal.io/sdk/workflow"
 
 	"strconv"
@@ -20,7 +19,7 @@ type SNSNotifier struct {
 	Activity auditActivity
 }
 
-func (n *SNSNotifier) Notify(ctx workflow.Context, deploymentInfo terraform.DeploymentInfo, workflowState *state.Workflow) error {
+func (n *SNSNotifier) Notify(ctx workflow.Context, deploymentInfo plugins.TerraformDeploymentInfo, workflowState *plugins.TerraformWorkflowState) error {
 	if workflowState.Apply == nil {
 		return nil
 	}
@@ -32,12 +31,12 @@ func (n *SNSNotifier) Notify(ctx workflow.Context, deploymentInfo terraform.Depl
 
 	var endTime string
 	switch jobState.Status {
-	case state.InProgressJobStatus:
+	case plugins.InProgressJobStatus:
 		atlantisJobState = activities.AtlantisJobStateRunning
-	case state.SuccessJobStatus:
+	case plugins.SuccessJobStatus:
 		atlantisJobState = activities.AtlantisJobStateSuccess
 		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
-	case state.FailedJobStatus:
+	case plugins.FailedJobStatus:
 		atlantisJobState = activities.AtlantisJobStateFailure
 		endTime = strconv.FormatInt(jobState.EndTime.Unix(), 10)
 

--- a/server/neptune/lyft/notifier/sns_test.go
+++ b/server/neptune/lyft/notifier/sns_test.go
@@ -60,9 +60,9 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 	stTime := time.Now()
 	endTime := stTime.Add(time.Second * 5)
 	internalDeploymentInfo := plugins.TerraformDeploymentInfo{
-		ID:         uuid.New(),
-		Root:       terraform.Root{Name: "root"},
-		Repo:       github.Repo{Name: "hello"},
+		ID:   uuid.New(),
+		Root: terraform.Root{Name: "root"},
+		Repo: github.Repo{Name: "hello"},
 		Commit: github.Commit{
 			Revision: "12345",
 		},
@@ -205,9 +205,9 @@ func TestSNSNotifier_IfApplyJobNil(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	internalDeploymentInfo := plugins.TerraformDeploymentInfo{
-		ID:         uuid.New(),
-		Root:       terraform.Root{Name: "root"},
-		Repo:       github.Repo{Name: "hello"},
+		ID:   uuid.New(),
+		Root: terraform.Root{Name: "root"},
+		Repo: github.Repo{Name: "hello"},
 		Commit: github.Commit{
 			Revision: "12345",
 		},

--- a/server/neptune/lyft/notifier/sns_test.go
+++ b/server/neptune/lyft/notifier/sns_test.go
@@ -60,7 +60,6 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 	stTime := time.Now()
 	endTime := stTime.Add(time.Second * 5)
 	internalDeploymentInfo := plugins.TerraformDeploymentInfo{
-		CheckRunID: 1,
 		ID:         uuid.New(),
 		Root:       terraform.Root{Name: "root"},
 		Repo:       github.Repo{Name: "hello"},
@@ -75,10 +74,10 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 	}{
 		{
 			State: &plugins.TerraformWorkflowState{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
-				Apply: &plugins.Job{
+				Apply: &plugins.JobState{
 					Status:    plugins.InProgressJobStatus,
 					StartTime: stTime,
 				},
@@ -94,10 +93,10 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 		},
 		{
 			State: &plugins.TerraformWorkflowState{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
-				Apply: &plugins.Job{
+				Apply: &plugins.JobState{
 					Status:    plugins.FailedJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,
@@ -115,10 +114,10 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 		},
 		{
 			State: &plugins.TerraformWorkflowState{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
-				Apply: &plugins.Job{
+				Apply: &plugins.JobState{
 					Status:    plugins.FailedJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,
@@ -136,10 +135,10 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 		},
 		{
 			State: &plugins.TerraformWorkflowState{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
-				Apply: &plugins.Job{
+				Apply: &plugins.JobState{
 					Status:    plugins.FailedJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,
@@ -157,10 +156,10 @@ func TestSNSNotifier_SendsMessage(t *testing.T) {
 		},
 		{
 			State: &plugins.TerraformWorkflowState{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
-				Apply: &plugins.Job{
+				Apply: &plugins.JobState{
 					Status:    plugins.SuccessJobStatus,
 					StartTime: stTime,
 					EndTime:   endTime,
@@ -206,7 +205,6 @@ func TestSNSNotifier_IfApplyJobNil(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	internalDeploymentInfo := plugins.TerraformDeploymentInfo{
-		CheckRunID: 1,
 		ID:         uuid.New(),
 		Root:       terraform.Root{Name: "root"},
 		Repo:       github.Repo{Name: "hello"},
@@ -221,7 +219,7 @@ func TestSNSNotifier_IfApplyJobNil(t *testing.T) {
 	env.ExecuteWorkflow(testSNSNotifierWorkflow, snsNotifierRequest{
 		StatesToSend: []*plugins.TerraformWorkflowState{
 			{
-				Plan: &plugins.Job{
+				Plan: &plugins.JobState{
 					Status: plugins.SuccessJobStatus,
 				},
 			},

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -13,15 +13,15 @@ import (
 	"syscall"
 	"time"
 
-	awsSns "github.com/aws/aws-sdk-go/service/sns"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/lyft/aws"
 	"github.com/runatlantis/atlantis/server/metrics"
 	neptune_http "github.com/runatlantis/atlantis/server/neptune/http"
+	lyftActivities "github.com/runatlantis/atlantis/server/neptune/lyft/activities"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/notifier"
 	internalSync "github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/sync/crons"
 	"github.com/runatlantis/atlantis/server/neptune/temporal"
@@ -30,12 +30,13 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/job"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/aws/sns"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"github.com/runatlantis/atlantis/server/static"
 	"github.com/uber-go/tally/v4"
 	"github.com/urfave/negroni"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 )
 
 const (
@@ -72,8 +73,11 @@ type Server struct {
 	TerraformActivities      *activities.Terraform
 	GithubActivities         *activities.Github
 	RevisionSetterActivities *activities.RevsionSetter
-	TerraformTaskQueue       string
-	RevisionSetterConfig     valid.RevisionSetter
+	// Temporary until we move this into our private code
+	LyftActivities       *lyftActivities.Activities
+	TerraformTaskQueue   string
+	RevisionSetterConfig valid.RevisionSetter
+	AdditionalNotifiers  []plugins.TerraformWorkflowNotifier
 }
 
 func NewServer(config *config.Config) (*Server, error) {
@@ -133,23 +137,11 @@ func NewServer(config *config.Config) (*Server, error) {
 		Logger:      config.CtxLogger,
 	}
 
-	//TODO: move this within the activity construction
-	// we only initialize the AWS session if we have a topic, otherwise we just drop the message,
-	// for now this is how we get around local testing without aws resources.
-	var snsWriter io.Writer
-	if config.LyftAuditJobsSnsTopicArn != "" {
-		session, err := aws.NewSession()
-		if err != nil {
-			return nil, errors.Wrap(err, "initializing new aws session")
-		}
-		snsWriter = &sns.Writer{
-			Client:   awsSns.New(session),
-			TopicArn: &config.LyftAuditJobsSnsTopicArn,
-		}
-	} else {
-		snsWriter = io.Discard
+	lyftActivities, err := lyftActivities.NewActivities(config.LyftAuditJobsSnsTopicArn)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing lyft activities")
 	}
-	deployActivities, err := activities.NewDeploy(config.DeploymentConfig, snsWriter)
+	deployActivities, err := activities.NewDeploy(config.DeploymentConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing deploy activities")
 	}
@@ -203,6 +195,7 @@ func NewServer(config *config.Config) (*Server, error) {
 		RevisionSetterActivities: revisionSetterActivities,
 		TerraformTaskQueue:       config.TemporalCfg.TerraformTaskQueue,
 		RevisionSetterConfig:     config.RevisionSetter,
+		LyftActivities:           lyftActivities,
 	}
 	return &server, nil
 }
@@ -344,8 +337,22 @@ func (s Server) buildDeployWorker() worker.Worker {
 	})
 	deployWorker.RegisterActivity(s.DeployActivities)
 	deployWorker.RegisterActivity(s.GithubActivities)
+	deployWorker.RegisterActivity(s.LyftActivities)
 	deployWorker.RegisterActivity(s.TerraformActivities)
-	deployWorker.RegisterWorkflow(workflows.Deploy)
+	deployWorker.RegisterWorkflow(workflows.GetDeployWithPlugins(
+		func(ctx workflow.Context, dr workflows.DeployRequest) (*plugins.Deploy, error) {
+			var a *lyftActivities.Activities
+
+			return &plugins.Deploy{
+				Notifiers: []plugins.TerraformWorkflowNotifier{
+					&notifier.SNSNotifier{
+						Activity: a,
+					},
+				},
+			}, nil
+
+		},
+	))
 	deployWorker.RegisterWorkflow(workflows.Terraform)
 	return deployWorker
 }

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -339,7 +339,7 @@ func (s Server) buildDeployWorker() worker.Worker {
 	deployWorker.RegisterActivity(s.GithubActivities)
 	deployWorker.RegisterActivity(s.LyftActivities)
 	deployWorker.RegisterActivity(s.TerraformActivities)
-	deployWorker.RegisterWorkflow(workflows.GetDeployWithPlugins(
+	deployWorker.RegisterWorkflowWithOptions(workflows.GetDeployWithPlugins(
 		func(ctx workflow.Context, dr workflows.DeployRequest) (plugins.Deploy, error) {
 			var a *lyftActivities.Activities
 
@@ -351,7 +351,9 @@ func (s Server) buildDeployWorker() worker.Worker {
 				},
 			}, nil
 		},
-	))
+	), workflow.RegisterOptions{
+		Name: workflows.Deploy,
+	})
 	deployWorker.RegisterWorkflow(workflows.Terraform)
 	return deployWorker
 }

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -340,10 +340,10 @@ func (s Server) buildDeployWorker() worker.Worker {
 	deployWorker.RegisterActivity(s.LyftActivities)
 	deployWorker.RegisterActivity(s.TerraformActivities)
 	deployWorker.RegisterWorkflow(workflows.GetDeployWithPlugins(
-		func(ctx workflow.Context, dr workflows.DeployRequest) (*plugins.Deploy, error) {
+		func(ctx workflow.Context, dr workflows.DeployRequest) (plugins.Deploy, error) {
 			var a *lyftActivities.Activities
 
-			return &plugins.Deploy{
+			return plugins.Deploy{
 				Notifiers: []plugins.TerraformWorkflowNotifier{
 					&notifier.SNSNotifier{
 						Activity: a,

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -350,7 +350,6 @@ func (s Server) buildDeployWorker() worker.Worker {
 					},
 				},
 			}, nil
-
 		},
 	))
 	deployWorker.RegisterWorkflow(workflows.Terraform)

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -1,7 +1,6 @@
 package activities
 
 import (
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,10 +42,9 @@ const (
 // registering multiple workflows to the same worker
 type Deploy struct {
 	*dbActivities
-	*auditActivities
 }
 
-func NewDeploy(deploymentStoreCfg valid.StoreConfig, snsWriter io.Writer) (*Deploy, error) {
+func NewDeploy(deploymentStoreCfg valid.StoreConfig) (*Deploy, error) {
 	storageClient, err := storage.NewClient(deploymentStoreCfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "intializing stow client")
@@ -60,9 +58,6 @@ func NewDeploy(deploymentStoreCfg valid.StoreConfig, snsWriter io.Writer) (*Depl
 	return &Deploy{
 		dbActivities: &dbActivities{
 			DeploymentInfoStore: deploymentStore,
-		},
-		auditActivities: &auditActivities{
-			SnsWriter: snsWriter,
 		},
 	}, nil
 }

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -44,11 +44,11 @@ var Deploy = "Deploy"
 type DeployFunc func(workflow.Context, DeployRequest) error
 
 // This is used to have user defined components of the workflow.
-type InitDeployPlugins func(workflow.Context, DeployRequest) (*plugins.Deploy, error)
+type InitDeployPlugins func(workflow.Context, DeployRequest) (plugins.Deploy, error)
 
 // NoPlugin is the default and should be used when there are no plugins to add
-func NoPlugins(ctx workflow.Context, req DeployRequest) (*plugins.Deploy, error) {
-	return nil, nil
+func NoPlugins(ctx workflow.Context, req DeployRequest) (plugins.Deploy, error) {
+	return plugins.Deploy{}, nil
 }
 
 func GetDeployWithPlugins(InitPlugins InitDeployPlugins) DeployFunc {

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -44,6 +44,8 @@ var Deploy = "Deploy"
 type DeployFunc func(workflow.Context, DeployRequest) error
 
 // This is used to have user defined components of the workflow.
+// Note: This can be dangerous as changes to these could have non-deterministic effects
+// on your workflows. Use this with caution.
 type InitDeployPlugins func(workflow.Context, DeployRequest) (plugins.Deploy, error)
 
 // NoPlugin is the default and should be used when there are no plugins to add
@@ -51,6 +53,9 @@ func NoPlugins(ctx workflow.Context, req DeployRequest) (plugins.Deploy, error) 
 	return plugins.Deploy{}, nil
 }
 
+// GetDeployWithPlugins returns a function closure for the deploy workflow.
+// The idea here is that any custom plugins get initialized in the closure,
+// before the workflow is run.
 func GetDeployWithPlugins(InitPlugins InitDeployPlugins) DeployFunc {
 	return func(ctx workflow.Context, req DeployRequest) error {
 		plugins, err := InitPlugins(ctx, req)

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -60,7 +60,7 @@ func GetDeployWithPlugins(InitPlugins InitDeployPlugins) DeployFunc {
 	return func(ctx workflow.Context, req DeployRequest) error {
 		plugins, err := InitPlugins(ctx, req)
 		if err != nil {
-			return errors.Wrap(err, "building plugin")
+			return errors.Wrap(err, "initializing plugins")
 		}
 		return deploy.Workflow(
 			ctx,

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -158,15 +158,6 @@ func buildConfig(t *testing.T) config.Config {
 	}
 }
 
-type testSnsWriter struct {
-	writes [][]byte
-}
-
-func (t *testSnsWriter) Write(p []byte) (n int, err error) {
-	t.writes = append(t.writes, p)
-	return 0, nil
-}
-
 func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironment, revReq workflows.DeployNewRevisionSignalRequest) *testSingletons {
 	cfg := buildConfig(t)
 

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -45,7 +45,9 @@ func TestDeployWorkflow(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	env.RegisterWorkflow(workflows.Deploy)
+	deployWorkflow := workflows.GetDeploy()
+
+	env.RegisterWorkflow(deployWorkflow)
 	env.RegisterWorkflow(workflows.Terraform)
 	env.RegisterWorkflow(workflows.PRRevision)
 
@@ -92,7 +94,7 @@ func TestDeployWorkflow(t *testing.T) {
 		signalWorkflow(env, revRequest)
 	}, 5*time.Second)
 
-	env.ExecuteWorkflow(workflows.Deploy, workflows.DeployRequest{
+	env.ExecuteWorkflow(deployWorkflow, workflows.DeployRequest{
 		Root: workflows.DeployRequestRoot{
 			Name: root.Name,
 		},
@@ -110,10 +112,6 @@ func TestDeployWorkflow(t *testing.T) {
 
 	// we should have output for 2 different jobs
 	assert.Len(t, s.streamCloser.CapturedJobOutput, 2)
-
-	// we should emit 3 events: IN_PROGRESS, SUCCESS, SUCCESS
-	// two success events are emitted since one happens on completion of the workflow.
-	assert.Len(t, s.snsWriter.writes, 3)
 }
 
 func signalWorkflow(env *testsuite.TestWorkflowEnvironment, revRequest workflows.DeployNewRevisionSignalRequest) {
@@ -125,7 +123,6 @@ type testSingletons struct {
 	githubClient         *testGithubClient
 	revisionSetterClient *testRevSetterClient
 	streamCloser         *testStreamCloser
-	snsWriter            *testSnsWriter
 }
 
 func buildConfig(t *testing.T) config.Config {
@@ -173,10 +170,7 @@ func (t *testSnsWriter) Write(p []byte) (n int, err error) {
 func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironment, revReq workflows.DeployNewRevisionSignalRequest) *testSingletons {
 	cfg := buildConfig(t)
 
-	snsWriter := &testSnsWriter{
-		writes: [][]byte{},
-	}
-	deployActivities, err := activities.NewDeploy(cfg.DeploymentConfig, snsWriter)
+	deployActivities, err := activities.NewDeploy(cfg.DeploymentConfig)
 
 	assert.NoError(t, err)
 
@@ -238,7 +232,6 @@ func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironm
 		},
 		githubClient:         githubClient,
 		streamCloser:         streamCloser,
-		snsWriter:            snsWriter,
 		revisionSetterClient: revSetterClient,
 	}
 }

--- a/server/neptune/workflows/internal/deploy/notifier/github_test.go
+++ b/server/neptune/workflows/internal/deploy/notifier/github_test.go
@@ -1,13 +1,11 @@
 package notifier_test
 
 import (
-	"context"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
@@ -30,10 +28,6 @@ func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID s
 	assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID)
 
 	return 1, nil
-}
-
-func (a *testActivities) AuditJob(ctx context.Context, request activities.AuditJobRequest) error {
-	return nil
 }
 
 type checkrunNotifierRequest struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -68,10 +68,6 @@ func (t *testDeployActivity) GithubUpdateCheckRun(ctx context.Context, deployerR
 	return activities.UpdateCheckRunResponse{}, nil
 }
 
-func (t *testDeployActivity) AuditJob(ctx context.Context, request activities.AuditJobRequest) error {
-	return nil
-}
-
 type deployerRequest struct {
 	Info              terraform.DeploymentInfo
 	LatestDeploy      *deployment.Info

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -94,7 +94,7 @@ func NewWorker(
 		},
 	}
 
-	tfWorkflowRunner := terraform.NewWorkflowRunner(tfWorkflow, notifiers)
+	tfWorkflowRunner := terraform.NewWorkflowRunner(tfWorkflow, notifiers, additionalNotifiers...)
 	deployer := &Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -1,7 +1,6 @@
 package queue
 
 import (
-	"context"
 	"fmt"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
@@ -10,12 +9,12 @@ import (
 
 	"github.com/pkg/errors"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -33,7 +32,6 @@ type deployer interface {
 
 type workerActivities interface {
 	deployerActivities
-	AuditJob(ctx context.Context, request activities.AuditJobRequest) error
 }
 
 type WorkerState string
@@ -88,16 +86,15 @@ func NewWorker(
 	prRevWorkflow Workflow,
 	repoName, rootName string,
 	githubCheckRunCache CheckRunClient,
+	additionalNotifiers ...plugins.TerraformWorkflowNotifier,
 ) (*Worker, error) {
-	checkRunNotifier := &notifier.CheckRunNotifier{
-		CheckRunSessionCache: githubCheckRunCache,
+	notifiers := []terraform.WorkflowNotifier{
+		&notifier.CheckRunNotifier{
+			CheckRunSessionCache: githubCheckRunCache,
+		},
 	}
 
-	snsNotifier := &notifier.SNSNotifier{
-		Activity: a,
-	}
-
-	tfWorkflowRunner := terraform.NewWorkflowRunner(a, tfWorkflow, snsNotifier, checkRunNotifier)
+	tfWorkflowRunner := terraform.NewWorkflowRunner(tfWorkflow, notifiers)
 	deployer := &Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 
 	"github.com/google/uuid"
 )
@@ -18,6 +19,17 @@ type DeploymentInfo struct {
 	Root           terraform.Root
 	Repo           github.Repo
 	Tags           map[string]string
+}
+
+func (i DeploymentInfo) ToExternalInfo() plugins.TerraformDeploymentInfo {
+	return plugins.TerraformDeploymentInfo{
+		ID:             i.ID,
+		Commit:         i.Commit,
+		InitiatingUser: i.InitiatingUser,
+		Root:           i.Root,
+		Repo:           i.Repo,
+		Tags:           i.Tags,
+	}
 }
 
 func (i DeploymentInfo) BuildPersistableInfo() *deployment.Info {

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -36,12 +37,12 @@ type stateReceiver interface {
 	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)
 }
 
-func NewWorkflowRunner(a receiverActivities, w Workflow, notifiers ...WorkflowNotifier) *WorkflowRunner {
+func NewWorkflowRunner(w Workflow, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {
 	return &WorkflowRunner{
 		Workflow: w,
 		StateReceiver: &StateReceiver{
-			Activity:  a,
-			Notifiers: notifiers,
+			InternalNotifiers:   internalNotifiers,
+			AdditionalNotifiers: additionalNotifiers,
 		},
 	}
 }

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -1,13 +1,11 @@
 package terraform
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/metrics"
 
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -15,18 +13,12 @@ type WorkflowNotifier interface {
 	Notify(workflow.Context, DeploymentInfo, *state.Workflow) error
 }
 
-type auditActivities interface {
-	AuditJob(ctx context.Context, request activities.AuditJobRequest) error
-}
-
-type receiverActivities interface {
-	auditActivities
-	GithubUpdateCheckRun(ctx context.Context, request activities.UpdateCheckRunRequest) (activities.UpdateCheckRunResponse, error)
-}
-
 type StateReceiver struct {
-	Activity  receiverActivities
-	Notifiers []WorkflowNotifier
+
+	// We have separate classes of notifiers since we can be more flexible with our internal ones in terms of the data model
+	// What we support externally should be well thought out so for now this is kept to a minimum.
+	InternalNotifiers   []WorkflowNotifier
+	AdditionalNotifiers []plugins.TerraformWorkflowNotifier
 }
 
 func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo) {
@@ -37,7 +29,15 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 		metrics.SignalNameTag: state.WorkflowStateChangeSignal,
 	}).Counter(metrics.SignalReceive).Inc(1)
 
-	for _, notifier := range n.Notifiers {
+	// for now we are doing these notifiers first because otherwise we'd need to version (since audit activities were moved here)
+	// TODO: Add the version clause to clean this up
+	for _, notifier := range n.AdditionalNotifiers {
+		if err := notifier.Notify(ctx, deploymentInfo.ToExternalInfo(), workflowState.ToExternalWorkflowState()); err != nil {
+			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
+		}
+	}
+
+	for _, notifier := range n.InternalNotifiers {
 		if err := notifier.Notify(ctx, deploymentInfo, workflowState); err != nil {
 			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
 		}

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -33,12 +33,14 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 	// TODO: Add the version clause to clean this up
 	for _, notifier := range n.AdditionalNotifiers {
 		if err := notifier.Notify(ctx, deploymentInfo.ToExternalInfo(), workflowState.ToExternalWorkflowState()); err != nil {
+			workflow.GetMetricsHandler(ctx).Counter("notifier_plugin_failure").Inc(1)
 			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
 		}
 	}
 
 	for _, notifier := range n.InternalNotifiers {
 		if err := notifier.Notify(ctx, deploymentInfo, workflowState); err != nil {
+			workflow.GetMetricsHandler(ctx).Counter("notifier_failure").Inc(1)
 			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
 		}
 	}

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -54,7 +54,7 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stat
 	}
 
 	receiver := &internalTerraform.StateReceiver{
-		Notifiers: []internalTerraform.WorkflowNotifier{
+		InternalNotifiers: []internalTerraform.WorkflowNotifier{
 			notifier,
 		},
 	}

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
@@ -31,6 +32,22 @@ func (n *testNotifier) Notify(ctx workflow.Context, info internalTerraform.Deplo
 	return nil
 }
 
+type testExternalNotifier struct {
+	expectedInfo  plugins.TerraformDeploymentInfo
+	expectedState *plugins.TerraformWorkflowState
+	expectedT     *testing.T
+	called        bool
+}
+
+func (n *testExternalNotifier) Notify(ctx workflow.Context, info plugins.TerraformDeploymentInfo, s *plugins.TerraformWorkflowState) error {
+	assert.Equal(n.expectedT, n.expectedInfo, info)
+	assert.Equal(n.expectedT, n.expectedState, s)
+
+	n.called = true
+
+	return nil
+}
+
 type stateReceiveRequest struct {
 	State          *state.Workflow
 	DeploymentInfo internalTerraform.DeploymentInfo
@@ -38,7 +55,8 @@ type stateReceiveRequest struct {
 }
 
 type stateReceiveResponse struct {
-	NotifierCalled bool
+	NotifierCalled         bool
+	ExternalNotifierCalled bool
 }
 
 func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stateReceiveResponse, error) {
@@ -53,9 +71,18 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stat
 		expectedT:     r.T,
 	}
 
+	externalNotifier := &testExternalNotifier{
+		expectedInfo:  r.DeploymentInfo.ToExternalInfo(),
+		expectedState: r.State.ToExternalWorkflowState(),
+		expectedT:     r.T,
+	}
+
 	receiver := &internalTerraform.StateReceiver{
 		InternalNotifiers: []internalTerraform.WorkflowNotifier{
 			notifier,
+		},
+		AdditionalNotifiers: []plugins.TerraformWorkflowNotifier{
+			externalNotifier,
 		},
 	}
 
@@ -66,7 +93,8 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stat
 	receiver.Receive(ctx, ch, r.DeploymentInfo)
 
 	return stateReceiveResponse{
-		NotifierCalled: notifier.called,
+		NotifierCalled:         notifier.called,
+		ExternalNotifierCalled: externalNotifier.called,
 	}, nil
 }
 
@@ -88,7 +116,7 @@ func TestStateReceive(t *testing.T) {
 		},
 	}
 
-	t.Run("calls notifier with state", func(t *testing.T) {
+	t.Run("calls notifiers with state", func(t *testing.T) {
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 
@@ -108,6 +136,7 @@ func TestStateReceive(t *testing.T) {
 		var result stateReceiveResponse
 		err = env.GetWorkflowResult(&result)
 		assert.True(t, result.NotifierCalled)
+		assert.True(t, result.ExternalNotifierCalled)
 		assert.NoError(t, err)
 	})
 }

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -56,7 +56,7 @@ type ChildWorkflows struct {
 	SetPRRevision queue.Workflow
 }
 
-func Workflow(ctx workflow.Context, request Request, children ChildWorkflows, plugins *plugins.Deploy) error {
+func Workflow(ctx workflow.Context, request Request, children ChildWorkflows, plugins plugins.Deploy) error {
 	options := workflow.ActivityOptions{
 		TaskQueue:           TaskQueue,
 		StartToCloseTimeout: 5 * time.Second,
@@ -82,7 +82,7 @@ type Runner struct {
 	Scope                    workflowMetrics.Scope
 }
 
-func newRunner(ctx workflow.Context, request Request, children ChildWorkflows, plugins *plugins.Deploy) (*Runner, error) {
+func newRunner(ctx workflow.Context, request Request, children ChildWorkflows, plugins plugins.Deploy) (*Runner, error) {
 	// inject dependencies
 
 	// temporal effectively "injects" this, it just cares about the method names,

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -100,7 +100,7 @@ func newRunner(ctx workflow.Context, request Request, children ChildWorkflows, p
 		lockStateUpdater.UpdateQueuedRevisions(ctx, d, request.Repo.FullName)
 	}, scope)
 
-	worker, err := queue.NewWorker(ctx, revisionQueue, a, children.Terraform, children.SetPRRevision, request.Repo.FullName, request.Root.Name, checkRunCache)
+	worker, err := queue.NewWorker(ctx, revisionQueue, a, children.Terraform, children.SetPRRevision, request.Repo.FullName, request.Root.Name, checkRunCache, plugins.Notifiers...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -12,6 +12,7 @@ import (
 	workflowMetrics "github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	temporalInternal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -50,14 +51,19 @@ type QueueWorker interface {
 	GetState() queue.WorkerState
 }
 
-func Workflow(ctx workflow.Context, request Request, tfWorkflow terraform.Workflow, prWorkflow queue.Workflow) error {
+type ChildWorkflows struct {
+	Terraform     terraform.Workflow
+	SetPRRevision queue.Workflow
+}
+
+func Workflow(ctx workflow.Context, request Request, children ChildWorkflows, plugins *plugins.Deploy) error {
 	options := workflow.ActivityOptions{
 		TaskQueue:           TaskQueue,
 		StartToCloseTimeout: 5 * time.Second,
 	}
 	ctx = workflow.WithActivityOptions(ctx, options)
 
-	runner, err := newRunner(ctx, request, tfWorkflow, prWorkflow)
+	runner, err := newRunner(ctx, request, children, plugins)
 
 	if err != nil {
 		return errors.Wrap(err, "initializing workflow runner")
@@ -76,7 +82,7 @@ type Runner struct {
 	Scope                    workflowMetrics.Scope
 }
 
-func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workflow, prRevWorkflow queue.Workflow) (*Runner, error) {
+func newRunner(ctx workflow.Context, request Request, children ChildWorkflows, plugins *plugins.Deploy) (*Runner, error) {
 	// inject dependencies
 
 	// temporal effectively "injects" this, it just cares about the method names,
@@ -94,7 +100,7 @@ func newRunner(ctx workflow.Context, request Request, tfWorkflow terraform.Workf
 		lockStateUpdater.UpdateQueuedRevisions(ctx, d, request.Repo.FullName)
 	}, scope)
 
-	worker, err := queue.NewWorker(ctx, revisionQueue, a, tfWorkflow, prRevWorkflow, request.Repo.FullName, request.Root.Name, checkRunCache)
+	worker, err := queue.NewWorker(ctx, revisionQueue, a, children.Terraform, children.SetPRRevision, request.Repo.FullName, request.Root.Name, checkRunCache)
 	if err != nil {
 		return nil, err
 	}

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -113,8 +113,15 @@ type Workflow struct {
 
 func (w *Workflow) ToExternalWorkflowState() *plugins.TerraformWorkflowState {
 	return &plugins.TerraformWorkflowState{
-		Plan:     w.Plan.toExternalJob(),
-		Apply:    w.Apply.toExternalJob(),
-		Validate: w.Validate.toExternalJob(),
+		Plan:     getExternalJob(w.Plan),
+		Apply:    getExternalJob(w.Apply),
+		Validate: getExternalJob(w.Validate),
 	}
+}
+
+func getExternalJob(j *Job) *plugins.Job {
+	if j == nil {
+		return nil
+	}
+	return j.toExternalJob()
 }

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -76,8 +76,8 @@ type Job struct {
 	EndTime          time.Time
 }
 
-func (j *Job) toExternalJob() *plugins.Job {
-	return &plugins.Job{
+func (j *Job) toExternalJob() *plugins.JobState {
+	return &plugins.JobState{
 		ID: j.ID,
 
 		// we can probably do this in a cleaner way
@@ -119,7 +119,7 @@ func (w *Workflow) ToExternalWorkflowState() *plugins.TerraformWorkflowState {
 	}
 }
 
-func getExternalJob(j *Job) *plugins.Job {
+func getExternalJob(j *Job) *plugins.JobState {
 	if j == nil {
 		return nil
 	}

--- a/server/neptune/workflows/plugins/deployment_info.go
+++ b/server/neptune/workflows/plugins/deployment_info.go
@@ -6,10 +6,10 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 )
 
-// ideally we should make this protos or something that has backwards compatible changes
+// TerraformDeploymentInfo contains all the information required for a Terraform deployment
+// to occur. 
 type TerraformDeploymentInfo struct {
 	ID             uuid.UUID
-	CheckRunID     int64
 	Commit         github.Commit
 	InitiatingUser github.User
 	Root           terraform.Root

--- a/server/neptune/workflows/plugins/deployment_info.go
+++ b/server/neptune/workflows/plugins/deployment_info.go
@@ -1,0 +1,18 @@
+package plugins
+
+import (
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+)
+
+// ideally we should make this protos or something that has backwards compatible changes
+type TerraformDeploymentInfo struct {
+	ID             uuid.UUID
+	CheckRunID     int64
+	Commit         github.Commit
+	InitiatingUser github.User
+	Root           terraform.Root
+	Repo           github.Repo
+	Tags           map[string]string
+}

--- a/server/neptune/workflows/plugins/deployment_info.go
+++ b/server/neptune/workflows/plugins/deployment_info.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TerraformDeploymentInfo contains all the information required for a Terraform deployment
-// to occur. 
+// to occur.
 type TerraformDeploymentInfo struct {
 	ID             uuid.UUID
 	Commit         github.Commit

--- a/server/neptune/workflows/plugins/notifier.go
+++ b/server/neptune/workflows/plugins/notifier.go
@@ -2,10 +2,15 @@ package plugins
 
 import "go.temporal.io/sdk/workflow"
 
+// TerraformWorkflowNotifiers get called whenever there is a change to the WorkflowState
+// For example, when plans are in-progress or when they complete.
 type TerraformWorkflowNotifier interface {
 	Notify(workflow.Context, TerraformDeploymentInfo, *TerraformWorkflowState) error
 }
 
+// Customizable plugins for the deploy workflow
 type Deploy struct {
+
+	// A set of notifiers that are called for TerraformWorkflowState changes
 	Notifiers []TerraformWorkflowNotifier
 }

--- a/server/neptune/workflows/plugins/notifier.go
+++ b/server/neptune/workflows/plugins/notifier.go
@@ -1,0 +1,11 @@
+package plugins
+
+import "go.temporal.io/sdk/workflow"
+
+type TerraformWorkflowNotifier interface {
+	Notify(workflow.Context, TerraformDeploymentInfo, *TerraformWorkflowState) error
+}
+
+type Deploy struct {
+	Notifiers []TerraformWorkflowNotifier
+}

--- a/server/neptune/workflows/plugins/workflow_state.go
+++ b/server/neptune/workflows/plugins/workflow_state.go
@@ -1,0 +1,35 @@
+package plugins
+
+import (
+	"time"
+)
+
+type JobStatus string
+
+const (
+	WaitingJobStatus    JobStatus = "waiting"
+	InProgressJobStatus JobStatus = "in-progress"
+	RejectedJobStatus   JobStatus = "rejected"
+	FailedJobStatus     JobStatus = "failed"
+	SuccessJobStatus    JobStatus = "success"
+)
+
+type TerraformWorkflowStatus int
+
+const (
+	InProgressWorkflowStatus TerraformWorkflowStatus = iota
+	CompleteWorkflowStatus
+)
+
+type Job struct {
+	ID        string
+	Status    JobStatus
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+type TerraformWorkflowState struct {
+	Plan     *Job
+	Validate *Job
+	Apply    *Job
+}

--- a/server/neptune/workflows/plugins/workflow_state.go
+++ b/server/neptune/workflows/plugins/workflow_state.go
@@ -14,22 +14,19 @@ const (
 	SuccessJobStatus    JobStatus = "success"
 )
 
-type TerraformWorkflowStatus int
-
-const (
-	InProgressWorkflowStatus TerraformWorkflowStatus = iota
-	CompleteWorkflowStatus
-)
-
-type Job struct {
+// JobState represents the state of a job at a given time.
+type JobState struct {
 	ID        string
 	Status    JobStatus
 	StartTime time.Time
 	EndTime   time.Time
 }
 
+// TerraformWorkflowState contains the state of all jobs in the workflow
+// at a given time.  Note: jobs must always be checked for nil as they might
+// not exist at certain points.
 type TerraformWorkflowState struct {
-	Plan     *Job
-	Validate *Job
-	Apply    *Job
+	Plan     *JobState
+	Validate *JobState
+	Apply    *JobState
 }


### PR DESCRIPTION
Removes our sns notifier from being defined in the workflow to outside of it.  Starts a plugin paradigm to allow passing in user defined components that are initialized in the workflow. This paradigm leverages closures and requires us to now register the workflow with a specific name instead of just piggybacking off the function name.

Follow up PR will actually support plumbing these plugins through the codebase and initializing them from our private repository.