### PR TITLE
Fix checkrun UI

### DIFF
--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -10,9 +10,9 @@ Github Actions are blocking this deployment from proceeding.
 | Operation | **Status** | **Logs** |  
 | - | - | - |
 | Plan | {{ if .PlanStatus }}`{{.PlanStatus}}`{{else}}N/A{{end}} |{{ if .PlanLogURL }}[Click Here]({{.PlanLogURL}}){{else}}N/A{{end}} |
-{{ if .PRMode }}
+{{ if .PRMode -}}
 | Validate | {{ if .ValidateStatus }}`{{.ValidateStatus}}`{{else}}N/A{{end}} |{{ if .ValidateLogURL }}[Click Here]({{.ValidateLogURL}}){{else}}N/A{{end}} |
-{{else}}
+{{else -}}
 | Apply | {{ if .ApplyStatus }}`{{.ApplyStatus}}`{{else}}N/A{{end}} |{{ if .ApplyLogURL }}[Click Here]({{.ApplyLogURL}}){{else}}N/A{{end}} |
 {{end}}
 


### PR DESCRIPTION
Noticed the deploy checkruns table isn't rendering properly, I believe it is due to some whitespace breaking apart the markdown rows. This should remove the unnecessary spacing and render the tables again.

Before:

| Operation | **Status** | **Logs** |  
| - | - | - |
| Plan | n/a | n/a |

| Apply | n/a | n/a |

After:
| Operation | **Status** | **Logs** |  
| - | - | - |
| Plan | n/a | n/a |
| Apply | n/a | n/a |
