### PR TITLE
Terraform workflow runner for PR Mode

### DIFF
--- a/server/neptune/workflows/internal/pr/terraform/root.go
+++ b/server/neptune/workflows/internal/pr/terraform/root.go
@@ -1,0 +1,26 @@
+package terraform
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+)
+
+type PRRootInfo struct {
+	ID     uuid.UUID
+	Commit github.Commit
+	Root   terraform.Root
+	Repo   github.Repo
+	Tags   map[string]string
+}
+
+func (i PRRootInfo) ToInternalInfo() notifier.Info {
+	return notifier.Info{
+		ID:       i.ID,
+		Commit:   i.Commit,
+		RootName: i.Root.Name,
+		Repo:     i.Repo,
+	}
+}

--- a/server/neptune/workflows/internal/pr/terraform/runner.go
+++ b/server/neptune/workflows/internal/pr/terraform/runner.go
@@ -1,0 +1,89 @@
+package terraform
+
+import (
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+type Workflow func(ctx workflow.Context, request terraform.Request) (terraform.Response, error)
+
+type stateReceiver interface {
+	Receive(ctx workflow.Context, c workflow.ReceiveChannel, prInfo PRRootInfo)
+}
+
+func NewWorkflowRunner(w Workflow, internalNotifiers []WorkflowNotifier) *WorkflowRunner {
+	return &WorkflowRunner{
+		Workflow: w,
+		StateReceiver: &StateReceiver{
+			InternalNotifiers: internalNotifiers,
+		},
+	}
+}
+
+type WorkflowRunner struct {
+	StateReceiver stateReceiver
+	Workflow      Workflow
+}
+
+func (r *WorkflowRunner) Run(ctx workflow.Context, prRootInfo PRRootInfo) (map[string]activities.PolicySet, error) {
+	id := prRootInfo.ID
+	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID: id.String(),
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+
+		// allows all signals to be received even in a cancellation state
+		WaitForCancellation: true,
+		SearchAttributes: map[string]interface{}{
+			"atlantis_repository": prRootInfo.Repo.GetFullName(),
+			"atlantis_root":       prRootInfo.Root.Name,
+			"atlantis_trigger":    prRootInfo.Root.Trigger,
+			"atlantis_revision":   prRootInfo.Commit.Revision,
+		},
+	})
+
+	request := terraform.Request{
+		Repo:         prRootInfo.Repo,
+		Root:         prRootInfo.Root,
+		DeploymentID: id.String(),
+		Revision:     prRootInfo.Commit.Revision,
+		WorkflowMode: terraformActivities.PR,
+	}
+
+	future := workflow.ExecuteChildWorkflow(ctx, r.Workflow, request)
+	return r.awaitWorkflow(ctx, future, prRootInfo)
+}
+
+func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.ChildWorkflowFuture, prInfo PRRootInfo) (map[string]activities.PolicySet, error) {
+	selector := workflow.NewNamedSelector(ctx, "TerraformChildWorkflow")
+	ch := workflow.GetSignalChannel(ctx, state.WorkflowStateChangeSignal)
+	selector.AddReceive(ch, func(c workflow.ReceiveChannel, _ bool) {
+		r.StateReceiver.Receive(ctx, c, prInfo)
+	})
+	var workflowComplete bool
+	var err error
+	failedPolicies := make(map[string]activities.PolicySet)
+	selector.AddFuture(future, func(f workflow.Future) {
+		workflowComplete = true
+		var resp terraform.Response
+		err = f.Get(ctx, &resp)
+		for _, result := range resp.ValidationResults {
+			if result.Status == activities.Fail {
+				failedPolicies[result.PolicySet.Name] = result.PolicySet
+			}
+		}
+	})
+	for {
+		selector.Select(ctx)
+		if workflowComplete {
+			break
+		}
+	}
+	return failedPolicies, errors.Wrap(err, "executing terraform workflow")
+}

--- a/server/neptune/workflows/internal/pr/terraform/runner_test.go
+++ b/server/neptune/workflows/internal/pr/terraform/runner_test.go
@@ -1,0 +1,115 @@
+package terraform_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/terraform"
+	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type testStateReceiver struct {
+	payloads []testSignalPayload
+}
+
+func (r *testStateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel, info internalTerraform.PRRootInfo) {
+	var payload testSignalPayload
+	c.Receive(ctx, &payload)
+
+	r.payloads = append(r.payloads, payload)
+}
+
+type testSignalPayload struct {
+	S string
+}
+
+// signals parent twice with a sleep in between to mimic what our real terraform workflow would be like
+func testTerraformWorkflow(ctx workflow.Context, request terraformWorkflow.Request) (terraformWorkflow.Response, error) {
+	info := workflow.GetInfo(ctx)
+	parentExecution := info.ParentWorkflowExecution
+
+	payload := testSignalPayload{
+		S: "hello",
+	}
+
+	if err := workflow.SignalExternalWorkflow(ctx, parentExecution.ID, parentExecution.RunID, state.WorkflowStateChangeSignal, payload).Get(ctx, nil); err != nil {
+		return terraformWorkflow.Response{}, err
+	}
+
+	if err := workflow.Sleep(ctx, 5*time.Second); err != nil {
+		return terraformWorkflow.Response{}, err
+	}
+
+	return terraformWorkflow.Response{}, workflow.SignalExternalWorkflow(ctx, parentExecution.ID, parentExecution.RunID, state.WorkflowStateChangeSignal, payload).Get(ctx, nil)
+}
+
+type request struct {
+	Info internalTerraform.PRRootInfo
+}
+
+type response struct {
+	Payloads []testSignalPayload
+}
+
+func parentWorkflow(ctx workflow.Context, r request) (response, error) {
+	receiver := &testStateReceiver{}
+	runner := &internalTerraform.WorkflowRunner{
+		StateReceiver: receiver,
+		Workflow:      testTerraformWorkflow,
+	}
+
+	_, err := runner.Run(ctx, r.Info)
+	if err != nil {
+		return response{}, err
+	}
+
+	return response{
+		Payloads: receiver.payloads,
+	}, nil
+}
+
+func buildPRRootInfo() internalTerraform.PRRootInfo {
+	uuid := uuid.New()
+
+	return internalTerraform.PRRootInfo{
+		ID: uuid,
+		Commit: github.Commit{
+			Revision: "1234",
+		},
+		Root: terraform.Root{
+			Name: "some-root",
+			Plan: terraform.PlanJob{},
+		},
+		Repo: github.Repo{},
+	}
+}
+
+func TestWorkflowRunner_Run(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	env.RegisterWorkflow(testTerraformWorkflow)
+
+	env.ExecuteWorkflow(parentWorkflow, request{
+		Info: buildPRRootInfo(),
+	})
+
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+
+	assert.Len(t, resp.Payloads, 2)
+
+	for _, p := range resp.Payloads {
+		assert.Equal(t, testSignalPayload{
+			S: "hello",
+		}, p)
+	}
+}

--- a/server/neptune/workflows/internal/pr/terraform/state.go
+++ b/server/neptune/workflows/internal/pr/terraform/state.go
@@ -1,0 +1,35 @@
+package terraform
+
+import (
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"go.temporal.io/sdk/workflow"
+)
+
+type WorkflowNotifier interface {
+	Notify(workflow.Context, notifier.Info, *state.Workflow) error
+}
+
+type StateReceiver struct {
+	InternalNotifiers []WorkflowNotifier
+	//TODO: support additional notifiers?
+}
+
+func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel, prRootInfo PRRootInfo) {
+	var workflowState *state.Workflow
+	c.Receive(ctx, &workflowState)
+
+	workflow.GetMetricsHandler(ctx).WithTags(map[string]string{
+		metrics.SignalNameTag: state.WorkflowStateChangeSignal,
+	}).Counter(metrics.SignalReceive).Inc(1)
+
+	for _, notifier := range n.InternalNotifiers {
+		if err := notifier.Notify(ctx, prRootInfo.ToInternalInfo(), workflowState); err != nil {
+			workflow.GetMetricsHandler(ctx).Counter("notifier_failure").Inc(1)
+			workflow.GetLogger(ctx).Error(errors.Wrap(err, "notifying workflow state change").Error())
+		}
+	}
+}

--- a/server/neptune/workflows/internal/pr/terraform/state.go
+++ b/server/neptune/workflows/internal/pr/terraform/state.go
@@ -15,7 +15,6 @@ type WorkflowNotifier interface {
 
 type StateReceiver struct {
 	InternalNotifiers []WorkflowNotifier
-	//TODO: support additional notifiers?
 }
 
 func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel, prRootInfo PRRootInfo) {

--- a/server/neptune/workflows/internal/pr/terraform/state_test.go
+++ b/server/neptune/workflows/internal/pr/terraform/state_test.go
@@ -1,0 +1,113 @@
+package terraform_test
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
+	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/terraform"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type testNotifier struct {
+	expectedInfo  notifier.Info
+	expectedState *state.Workflow
+	expectedT     *testing.T
+	called        bool
+}
+
+func (n *testNotifier) Notify(ctx workflow.Context, info notifier.Info, s *state.Workflow) error {
+	assert.Equal(n.expectedT, n.expectedInfo, info)
+	assert.Equal(n.expectedT, n.expectedState, s)
+
+	n.called = true
+
+	return nil
+}
+
+type stateReceiveRequest struct {
+	State      *state.Workflow
+	PRRootInfo internalTerraform.PRRootInfo
+	T          *testing.T
+}
+
+type stateReceiveResponse struct {
+	NotifierCalled bool
+}
+
+func testStateReceiveWorkflow(ctx workflow.Context, r stateReceiveRequest) (stateReceiveResponse, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
+	ch := workflow.NewChannel(ctx)
+
+	notifier := &testNotifier{
+		expectedInfo:  r.PRRootInfo.ToInternalInfo(),
+		expectedState: r.State,
+		expectedT:     r.T,
+	}
+
+	receiver := &internalTerraform.StateReceiver{
+		InternalNotifiers: []internalTerraform.WorkflowNotifier{
+			notifier,
+		},
+	}
+
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		ch.Send(ctx, r.State)
+	})
+
+	receiver.Receive(ctx, ch, r.PRRootInfo)
+
+	return stateReceiveResponse{
+		NotifierCalled: notifier.called,
+	}, nil
+}
+
+func TestStateReceive(t *testing.T) {
+	outputURL, err := url.Parse("www.nish.com")
+	assert.NoError(t, err)
+
+	jobOutput := &state.JobOutput{
+		URL: outputURL,
+	}
+
+	internalPRRootInfo := internalTerraform.PRRootInfo{
+		ID:   uuid.New(),
+		Root: terraform.Root{Name: "root"},
+		Repo: github.Repo{Name: "hello"},
+		Commit: github.Commit{
+			Revision: "12345",
+		},
+	}
+
+	t.Run("calls notifiers with state", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+
+		env.ExecuteWorkflow(testStateReceiveWorkflow, stateReceiveRequest{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.WaitingJobStatus,
+				},
+			},
+			PRRootInfo: internalPRRootInfo,
+			T:          t,
+		})
+
+		env.AssertExpectations(t)
+
+		var result stateReceiveResponse
+		err = env.GetWorkflowResult(&result)
+		assert.True(t, result.NotifierCalled)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Establishes the Terraform workflow runner that the parent PR workflow will use to spin up terraform workflows for each modified root given a revision.