### PR TITLE
Create initial PR worker in temporalworker server

### DIFF
--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -229,7 +229,9 @@ func (s Server) Start() error {
 			},
 		})
 		prWorker.RegisterActivity(s.GithubActivities)
+		prWorker.RegisterActivity(s.TerraformActivities)
 		prWorker.RegisterWorkflow(workflows.PR)
+		prWorker.RegisterWorkflow(workflows.Terraform)
 		if err := prWorker.Run(worker.InterruptCh()); err != nil {
 			log.Fatalln("unable to start pr worker", err)
 		}

--- a/server/neptune/workflows/internal/pr/workflow.go
+++ b/server/neptune/workflows/internal/pr/workflow.go
@@ -2,6 +2,8 @@ package pr
 
 import "go.temporal.io/sdk/workflow"
 
+const TaskQueue = "pr"
+
 func Workflow(ctx workflow.Context, request Request) error {
 	// TODO: implement workflow
 	return nil

--- a/server/neptune/workflows/pr.go
+++ b/server/neptune/workflows/pr.go
@@ -5,6 +5,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+var PRTaskQueue = pr.TaskQueue
+
 type PRRequest = pr.Request
 
 func PR(ctx workflow.Context, request PRRequest) error {


### PR DESCRIPTION
Sets up the PR worker + TQ for the new workflows. Similar to the deploy worker, we register TF activities to the parent PR worker because we wait until the initial TF activity (i.e. `activities.GetWorkerInfo`) runs to determine which TQ to use for the remaining TF activities.