### PR TITLE
Split out sns/temporal usecases within comment handler.

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -196,7 +196,6 @@ func (p *SNSWorkerProxy) shouldMarkEventQueued(event Comment, cmd *command.Comme
 
 type CommentEventWorkerProxy struct {
 	logger             logging.Logger
-	scope              tally.Scope
 	allocator          feature.Allocator
 	scheduler          scheduler
 	vcsStatusUpdater   statusUpdater


### PR DESCRIPTION
IMO this split makes it a lot less confusing to see when certain things are invoked. Now we can clearly see for platform mode, we don't do anything on comments except for force applies. 

Going forward now I can add the apply logic there.