### PR TITLE
Build response for Terraform Workflow

### DIFF
--- a/server/neptune/workflows/activities/conftest.go
+++ b/server/neptune/workflows/activities/conftest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/go-version"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/temporal"
 	"go.temporal.io/sdk/activity"
@@ -28,7 +27,7 @@ type conftestActivity struct {
 	DefaultConftestVersion *version.Version
 	ConftestClient         asyncClient
 	StreamHandler          streamer
-	Policies               valid.PolicySets
+	Policies               []PolicySet
 	FileValidator          fileValidator
 }
 
@@ -50,7 +49,7 @@ const (
 
 type ValidationResult struct {
 	Status    ValidationStatus
-	PolicySet valid.PolicySet
+	PolicySet PolicySet
 }
 
 type ConftestResponse struct {
@@ -77,7 +76,7 @@ func (c *conftestActivity) Conftest(ctx context.Context, request ConftestRequest
 	var validationResults []ValidationResult
 
 	// run each policy separately to track which pass and fail
-	for _, policy := range c.Policies.PolicySets {
+	for _, policy := range c.Policies {
 		// add paths as arguments
 		var policyArgs []command.Argument
 		for _, path := range policy.Paths {
@@ -141,7 +140,7 @@ func (c *conftestActivity) sanitizeOutput(inputFile string, output string) strin
 	return strings.Replace(output, inputFile, "<redacted plan file>", -1)
 }
 
-func (c *conftestActivity) processOutput(output string, policySet valid.PolicySet, err error) string {
+func (c *conftestActivity) processOutput(output string, policySet PolicySet, err error) string {
 	// errored results need an extra newline
 	if err != nil {
 		return policySet.Name + ":\n" + output

--- a/server/neptune/workflows/activities/conftest.go
+++ b/server/neptune/workflows/activities/conftest.go
@@ -45,6 +45,7 @@ type ValidationStatus int
 const (
 	Success ValidationStatus = iota
 	Fail
+	//todo: support warn status
 )
 
 type ValidationResult struct {

--- a/server/neptune/workflows/activities/conftest_test.go
+++ b/server/neptune/workflows/activities/conftest_test.go
@@ -2,7 +2,6 @@ package activities
 
 import (
 	"github.com/hashicorp/go-version"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
@@ -86,12 +85,10 @@ func TestConftest_RequestValidation(t *testing.T) {
 				ShowFile:    "some/path/output.json",
 			}
 
-			policySets := valid.PolicySets{
-				PolicySets: []valid.PolicySet{
-					{
-						Name:  "policy1",
-						Paths: []string{"path/one", "path/two"},
-					},
+			policySets := []PolicySet{
+				{
+					Name:  "policy1",
+					Paths: []string{"path/one", "path/two"},
 				},
 			}
 			activity := conftestActivity{
@@ -161,12 +158,10 @@ func TestConftest_StreamsOutput(t *testing.T) {
 		expectedJobID: jobID,
 	}
 
-	policySets := valid.PolicySets{
-		PolicySets: []valid.PolicySet{
-			{
-				Name:  "policy1",
-				Paths: []string{"path/one", "path/two"},
-			},
+	policySets := []PolicySet{
+		{
+			Name:  "policy1",
+			Paths: []string{"path/one", "path/two"},
 		},
 	}
 	activity := conftestActivity{

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -82,6 +82,12 @@ type TerraformOptions struct {
 	GitCredentialsRefresher gitCredentialsRefresher
 }
 
+type PolicySet struct {
+	Name  string
+	Owner string
+	Paths []string
+}
+
 func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.ValidationConfig, ghAppConfig githubapp.Config, dataDir string, serverURL *url.URL, taskQueue string, streamHandler StreamCloser, opts ...TerraformOptions) (*Terraform, error) {
 	binDir, err := mkSubDir(dataDir, BinDirName)
 	if err != nil {
@@ -258,12 +264,6 @@ func NewRevisionSetterWithClient(client revisionSetterClient, cfg valid.Revision
 			basicAuth: cfg.BasicAuth,
 		},
 	}, nil
-}
-
-type PolicySet struct {
-	Name  string
-	Owner string
-	Paths []string
 }
 
 func convertPolicies(policies []valid.PolicySet) []PolicySet {

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -158,6 +158,8 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 		return nil, err
 	}
 
+	policies := convertPolicies(validationConfig.Policies.PolicySets)
+
 	return &Terraform{
 		executeCommandActivities: &executeCommandActivities{},
 		workerInfoActivity: &workerInfoActivity{
@@ -177,7 +179,7 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 			DefaultConftestVersion: defaultConftestVersion,
 			ConftestClient:         conftestClient,
 			StreamHandler:          streamHandler,
-			Policies:               validationConfig.Policies,
+			Policies:               policies,
 			FileValidator:          &file.Validator{},
 		},
 		jobActivities: &jobActivities{
@@ -256,4 +258,22 @@ func NewRevisionSetterWithClient(client revisionSetterClient, cfg valid.Revision
 			basicAuth: cfg.BasicAuth,
 		},
 	}, nil
+}
+
+type PolicySet struct {
+	Name  string
+	Owner string
+	Paths []string
+}
+
+func convertPolicies(policies []valid.PolicySet) []PolicySet {
+	var convertedPolicies []PolicySet
+	for _, policy := range policies {
+		convertedPolicies = append(convertedPolicies, PolicySet{
+			Name:  policy.Name,
+			Owner: policy.Owner,
+			Paths: policy.Paths,
+		})
+	}
+	return convertedPolicies
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -383,8 +383,8 @@ func TestWorker_DeploysItems_ValidationError_SkipLatestDeploymentUpdate(t *testi
 }
 
 func TestNewWorker(t *testing.T) {
-	emptyWorkflow := func(ctx workflow.Context, request terraformWorkflow.Request) error {
-		return nil
+	emptyWorkflow := func(ctx workflow.Context, request terraformWorkflow.Request) (terraformWorkflow.Response, error) {
+		return terraformWorkflow.Response{}, nil
 	}
 
 	emptyPRRevWorkflow := func(ctx workflow.Context, request prrevision.Request) error {

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -31,7 +31,7 @@ func (e PlanRejectionError) Error() string {
 	return e.msg
 }
 
-type Workflow func(ctx workflow.Context, request terraform.Request) error
+type Workflow func(ctx workflow.Context, request terraform.Request) (terraform.Response, error)
 
 type stateReceiver interface {
 	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)

--- a/server/neptune/workflows/internal/terraform/job/runner_test.go
+++ b/server/neptune/workflows/internal/terraform/job/runner_test.go
@@ -120,7 +120,8 @@ func testJobValidateWorkflow(ctx workflow.Context, r terraform.Request) error {
 
 	var a *testTerraformActivity
 	jobRunner := job.NewRunner(&job.CmdStepRunner{}, &job.EnvStepRunner{}, a)
-	return jobRunner.Validate(ctx, &localRoot, JobID, "")
+	_, err := jobRunner.Validate(ctx, &localRoot, JobID, "")
+	return err
 }
 
 func TestJobRunner_Plan(t *testing.T) {

--- a/server/neptune/workflows/internal/terraform/response.go
+++ b/server/neptune/workflows/internal/terraform/response.go
@@ -1,7 +1,9 @@
 package terraform
 
-import "github.com/runatlantis/atlantis/server/core/config/valid"
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+)
 
 type Response struct {
-	FailedPolicies map[string]valid.PolicySet
+	ValidationResults []activities.ValidationResult
 }

--- a/server/neptune/workflows/internal/terraform/response.go
+++ b/server/neptune/workflows/internal/terraform/response.go
@@ -1,0 +1,7 @@
+package terraform
+
+import "github.com/runatlantis/atlantis/server/core/config/valid"
+
+type Response struct {
+	FailedPolicies map[string]valid.PolicySet
+}

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"net/url"
 	"testing"
 	"time"
@@ -104,7 +103,7 @@ func (r *jobRunner) Apply(ctx workflow.Context, localRoot *terraformModel.LocalR
 	return r.expectedError
 }
 
-func (r *jobRunner) Validate(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, showFile string) (map[string]valid.PolicySet, error) {
+func (r *jobRunner) Validate(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, showFile string) ([]activities.ValidationResult, error) {
 	return nil, r.expectedError
 }
 

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"net/url"
 	"testing"
 	"time"
@@ -496,7 +495,7 @@ func TestSuccess_PRMode(t *testing.T) {
 		ValidateResults: []activities.ValidationResult{
 			{
 				Status:    activities.Success,
-				PolicySet: valid.PolicySet{},
+				PolicySet: activities.PolicySet{},
 			},
 		},
 	})
@@ -640,7 +639,7 @@ func TestSuccess_PRMode_FailedPolicy(t *testing.T) {
 		ValidateResults: []activities.ValidationResult{
 			{
 				Status:    activities.Fail,
-				PolicySet: valid.PolicySet{},
+				PolicySet: activities.PolicySet{},
 			},
 		},
 	})

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"net/url"
 	"testing"
 	"time"
@@ -103,8 +104,8 @@ func (r *jobRunner) Apply(ctx workflow.Context, localRoot *terraformModel.LocalR
 	return r.expectedError
 }
 
-func (r *jobRunner) Validate(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, showFile string) error {
-	return r.expectedError
+func (r *jobRunner) Validate(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, showFile string) (map[string]valid.PolicySet, error) {
+	return nil, r.expectedError
 }
 
 func (r *jobRunner) Plan(ctx workflow.Context, localRoot *terraformModel.LocalRoot, jobID string, workflowMode terraformModel.WorkflowMode) (activities.TerraformPlanResponse, error) {
@@ -190,7 +191,7 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 
 	var planRejected bool
 	var updateJobErr bool
-	if err := subject.Run(ctx); err != nil {
+	if _, err := subject.Run(ctx); err != nil {
 		var appErr *temporal.ApplicationError
 		if errors.As(err, &appErr) {
 			switch appErr.Type() {

--- a/server/neptune/workflows/terraform.go
+++ b/server/neptune/workflows/terraform.go
@@ -8,6 +8,7 @@ import (
 
 // Export anything that callers need such as requests, signals, etc.
 type TerraformRequest = terraform.Request
+type TerraformResponse = terraform.Response
 
 type TerraformPlanReviewSignalRequest = gate.PlanReviewSignalRequest
 
@@ -18,6 +19,6 @@ const RejectedPlanReviewStatus = gate.Rejected
 
 const TerraformPlanReviewSignalName = gate.PlanReviewSignalName
 
-func Terraform(ctx workflow.Context, request TerraformRequest) error {
+func Terraform(ctx workflow.Context, request TerraformRequest) (TerraformResponse, error) {
 	return terraform.Workflow(ctx, request)
 }


### PR DESCRIPTION
Now that the conftest activity returns the set of failed policies, we can feed it through as a response of the Terraform Worfklow. Note that the parent Deploy workflow does not generate/attempt to process these failed policies since platform mode doesn't run the validate step. We will only process it when the parent workflow is the PR, which will be the next major change.
