### PR TITLE
Add TriggerInfo to gateway request population.

### DIFF
--- a/server/neptune/gateway/api/deploy.go
+++ b/server/neptune/gateway/api/deploy.go
@@ -51,7 +51,9 @@ func (c *DeployHandler) Handle(ctx context.Context, r request.Deploy) error {
 					CloneDepth: 1,
 				},
 
-				Trigger: workflows.ManualTrigger,
+				TriggerInfo: workflows.DeployTriggerInfo{
+					Type: workflows.ManualTrigger,
+				},
 			})
 		},
 	)

--- a/server/neptune/gateway/deploy/deployer.go
+++ b/server/neptune/gateway/deploy/deployer.go
@@ -33,6 +33,9 @@ type RootDeployer struct {
 type RootDeployOptions struct {
 	Repo models.Repo
 
+	// Safe deployments
+	Safe bool
+
 	// RootNames specify an optional list of roots to deploy for, if this is not provided, the roots are computed
 	// via the configured fallback strategy.
 	RootNames []string
@@ -50,8 +53,7 @@ type RootDeployOptions struct {
 	// TODO: Remove this from this struct, consumers shouldn't need to know about this
 	// instead we should just inject implementations of RepoFetcher to handle different scenarios
 	RepoFetcherOptions *github.RepoFetcherOptions
-	Trigger            workflows.Trigger
-	Rerun              bool
+	TriggerInfo        workflows.DeployTriggerInfo
 }
 
 func (d *RootDeployer) Deploy(ctx context.Context, deployOptions RootDeployOptions) error {

--- a/server/neptune/gateway/deploy/signaler.go
+++ b/server/neptune/gateway/deploy/signaler.go
@@ -61,8 +61,11 @@ func (d *WorkflowSignaler) SignalWithStartWorkflow(ctx context.Context, rootCfg 
 				TrackedFiles: rootCfg.WhenModified,
 				TfVersion:    tfVersion,
 				PlanMode:     d.generatePlanMode(rootCfg),
-				Trigger:      rootDeployOptions.Trigger,
-				Rerun:        rootDeployOptions.Rerun,
+				TriggerInfo:  rootDeployOptions.TriggerInfo,
+
+				// todo: remove once we stop using this in our workflows.
+				Trigger: rootDeployOptions.TriggerInfo.Type,
+				Rerun:   rootDeployOptions.TriggerInfo.Rerun,
 			},
 			Repo: workflows.Repo{
 				URL:      repo.CloneURL,

--- a/server/neptune/gateway/deploy/signaler_test.go
+++ b/server/neptune/gateway/deploy/signaler_test.go
@@ -123,6 +123,9 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					TfVersion: version.String(),
 					PlanMode:  workflows.NormalPlanMode,
 					Trigger:   workflows.MergeTrigger,
+					TriggerInfo: workflows.DeployTriggerInfo{
+						Type: workflows.MergeTrigger,
+					},
 				},
 				InitiatingUser: workflows.User{
 					Name: user.Username,
@@ -160,7 +163,9 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 			Revision: sha,
 			Branch:   branch,
 			Sender:   user,
-			Trigger:  workflows.MergeTrigger,
+			TriggerInfo: workflows.DeployTriggerInfo{
+				Type: workflows.MergeTrigger,
+			},
 		}
 		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, rootDeployOptions)
 		assert.NoError(t, err)
@@ -198,6 +203,9 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 					TfVersion: version.String(),
 					PlanMode:  workflows.DestroyPlanMode,
 					Trigger:   workflows.MergeTrigger,
+					TriggerInfo: workflows.DeployTriggerInfo{
+						Type: workflows.MergeTrigger,
+					},
 				},
 				InitiatingUser: workflows.User{
 					Name: user.Username,
@@ -238,7 +246,9 @@ func TestSignalWithStartWorkflow_Success(t *testing.T) {
 			Revision: sha,
 			Branch:   branch,
 			Sender:   user,
-			Trigger:  workflows.MergeTrigger,
+			TriggerInfo: workflows.DeployTriggerInfo{
+				Type: workflows.MergeTrigger,
+			},
 		}
 		run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, rootDeployOptions)
 		assert.NoError(t, err)
@@ -294,6 +304,9 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 				TfVersion: version.String(),
 				PlanMode:  workflows.NormalPlanMode,
 				Trigger:   workflows.MergeTrigger,
+				TriggerInfo: workflows.DeployTriggerInfo{
+					Type: workflows.MergeTrigger,
+				},
 			},
 			InitiatingUser: workflows.User{
 				Name: user.Username,
@@ -332,7 +345,9 @@ func TestSignalWithStartWorkflow_Failure(t *testing.T) {
 		Revision: sha,
 		Branch:   branch,
 		Sender:   user,
-		Trigger:  workflows.MergeTrigger,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type: workflows.MergeTrigger,
+		},
 	}
 	run, err := deploySignaler.SignalWithStartWorkflow(context.Background(), &rootCfg, rootDeployOptions)
 	assert.Error(t, err)

--- a/server/neptune/gateway/event/check_run_handler.go
+++ b/server/neptune/gateway/event/check_run_handler.go
@@ -167,8 +167,10 @@ func (h *CheckRunHandler) buildRoot(ctx context.Context, event CheckRun, rootNam
 		Revision:          event.HeadSha,
 		Sender:            event.User,
 		InstallationToken: event.InstallationToken,
-		Trigger:           workflows.ManualTrigger,
-		Rerun:             true,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type:  workflows.ManualTrigger,
+			Rerun: true,
+		},
 	}
 	return errors.Wrap(h.RootDeployer.Deploy(ctx, deployOptions), "deploying workflow")
 }

--- a/server/neptune/gateway/event/check_suite_handler.go
+++ b/server/neptune/gateway/event/check_suite_handler.go
@@ -45,8 +45,10 @@ func (h *CheckSuiteHandler) handle(ctx context.Context, event CheckSuite) error 
 		Revision:          event.HeadSha,
 		Sender:            event.Sender,
 		InstallationToken: event.InstallationToken,
-		Trigger:           workflows.ManualTrigger,
-		Rerun:             true,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type:  workflows.ManualTrigger,
+			Rerun: true,
+		},
 	}
 	return h.RootDeployer.Deploy(ctx, rootDeployOptions)
 }

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -276,7 +276,11 @@ func (p *CommentEventWorkerProxy) forceApplyPlatformMode(ctx context.Context, ev
 		OptionalPullNum:   event.Pull.Num,
 		Sender:            event.User,
 		InstallationToken: event.InstallationToken,
-		Trigger:           workflows.ManualTrigger,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type:  workflows.ManualTrigger,
+			Force: true,
+		},
 	}
+
 	return p.rootDeployer.Deploy(ctx, rootDeployOptions)
 }

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -169,7 +169,10 @@ func TestCommentEventWorkerProxy_HandleForceApply_BothModes(t *testing.T) {
 			OptionalPullNum:   testPull.Num,
 			Sender:            commentEvent.User,
 			InstallationToken: commentEvent.InstallationToken,
-			Trigger:           workflows.ManualTrigger,
+			TriggerInfo: workflows.DeployTriggerInfo{
+				Type:  workflows.ManualTrigger,
+				Force: true,
+			},
 		},
 	}
 	commentCreator := &mockCommentCreator{}
@@ -243,7 +246,10 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 			OptionalPullNum:   testPull.Num,
 			Sender:            commentEvent.User,
 			InstallationToken: commentEvent.InstallationToken,
-			Trigger:           workflows.ManualTrigger,
+			TriggerInfo: workflows.DeployTriggerInfo{
+				Type:  workflows.ManualTrigger,
+				Force: true,
+			},
 		},
 	}
 	commentCreator := &mockCommentCreator{

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -85,7 +85,9 @@ func (p *PushHandler) handle(ctx context.Context, event Push) error {
 		RepoFetcherOptions: &github.RepoFetcherOptions{
 			CloneDepth: 5,
 		},
-		Trigger: workflows.MergeTrigger,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type: workflows.MergeTrigger,
+		},
 	}
 	return p.RootDeployer.Deploy(ctx, rootDeployOptions)
 }

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -22,6 +22,7 @@ type AppCredentials = request.AppCredentials
 type User = request.User
 type PlanMode = request.PlanMode
 type Trigger = request.Trigger
+type DeployTriggerInfo = request.TriggerInfo
 
 const DestroyPlanMode = request.DestroyPlanMode
 const NormalPlanMode = request.NormalPlanMode

--- a/server/neptune/workflows/internal/deploy/request/root.go
+++ b/server/neptune/workflows/internal/deploy/request/root.go
@@ -7,6 +7,12 @@ const (
 	NormalPlanMode  PlanMode = "normal"
 )
 
+type TriggerInfo struct {
+	Type  Trigger
+	Force bool
+	Rerun bool
+}
+
 type Trigger string
 
 const (
@@ -34,8 +40,12 @@ type Root struct {
 	TfVersion    string
 	PlanMode     PlanMode
 	PlanApproval PlanApproval
-	Trigger      Trigger
-	Rerun        bool
+	TriggerInfo  TriggerInfo
+
+	// todo: keeping for backwards compatibility with existing workflows
+	// remove once we cutover to using TriggerInfo
+	Trigger Trigger
+	Rerun   bool
 }
 
 type Job struct {


### PR DESCRIPTION
This is necessary as our workflows need to differentiate between force applies and normal applies (for auditing).  Also this data model makes a bit more sense than scattering rerun and force in the request itself.