### PR TITLE
Move notifier package out of deploy package

### DIFF
--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
@@ -179,7 +179,7 @@ func (p *Deployer) updateCheckRun(ctx workflow.Context, deployRequest terraformW
 	})
 
 	request := notifier.GithubCheckRunRequest{
-		Title:   terraformWorkflow.BuildCheckRunTitle(deployRequest.Root.Name),
+		Title:   notifier.BuildCheckRunTitle("deploy", deployRequest.Root.Name),
 		Sha:     deployRequest.Commit.Revision,
 		State:   state,
 		Repo:    deployRequest.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -179,7 +179,7 @@ func (p *Deployer) updateCheckRun(ctx workflow.Context, deployRequest terraformW
 	})
 
 	request := notifier.GithubCheckRunRequest{
-		Title:   notifier.BuildCheckRunTitle("deploy", deployRequest.Root.Name),
+		Title:   notifier.BuildDeployCheckRunTitle(deployRequest.Root.Name),
 		Sha:     deployRequest.Commit.Revision,
 		State:   state,
 		Repo:    deployRequest.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	model "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
@@ -400,7 +400,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			Info:         deploymentInfo,
 			LatestDeploy: latestDeployedRevision,
 			ExpectedGHRequest: notifier.GithubCheckRunRequest{
-				Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+				Title:   notifier.BuildCheckRunTitle("deploy", deploymentInfo.Root.Name),
 				State:   github.CheckRunFailure,
 				Repo:    repo,
 				Summary: queue.DirectionBehindSummary,
@@ -439,7 +439,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 				Info:         deploymentInfo,
 				LatestDeploy: latestDeployedRevision,
 				ExpectedGHRequest: notifier.GithubCheckRunRequest{
-					Title:   terraform.BuildCheckRunTitle(deploymentInfo.Root.Name),
+					Title:   notifier.BuildCheckRunTitle("deploy", deploymentInfo.Root.Name),
 					State:   github.CheckRunFailure,
 					Repo:    repo,
 					Summary: queue.RerunNotIdenticalSummary,

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -400,7 +400,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			Info:         deploymentInfo,
 			LatestDeploy: latestDeployedRevision,
 			ExpectedGHRequest: notifier.GithubCheckRunRequest{
-				Title:   notifier.BuildCheckRunTitle("deploy", deploymentInfo.Root.Name),
+				Title:   notifier.BuildDeployCheckRunTitle(deploymentInfo.Root.Name),
 				State:   github.CheckRunFailure,
 				Repo:    repo,
 				Summary: queue.DirectionBehindSummary,
@@ -439,7 +439,7 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 				Info:         deploymentInfo,
 				LatestDeploy: latestDeployedRevision,
 				ExpectedGHRequest: notifier.GithubCheckRunRequest{
-					Title:   notifier.BuildCheckRunTitle("deploy", deploymentInfo.Root.Name),
+					Title:   notifier.BuildDeployCheckRunTitle(deploymentInfo.Root.Name),
 					State:   github.CheckRunFailure,
 					Repo:    repo,
 					Summary: queue.RerunNotIdenticalSummary,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -3,10 +3,9 @@ package queue
 import (
 	"fmt"
 	key "github.com/runatlantis/atlantis/server/neptune/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -35,7 +34,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 
 	for _, i := range infos {
 		request := notifier.GithubCheckRunRequest{
-			Title:   terraform.BuildCheckRunTitle(i.Root.Name),
+			Title:   notifier.BuildCheckRunTitle("deploy", i.Root.Name),
 			Sha:     i.Commit.Revision,
 			State:   state,
 			Repo:    i.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -34,7 +34,7 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 
 	for _, i := range infos {
 		request := notifier.GithubCheckRunRequest{
-			Title:   notifier.BuildCheckRunTitle("deploy", i.Root.Name),
+			Title:   notifier.BuildDeployCheckRunTitle(i.Root.Name),
 			Sha:     i.Commit.Revision,
 			State:   state,
 			Repo:    i.Repo,

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -54,7 +54,7 @@ func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
 	}
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
-		Title: notifier.BuildCheckRunTitle("deploy", info.Root.Name),
+		Title: notifier.BuildDeployCheckRunTitle(info.Root.Name),
 		State: github.CheckRunQueued,
 		Repo:  info.Repo,
 		ID:    info.CheckRunID,
@@ -65,7 +65,7 @@ func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title: notifier.BuildCheckRunTitle("deploy", info.Root.Name),
+			Title: notifier.BuildDeployCheckRunTitle(info.Root.Name),
 			State: github.CheckRunQueued,
 			Repo:  info.Repo,
 			Sha:   info.Commit.Revision,
@@ -103,7 +103,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 	}
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
-		Title:   notifier.BuildCheckRunTitle("deploy", info.Root.Name),
+		Title:   notifier.BuildDeployCheckRunTitle(info.Root.Name),
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
@@ -122,7 +122,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 			Revision: "1234",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:   notifier.BuildCheckRunTitle("deploy", info.Root.Name),
+			Title:   notifier.BuildDeployCheckRunTitle(info.Root.Name),
 			State:   github.CheckRunActionRequired,
 			Repo:    info.Repo,
 			Summary: "This deploy is locked from a manual deployment for revision [1234](https://github.com/some-org/some-repo/commit/1234).  Unlock to proceed.",

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -1,6 +1,7 @@
 package queue_test
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	tfActivity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -54,7 +54,7 @@ func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
 	}
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
-		Title: terraform.BuildCheckRunTitle(info.Root.Name),
+		Title: notifier.BuildCheckRunTitle("deploy", info.Root.Name),
 		State: github.CheckRunQueued,
 		Repo:  info.Repo,
 		ID:    info.CheckRunID,
@@ -65,7 +65,7 @@ func TestLockStateUpdater_unlocked_new_version(t *testing.T) {
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title: terraform.BuildCheckRunTitle(info.Root.Name),
+			Title: notifier.BuildCheckRunTitle("deploy", info.Root.Name),
 			State: github.CheckRunQueued,
 			Repo:  info.Repo,
 			Sha:   info.Commit.Revision,
@@ -103,7 +103,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 	}
 
 	updateCheckRunRequest := activities.UpdateCheckRunRequest{
-		Title:   terraform.BuildCheckRunTitle(info.Root.Name),
+		Title:   notifier.BuildCheckRunTitle("deploy", info.Root.Name),
 		State:   github.CheckRunActionRequired,
 		Repo:    info.Repo,
 		ID:      info.CheckRunID,
@@ -122,7 +122,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 			Revision: "1234",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
-			Title:   terraform.BuildCheckRunTitle(info.Root.Name),
+			Title:   notifier.BuildCheckRunTitle("deploy", info.Root.Name),
 			State:   github.CheckRunActionRequired,
 			Repo:    info.Repo,
 			Summary: "This deploy is locked from a manual deployment for revision [1234](https://github.com/some-org/some-repo/commit/1234).  Unlock to proceed.",

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -91,7 +91,7 @@ func NewWorker(
 	notifiers := []terraform.WorkflowNotifier{
 		&notifier.CheckRunNotifier{
 			CheckRunSessionCache: githubCheckRunCache,
-			Mode:                 notifier.Deploy,
+			Mode:                 tfModel.Deploy,
 		},
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 
@@ -11,7 +12,6 @@ import (
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
@@ -91,6 +91,7 @@ func NewWorker(
 	notifiers := []terraform.WorkflowNotifier{
 		&notifier.CheckRunNotifier{
 			CheckRunSessionCache: githubCheckRunCache,
+			Mode:                 "deploy",
 		},
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -91,7 +91,7 @@ func NewWorker(
 	notifiers := []terraform.WorkflowNotifier{
 		&notifier.CheckRunNotifier{
 			CheckRunSessionCache: githubCheckRunCache,
-			Mode:                 "deploy",
+			Mode:                 notifier.Deploy,
 		},
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -146,7 +146,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	}
 
 	cid, err := n.checkRunClient.CreateOrUpdate(ctx, id, notifier.GithubCheckRunRequest{
-		Title:   notifier.BuildCheckRunTitle("deploy", root.Name),
+		Title:   notifier.BuildDeployCheckRunTitle(root.Name),
 		Sha:     revision,
 		Repo:    repo,
 		Summary: summary,

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -3,6 +3,7 @@ package revision
 import (
 	"context"
 	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/runatlantis/atlantis/server/events/metrics"
 	key "github.com/runatlantis/atlantis/server/neptune/context"
@@ -11,7 +12,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request/converter"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
@@ -146,7 +146,7 @@ func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, roo
 	}
 
 	cid, err := n.checkRunClient.CreateOrUpdate(ctx, id, notifier.GithubCheckRunRequest{
-		Title:   terraform.BuildCheckRunTitle(root.Name),
+		Title:   notifier.BuildCheckRunTitle("deploy", root.Name),
 		Sha:     revision,
 		Repo:    repo,
 		Summary: summary,

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -1,13 +1,13 @@
 package revision_test
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"

--- a/server/neptune/workflows/internal/deploy/terraform/deployment.go
+++ b/server/neptune/workflows/internal/deploy/terraform/deployment.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
@@ -49,6 +49,11 @@ func (i DeploymentInfo) BuildPersistableInfo() *deployment.Info {
 	}
 }
 
-func BuildCheckRunTitle(rootName string) string {
-	return fmt.Sprintf("atlantis/deploy: %s", rootName)
+func (i DeploymentInfo) ToInternalInfo() notifier.Info {
+	return notifier.Info{
+		ID:       i.ID,
+		Commit:   i.Commit,
+		RootName: i.Root.Name,
+		Repo:     i.Repo,
+	}
 }

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
@@ -10,7 +11,7 @@ import (
 )
 
 type WorkflowNotifier interface {
-	Notify(workflow.Context, DeploymentInfo, *state.Workflow) error
+	Notify(workflow.Context, notifier.Info, *state.Workflow) error
 }
 
 type StateReceiver struct {
@@ -39,7 +40,7 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 	}
 
 	for _, notifier := range n.InternalNotifiers {
-		if err := notifier.Notify(ctx, deploymentInfo, workflowState); err != nil {
+		if err := notifier.Notify(ctx, deploymentInfo.ToInternalInfo(), workflowState); err != nil {
 			workflow.GetMetricsHandler(ctx).Counter("notifier_failure").Inc(1)
 			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
 		}

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"net/url"
 	"testing"
 	"time"
@@ -17,13 +18,13 @@ import (
 )
 
 type testNotifier struct {
-	expectedInfo  internalTerraform.DeploymentInfo
+	expectedInfo  notifier.Info
 	expectedState *state.Workflow
 	expectedT     *testing.T
 	called        bool
 }
 
-func (n *testNotifier) Notify(ctx workflow.Context, info internalTerraform.DeploymentInfo, s *state.Workflow) error {
+func (n *testNotifier) Notify(ctx workflow.Context, info notifier.Info, s *state.Workflow) error {
 	assert.Equal(n.expectedT, n.expectedInfo, info)
 	assert.Equal(n.expectedT, n.expectedState, s)
 
@@ -66,7 +67,7 @@ func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stat
 	ch := workflow.NewChannel(ctx)
 
 	notifier := &testNotifier{
-		expectedInfo:  r.DeploymentInfo,
+		expectedInfo:  r.DeploymentInfo.ToInternalInfo(),
 		expectedState: r.State,
 		expectedT:     r.T,
 	}

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -1,11 +1,11 @@
 package deploy
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"

--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -126,16 +127,9 @@ type checkRunClient interface {
 	CreateOrUpdate(ctx workflow.Context, deploymentID string, request GithubCheckRunRequest) (int64, error)
 }
 
-type Mode int
-
-const (
-	Deploy Mode = iota
-	PR
-)
-
 type CheckRunNotifier struct {
 	CheckRunSessionCache checkRunClient
-	Mode                 Mode
+	Mode                 terraform.WorkflowMode
 }
 
 type Info struct {
@@ -154,7 +148,7 @@ func (n *CheckRunNotifier) updateCheckRun(ctx workflow.Context, workflowState *s
 	checkRunState := determineCheckRunState(workflowState)
 
 	var title string
-	if n.Mode == Deploy {
+	if n.Mode == terraform.Deploy {
 		title = BuildDeployCheckRunTitle(info.RootName)
 	} else {
 		title = BuildPlanCheckRunTitle(info.RootName)

--- a/server/neptune/workflows/internal/notifier/github_cache_test.go
+++ b/server/neptune/workflows/internal/notifier/github_cache_test.go
@@ -2,12 +2,12 @@ package notifier_test
 
 import (
 	"context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"

--- a/server/neptune/workflows/internal/notifier/github_test.go
+++ b/server/neptune/workflows/internal/notifier/github_test.go
@@ -1,6 +1,7 @@
 package notifier_test
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"net/url"
 	"testing"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/notifier"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"

--- a/server/neptune/workflows/internal/notifier/github_test.go
+++ b/server/neptune/workflows/internal/notifier/github_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/markdown"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
@@ -32,7 +31,7 @@ func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID s
 
 type checkrunNotifierRequest struct {
 	StatesToSend    []*state.Workflow
-	DeploymentInfo  internalTerraform.DeploymentInfo
+	NotifierInfo    notifier.Info
 	ExpectedRequest notifier.GithubCheckRunRequest
 	T               *testing.T
 }
@@ -50,7 +49,7 @@ func testCheckRunNotifier(ctx workflow.Context, r checkrunNotifierRequest) error
 	}
 
 	for _, s := range r.StatesToSend {
-		if err := notifier.Notify(ctx, r.DeploymentInfo, s); err != nil {
+		if err := notifier.Notify(ctx, r.NotifierInfo, s); err != nil {
 			return err
 		}
 	}
@@ -71,14 +70,13 @@ func TestCheckRunNotifier(t *testing.T) {
 
 	stTime := time.Now()
 	endTime := stTime.Add(time.Second * 5)
-	internalDeploymentInfo := internalTerraform.DeploymentInfo{
-		CheckRunID: 1,
-		ID:         uuid.New(),
-		Root:       terraform.Root{Name: "root"},
-		Repo:       github.Repo{Name: "hello"},
+	notifierInfo := notifier.Info{
+		ID:   uuid.New(),
+		Repo: github.Repo{Name: "hello"},
 		Commit: github.Commit{
 			Revision: "12345",
 		},
+		RootName: "root",
 	}
 
 	cases := []struct {
@@ -375,11 +373,11 @@ func TestCheckRunNotifier(t *testing.T) {
 			env.RegisterActivity(a)
 
 			env.ExecuteWorkflow(testCheckRunNotifier, checkrunNotifierRequest{
-				StatesToSend:   []*state.Workflow{c.State},
-				DeploymentInfo: internalDeploymentInfo,
+				StatesToSend: []*state.Workflow{c.State},
+				NotifierInfo: notifierInfo,
 				ExpectedRequest: notifier.GithubCheckRunRequest{
 					Title: "atlantis/deploy: root",
-					Sha:   internalDeploymentInfo.Commit.Revision,
+					Sha:   notifierInfo.Commit.Revision,
 					State: c.ExpectedCheckRunState,
 					Repo: github.Repo{
 						Name: "hello",


### PR DESCRIPTION
PR here is to begin extracting out some of the logic that should be shared by both the PR and Deploy workflows. This does the following:

- Moves notifier pkg out of deploy pkg
- Creates an Info struct in the Notifier pkg to replace using the deploy-based concept (i.e. `DeploymentInfo`) for the Notify interface (this is only a change for the Github CheckRun notifier)
- Turn `BuildCheckRunTitle` to a fxn that supports  passing in both the workflow mode and root name

Combined, these changes allow us to create a new state receiver that can process pr mode generated state events from the TF workflow. These events can be defined as the now generic `notifier.Info` objects used by the Github CheckRun notifier to update the commit's atlantis/pr check run. Can't think of a better way to approach this, so feel free to offer suggestions if you have any.