### PR TITLE
Support atlantis apply on neptune for teams.

### DIFF
--- a/server/lyft/command/feature_runner.go
+++ b/server/lyft/command/feature_runner.go
@@ -59,30 +59,9 @@ func (a *PlatformModeRunner) Run(ctx *command.Context, cmd *command.Comment) {
 		return
 	}
 
-	if shouldAllocate && allProjectInPlatformMode(projectCmds) {
-		// return error if loading template fails since we should have default templates configured
-		comment, err := a.TemplateLoader.Load(template.LegacyApplyComment, ctx.Pull.BaseRepo, LegacyApplyCommentInput{})
-		if err != nil {
-			a.Logger.ErrorContext(ctx.RequestCtx, fmt.Sprintf("loading template: %s", template.LegacyApplyComment))
-		}
-
-		if err := a.VCSClient.CreateComment(ctx.Pull.BaseRepo, ctx.Pull.Num, comment, ""); err != nil {
-			a.Logger.ErrorContext(ctx.RequestCtx, err.Error())
-		}
-	}
-
 	// at this point we've either commented about this being a legacy apply or not, so let's just proceed with
 	// the run now.
 	a.Runner.Run(ctx, cmd)
-}
-
-func allProjectInPlatformMode(cmds []command.ProjectContext) bool {
-	for _, cmd := range cmds {
-		if cmd.WorkflowModeType != valid.PlatformWorkflowMode {
-			return false
-		}
-	}
-	return true
 }
 
 // DefaultProjectCommandRunner implements ProjectCommandRunner.

--- a/server/lyft/command/feature_runner_test.go
+++ b/server/lyft/command/feature_runner_test.go
@@ -311,12 +311,7 @@ func TestPlatformModeRunner_success(t *testing.T) {
 		expectedCmd: cmd,
 	}
 
-	commenter := &TestCommenter{
-		expectedT:       t,
-		expectedComment: "Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. ",
-		expectedPullNum: 1,
-		expectedRepo:    ctx.Pull.BaseRepo,
-	}
+	commenter := &TestCommenter{}
 
 	subject := &lyftCommand.PlatformModeRunner{
 		Allocator: &testAllocator{
@@ -338,7 +333,7 @@ func TestPlatformModeRunner_success(t *testing.T) {
 
 	assert.True(t, runner.called)
 	assert.True(t, builder.called)
-	assert.True(t, commenter.called)
+	assert.False(t, commenter.called)
 }
 
 func TestPlatformModeProjectRunner_plan(t *testing.T) {

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -79,7 +79,7 @@ func NewVCSEventsController(
 		logger,
 	)
 
-	requirementChecker := requirement.NewAggregate(globalCfg, teamMemberFetcher)
+	requirementChecker := requirement.NewAggregate(globalCfg, teamMemberFetcher, logger)
 	commentHandler := handlers.NewCommentEventWithCommandHandler(
 		commentParser,
 		repoAllowlistChecker,

--- a/server/neptune/gateway/deploy/requirement/aggregate.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate.go
@@ -33,7 +33,6 @@ func NewAggregate(cfg valid.GlobalCfg, fetcher *github.TeamMemberFetcher) *Aggre
 }
 
 func (a *Aggregate) Check(ctx context.Context, criteria Criteria) error {
-
 	for _, d := range a.nonOverrideableRequirements {
 		if err := d.Check(ctx, criteria); err != nil {
 			return err

--- a/server/neptune/gateway/deploy/requirement/aggregate.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate.go
@@ -9,17 +9,26 @@ import (
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 )
 
-type requirement interface {
+type Requirement interface {
 	Check(ctx context.Context, criteria Criteria) error
 }
 type Aggregate struct {
-	overrideableRequirements    []requirement
-	nonOverrideableRequirements []requirement
+	overrideableRequirements    []Requirement
+	nonOverrideableRequirements []Requirement
+}
+
+func NewAggregateWithRequirements(overrideableRequirements []Requirement, nonOverrideableRequirements []Requirement) *Aggregate {
+	return &Aggregate{
+		overrideableRequirements:    overrideableRequirements,
+		nonOverrideableRequirements: nonOverrideableRequirements,
+	}
 }
 
 func NewAggregate(cfg valid.GlobalCfg, fetcher *github.TeamMemberFetcher, logger logging.Logger) *Aggregate {
-	return &Aggregate{
-		overrideableRequirements: []requirement{
+	return NewAggregateWithRequirements(
+
+		// overrideable
+		[]Requirement{
 
 			// order matters here since we fail iteratively
 			&branchRestriction{
@@ -38,10 +47,12 @@ func NewAggregate(cfg valid.GlobalCfg, fetcher *github.TeamMemberFetcher, logger
 				},
 			},
 		},
-		nonOverrideableRequirements: []requirement{
+
+		// non-overrideable
+		[]Requirement{
 			pull{},
 		},
-	}
+	)
 }
 
 func (a *Aggregate) Check(ctx context.Context, criteria Criteria) error {

--- a/server/neptune/gateway/deploy/requirement/aggregate.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate.go
@@ -1,0 +1,45 @@
+package requirement
+
+import (
+	"context"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
+)
+
+type requirement interface {
+	Check(ctx context.Context, criteria Criteria) error
+}
+type Aggregate struct {
+	delegates []requirement
+}
+
+func NewAggregate(cfg valid.GlobalCfg, fetcher *github.TeamMemberFetcher) *Aggregate {
+	delegates := []requirement{
+		&team{
+			cfg:     cfg,
+			fetcher: fetcher,
+		},
+		&branchRestriction{
+			cfg: cfg,
+		},
+	}
+
+	return &Aggregate{
+		delegates: delegates,
+	}
+}
+
+func (a *Aggregate) Check(ctx context.Context, criteria Criteria) error {
+	// bypass all requirements if we are forcing the deployment to happen
+	if criteria.TriggerInfo.Force {
+		return nil
+	}
+
+	for _, d := range a.delegates {
+		if err := d.Check(ctx, criteria); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/server/neptune/gateway/deploy/requirement/aggregate_test.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate_test.go
@@ -1,0 +1,125 @@
+package requirement_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/requirement"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/stretchr/testify/assert"
+)
+
+type noopRequirement struct {
+	expectedT         *testing.T
+	expectedCriterita requirement.Criteria
+	expectedErr       error
+
+	called bool
+}
+
+func (r *noopRequirement) Check(ctx context.Context, criteria requirement.Criteria) error {
+	assert.Equal(r.expectedT, r.expectedCriterita, criteria)
+
+	r.called = true
+	return r.expectedErr
+}
+
+func TestAggregate_Success(t *testing.T) {
+	expectedCriteria := requirement.Criteria{
+		Repo: models.Repo{Name: "hi"},
+	}
+	overrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	nonOverrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	subject := requirement.NewAggregateWithRequirements([]requirement.Requirement{overrideable}, []requirement.Requirement{nonOverrideable})
+
+	err := subject.Check(context.Background(), expectedCriteria)
+	assert.NoError(t, err)
+	assert.True(t, overrideable.called)
+	assert.True(t, nonOverrideable.called)
+}
+
+func TestAggregate_ForceTrigger(t *testing.T) {
+	expectedCriteria := requirement.Criteria{
+		Repo: models.Repo{Name: "hi"},
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Force: true,
+		},
+	}
+	overrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	nonOverrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	subject := requirement.NewAggregateWithRequirements([]requirement.Requirement{overrideable}, []requirement.Requirement{nonOverrideable})
+
+	err := subject.Check(context.Background(), expectedCriteria)
+	assert.NoError(t, err)
+	assert.False(t, overrideable.called)
+	assert.True(t, nonOverrideable.called)
+}
+
+func TestAggregate_OverrideableError(t *testing.T) {
+	expectedCriteria := requirement.Criteria{
+		Repo: models.Repo{Name: "hi"},
+	}
+	overrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       assert.AnError,
+	}
+
+	nonOverrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	subject := requirement.NewAggregateWithRequirements([]requirement.Requirement{overrideable}, []requirement.Requirement{nonOverrideable})
+
+	err := subject.Check(context.Background(), expectedCriteria)
+	assert.Error(t, err)
+	assert.True(t, overrideable.called)
+	assert.True(t, nonOverrideable.called)
+}
+
+func TestAggregate_NonOverrideableError(t *testing.T) {
+	expectedCriteria := requirement.Criteria{
+		Repo: models.Repo{Name: "hi"},
+	}
+	overrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       nil,
+	}
+
+	nonOverrideable := &noopRequirement{
+		expectedT:         t,
+		expectedCriterita: expectedCriteria,
+		expectedErr:       assert.AnError,
+	}
+
+	subject := requirement.NewAggregateWithRequirements([]requirement.Requirement{overrideable}, []requirement.Requirement{nonOverrideable})
+
+	err := subject.Check(context.Background(), expectedCriteria)
+	assert.Error(t, err)
+	assert.False(t, overrideable.called)
+	assert.True(t, nonOverrideable.called)
+}

--- a/server/neptune/gateway/deploy/requirement/branch.go
+++ b/server/neptune/gateway/deploy/requirement/branch.go
@@ -1,0 +1,30 @@
+package requirement
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+)
+
+type BranchRestrictedError struct {
+	Branch string
+}
+
+func (e BranchRestrictedError) Error() string {
+	return fmt.Sprintf("deploys are forbidden on %s branch", e.Branch)
+}
+
+type branchRestriction struct {
+	cfg valid.GlobalCfg
+}
+
+func (r *branchRestriction) Check(ctx context.Context, criteria Criteria) error {
+	match := r.cfg.MatchingRepo(criteria.Repo.ID())
+
+	if match.ApplySettings.BranchRestriction == valid.DefaultBranchRestriction && criteria.Repo.DefaultBranch != criteria.Branch {
+		return BranchRestrictedError{Branch: criteria.Branch}
+	}
+
+	return nil
+}

--- a/server/neptune/gateway/deploy/requirement/branch.go
+++ b/server/neptune/gateway/deploy/requirement/branch.go
@@ -5,29 +5,69 @@ import (
 	"fmt"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+)
+
+const (
+	DefaultTemplate = "See error details below:"
 )
 
 type ForbiddenError struct {
-	message string
+	details  string
+	template string
 }
 
-func NewForbiddenError(msg string, format ...string) ForbiddenError {
-	return ForbiddenError{message: fmt.Sprintf(msg, format)}
+func NewForbiddenError(msg string, format ...any) ForbiddenError {
+	return ForbiddenError{template: DefaultTemplate, details: fmt.Sprintf(msg, format...)}
+}
+
+type errorGenerator[T any] struct {
+	loader template.Loader[T]
+	logger logging.Logger
+}
+
+func (g errorGenerator[T]) GenerateForbiddenError(ctx context.Context, key template.Key, repo models.Repo, data T, msg string, format ...any) ForbiddenError {
+	content, err := g.loader.Load(key, repo, data)
+	if err != nil {
+		g.logger.WarnContext(ctx, fmt.Sprintf("unable to load template %s", key))
+		content = DefaultTemplate
+	}
+
+	return ForbiddenError{
+		template: content,
+		details:  fmt.Sprintf(msg, format...),
+	}
+}
+
+// ErrorTemplate returns a human readable formatted error which
+// is appropriate to surface to the client
+func (e ForbiddenError) ErrorTemplate() string {
+	return e.template
 }
 
 func (e ForbiddenError) Error() string {
-	return e.message
+	return e.details
 }
 
 type branchRestriction struct {
-	cfg valid.GlobalCfg
+	cfg            valid.GlobalCfg
+	errorGenerator errorGenerator[template.BranchForbiddenData]
 }
 
 func (r *branchRestriction) Check(ctx context.Context, criteria Criteria) error {
 	match := r.cfg.MatchingRepo(criteria.Repo.ID())
 
 	if match.ApplySettings.BranchRestriction == valid.DefaultBranchRestriction && criteria.Repo.DefaultBranch != criteria.Branch {
-		return NewForbiddenError("deploys are forbidden on %s branch", criteria.Branch)
+		return r.errorGenerator.GenerateForbiddenError(
+			ctx,
+			template.BranchForbidden, criteria.Repo,
+			template.BranchForbiddenData{
+				DefaultBranch: criteria.Repo.DefaultBranch,
+			},
+			"deploys are forbidden on %s branch", criteria.Branch,
+		)
 	}
 
 	return nil

--- a/server/neptune/gateway/deploy/requirement/branch.go
+++ b/server/neptune/gateway/deploy/requirement/branch.go
@@ -7,12 +7,16 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 )
 
-type BranchRestrictedError struct {
-	Branch string
+type ForbiddenError struct {
+	message string
 }
 
-func (e BranchRestrictedError) Error() string {
-	return fmt.Sprintf("deploys are forbidden on %s branch", e.Branch)
+func NewForbiddenError(msg string, format ...string) ForbiddenError {
+	return ForbiddenError{message: fmt.Sprintf(msg, format)}
+}
+
+func (e ForbiddenError) Error() string {
+	return e.message
 }
 
 type branchRestriction struct {
@@ -23,7 +27,7 @@ func (r *branchRestriction) Check(ctx context.Context, criteria Criteria) error 
 	match := r.cfg.MatchingRepo(criteria.Repo.ID())
 
 	if match.ApplySettings.BranchRestriction == valid.DefaultBranchRestriction && criteria.Repo.DefaultBranch != criteria.Branch {
-		return BranchRestrictedError{Branch: criteria.Branch}
+		return NewForbiddenError("deploys are forbidden on %s branch", criteria.Branch)
 	}
 
 	return nil

--- a/server/neptune/gateway/deploy/requirement/branch_internal_test.go
+++ b/server/neptune/gateway/deploy/requirement/branch_internal_test.go
@@ -1,0 +1,74 @@
+package requirement
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+	"github.com/stretchr/testify/assert"
+)
+
+type testErrGenerator[T any] struct {
+	err ForbiddenError
+}
+
+func (g testErrGenerator[T]) GenerateForbiddenError(ctx context.Context, key template.Key, repo models.Repo, data T, msg string, format ...any) ForbiddenError {
+	return g.err
+}
+
+func TestBranch_OnDefaultBranch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo:   models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch: "main",
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		subject := &branchRestriction{
+			cfg:            globalCfg,
+			errorGenerator: testErrGenerator[template.BranchForbiddenData]{},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+	t.Run("error", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo:   models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch: "notmain",
+		}
+
+		expectedError := ForbiddenError{details: "hi"}
+
+		globalCfg := valid.NewGlobalCfg("")
+		subject := &branchRestriction{
+			cfg: globalCfg,
+			errorGenerator: testErrGenerator[template.BranchForbiddenData]{
+				err: expectedError,
+			},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.EqualError(t, err, expectedError.Error())
+	})
+}
+
+func TestBranch_NoRestriction(t *testing.T) {
+	expectedCriteria := Criteria{
+		Repo:   models.Repo{Name: "hi", DefaultBranch: "main"},
+		Branch: "notmain",
+	}
+
+	globalCfg := valid.NewGlobalCfg("")
+	globalCfg.Repos[0].ApplySettings.BranchRestriction = valid.NoBranchRestriction
+	subject := &branchRestriction{
+		cfg:            globalCfg,
+		errorGenerator: testErrGenerator[template.BranchForbiddenData]{},
+	}
+
+	err := subject.Check(context.Background(), expectedCriteria)
+	assert.NoError(t, err)
+
+}

--- a/server/neptune/gateway/deploy/requirement/branch_internal_test.go
+++ b/server/neptune/gateway/deploy/requirement/branch_internal_test.go
@@ -70,5 +70,4 @@ func TestBranch_NoRestriction(t *testing.T) {
 
 	err := subject.Check(context.Background(), expectedCriteria)
 	assert.NoError(t, err)
-
 }

--- a/server/neptune/gateway/deploy/requirement/pull.go
+++ b/server/neptune/gateway/deploy/requirement/pull.go
@@ -1,0 +1,25 @@
+package requirement
+
+import (
+	"context"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type pull struct{}
+
+func (r pull) Check(ctx context.Context, criteria Criteria) error {
+	if criteria.OptionalPull == nil {
+		return nil
+	}
+
+	if criteria.OptionalPull.BaseRepo.Owner != criteria.OptionalPull.HeadRepo.Owner {
+		return NewForbiddenError("pull request cannot be from a fork")
+	}
+
+	if criteria.OptionalPull.State == models.ClosedPullState {
+		return NewForbiddenError("deploy cannot be executed on a closed pull request")
+	}
+
+	return nil
+}

--- a/server/neptune/gateway/deploy/requirement/pull_internal_test.go
+++ b/server/neptune/gateway/deploy/requirement/pull_internal_test.go
@@ -1,0 +1,75 @@
+package requirement
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPull(t *testing.T) {
+	t.Run("no pull specified", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+		}
+
+		subject := pull{}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+
+	t.Run("forked pull", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			OptionalPull: &models.PullRequest{
+				BaseRepo: models.Repo{Owner: "lyft"},
+				HeadRepo: models.Repo{Owner: "notlyft"},
+			},
+		}
+
+		subject := pull{}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		var forbidden ForbiddenError
+		assert.ErrorAs(t, err, &forbidden)
+
+		assert.Equal(t, "pull request cannot be from a fork", forbidden.Error())
+	})
+
+	t.Run("closed pull", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			OptionalPull: &models.PullRequest{
+				BaseRepo: models.Repo{Owner: "lyft"},
+				HeadRepo: models.Repo{Owner: "lyft"},
+				State:    models.ClosedPullState,
+			},
+		}
+
+		subject := pull{}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		var forbidden ForbiddenError
+		assert.ErrorAs(t, err, &forbidden)
+
+		assert.Equal(t, "deploy cannot be executed on a closed pull request", forbidden.Error())
+	})
+
+	t.Run("valid pull", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			OptionalPull: &models.PullRequest{
+				BaseRepo: models.Repo{Owner: "lyft"},
+				HeadRepo: models.Repo{Owner: "lyft"},
+				State:    models.OpenPullState,
+			},
+		}
+
+		subject := pull{}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+}

--- a/server/neptune/gateway/deploy/requirement/team.go
+++ b/server/neptune/gateway/deploy/requirement/team.go
@@ -2,7 +2,6 @@ package requirement
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/core/config/valid"
@@ -15,16 +14,9 @@ type Criteria struct {
 	User              models.User
 	Branch            string
 	Repo              models.Repo
+	OptionalPull      *models.PullRequest
 	InstallationToken int64
 	TriggerInfo       workflows.DeployTriggerInfo
-}
-
-type UserForbiddenError struct {
-	User string
-}
-
-func (e UserForbiddenError) Error() string {
-	return fmt.Sprintf("User: %s is forbidden from executing a deploy", e.User)
 }
 
 type team struct {
@@ -50,5 +42,5 @@ func (r *team) Check(ctx context.Context, criteria Criteria) error {
 		}
 	}
 
-	return UserForbiddenError{User: criteria.User.Username}
+	return NewForbiddenError("User: %s is forbidden from executing a deploy", criteria.User.Username)
 }

--- a/server/neptune/gateway/deploy/requirement/team.go
+++ b/server/neptune/gateway/deploy/requirement/team.go
@@ -1,0 +1,54 @@
+package requirement
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
+)
+
+type Criteria struct {
+	User              models.User
+	Branch            string
+	Repo              models.Repo
+	InstallationToken int64
+	TriggerInfo       workflows.DeployTriggerInfo
+}
+
+type UserForbiddenError struct {
+	User string
+}
+
+func (e UserForbiddenError) Error() string {
+	return fmt.Sprintf("User: %s is forbidden from executing a deploy", e.User)
+}
+
+type team struct {
+	cfg     valid.GlobalCfg
+	fetcher *github.TeamMemberFetcher
+}
+
+func (r *team) Check(ctx context.Context, criteria Criteria) error {
+	match := r.cfg.MatchingRepo(criteria.Repo.ID())
+
+	if len(match.ApplySettings.Team) == 0 {
+		return nil
+	}
+
+	teamMembers, err := r.fetcher.ListTeamMembers(ctx, criteria.InstallationToken, match.ApplySettings.Team)
+	if err != nil {
+		return errors.Wrap(err, "fetching team members")
+	}
+
+	for _, t := range teamMembers {
+		if criteria.User.Username == t {
+			return nil
+		}
+	}
+
+	return UserForbiddenError{User: criteria.User.Username}
+}

--- a/server/neptune/gateway/deploy/requirement/team_internal_test.go
+++ b/server/neptune/gateway/deploy/requirement/team_internal_test.go
@@ -57,7 +57,6 @@ func TestTeam(t *testing.T) {
 
 		err := subject.Check(context.Background(), expectedCriteria)
 		assert.NoError(t, err)
-
 	})
 
 	t.Run("forbidden", func(t *testing.T) {

--- a/server/neptune/gateway/deploy/requirement/team_internal_test.go
+++ b/server/neptune/gateway/deploy/requirement/team_internal_test.go
@@ -1,0 +1,88 @@
+package requirement
+
+import (
+	"context"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+	"github.com/stretchr/testify/assert"
+)
+
+type testFetcher struct {
+	users []string
+	err   error
+}
+
+func (f testFetcher) ListTeamMembers(ctx context.Context, installationToken int64, teamSlug string) ([]string, error) {
+	return f.users, f.err
+}
+
+func TestTeam(t *testing.T) {
+	t.Run("no configuration", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			User: models.User{Username: "nish"},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+
+		subject := team{
+			cfg:     globalCfg,
+			fetcher: testFetcher{},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			User: models.User{Username: "nish"},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		globalCfg.Repos[0].ApplySettings.Team = "some-team"
+
+		subject := team{
+			cfg: globalCfg,
+			fetcher: testFetcher{
+				users: []string{
+					"nish",
+				},
+			},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo: models.Repo{Name: "hi", DefaultBranch: "main"},
+			User: models.User{Username: "nish"},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		globalCfg.Repos[0].ApplySettings.Team = "some-team"
+
+		expectedErr := ForbiddenError{details: "hi"}
+		subject := team{
+			cfg: globalCfg,
+			fetcher: testFetcher{
+				users: []string{
+					"samra",
+				},
+			},
+			errorGenerator: testErrGenerator[template.UserForbiddenData]{
+				err: expectedErr,
+			},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.EqualError(t, err, expectedErr.details)
+	})
+}

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
+	"github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/uber-go/tally/v4"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/runatlantis/atlantis/server/http"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/config"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/requirement"
 )
 
 const warningMessage = "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and confirm the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
@@ -36,6 +38,14 @@ type rootConfigBuilder interface {
 	Build(ctx context.Context, commit *config.RepoCommit, installationToken int64, opts ...config.BuilderOptions) ([]*valid.MergedProjectCfg, error)
 }
 
+type requirementChecker interface {
+	Check(ctx context.Context, criteria requirement.Criteria) error
+}
+
+type errorHandler interface {
+	WrapWithHandling(ctx context.Context, event PREvent, commandName string, executor sync.Executor) sync.Executor
+}
+
 // Comment is our internal representation of a vcs based comment event.
 type Comment struct {
 	Pull              models.PullRequest
@@ -49,6 +59,18 @@ type Comment struct {
 	InstallationToken int64
 }
 
+func (c Comment) GetPullNum() int {
+	return c.PullNum
+}
+
+func (c Comment) GetInstallationToken() int64 {
+	return c.InstallationToken
+}
+
+func (c Comment) GetRepo() models.Repo {
+	return c.BaseRepo
+}
+
 func NewCommentEventWorkerProxy(
 	logger logging.Logger,
 	scope tally.Scope,
@@ -60,6 +82,8 @@ func NewCommentEventWorkerProxy(
 	vcsStatusUpdater statusUpdater,
 	globalCfg valid.GlobalCfg,
 	rootConfigBuilder rootConfigBuilder,
+	errorHandler errorHandler,
+	requirementChecker requirementChecker,
 ) *CommentEventWorkerProxy {
 	return &CommentEventWorkerProxy{
 		logger:    logger,
@@ -72,31 +96,59 @@ func NewCommentEventWorkerProxy(
 			globalCfg:        globalCfg,
 		},
 		neptuneWorkerProxy: &NeptuneWorkerProxy{
-			logger:         logger,
-			signaler:       signaler,
-			commentCreator: commentCreator,
+			logger:             logger,
+			signaler:           signaler,
+			commentCreator:     commentCreator,
+			requirementChecker: requirementChecker,
 		},
 		vcsStatusUpdater:  vcsStatusUpdater,
 		rootConfigBuilder: rootConfigBuilder,
+		errorHandler:      errorHandler,
 	}
 }
 
 type NeptuneWorkerProxy struct {
-	logger         logging.Logger
-	signaler       deploySignaler
-	commentCreator commentCreator
+	logger             logging.Logger
+	signaler           deploySignaler
+	commentCreator     commentCreator
+	requirementChecker requirementChecker
 }
 
 func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg) error {
-	// currently the only comments on platform mode are force applies, we can add to this as necessary.
-	if !cmd.ForceApply {
+	// currently the only comments on platform mode are applies, we can add to this as necessary.
+	if cmd.Name != command.Apply {
 		return nil
+	}
+
+	triggerInfo := workflows.DeployTriggerInfo{
+		Type:  workflows.ManualTrigger,
+		Force: cmd.ForceApply,
 	}
 
 	platformModeRoots := partitionRootsByMode(valid.PlatformWorkflowMode, roots)
 
-	// let's only comment on the PR if we're fully on platform mode, otherwise there will be duplicates from the legacy worker and this.
-	if len(platformModeRoots) == len(roots) {
+	if cmd.IsForSpecificProject() {
+		platformModeRoots = partitionRootsByProject(cmd.ProjectName, platformModeRoots)
+	}
+
+	if len(platformModeRoots) == 0 {
+		p.logger.WarnContext(ctx, "no platform mode roots detected")
+		return nil
+	}
+
+	if err := p.requirementChecker.Check(ctx, requirement.Criteria{
+		Repo:              event.HeadRepo,
+		Branch:            event.Pull.HeadBranch,
+		User:              event.User,
+		InstallationToken: event.InstallationToken,
+		TriggerInfo:       triggerInfo,
+	}); err != nil {
+		return errors.Wrap(err, "checking deploy requirements")
+	}
+
+	// let's only post a force apply comment on the PR, if we are only operating on project OR if we are operating on all projects and
+	// if we're fully on platform mode, otherwise there will be duplicates from the legacy worker and this.
+	if cmd.ForceApply && (cmd.IsForSpecificProject() || len(platformModeRoots) == len(roots)) {
 		if err := p.commentCreator.CreateComment(event.BaseRepo, event.PullNum, warningMessage, ""); err != nil {
 			p.logger.ErrorContext(ctx, err.Error())
 		}
@@ -109,10 +161,7 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 		OptionalPullNum:   event.Pull.Num,
 		Sender:            event.User,
 		InstallationToken: event.InstallationToken,
-		TriggerInfo: workflows.DeployTriggerInfo{
-			Type:  workflows.ManualTrigger,
-			Force: cmd.ForceApply,
-		},
+		TriggerInfo:       triggerInfo,
 	}
 
 	for _, r := range platformModeRoots {
@@ -202,6 +251,7 @@ type CommentEventWorkerProxy struct {
 	rootConfigBuilder  rootConfigBuilder
 	snsWorkerProxy     *SNSWorkerProxy
 	neptuneWorkerProxy *NeptuneWorkerProxy
+	errorHandler       errorHandler
 }
 
 func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
@@ -221,11 +271,11 @@ func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.Buff
 		return p.handleLegacyComment(ctx, request, event, cmd)
 	}
 
-	err = p.scheduler.Schedule(ctx, func(ctx context.Context) error {
+	executor := p.errorHandler.WrapWithHandling(ctx, event, cmd.CommandName().String(), func(ctx context.Context) error {
 		return p.handle(ctx, request, event, cmd)
 	})
 
-	return errors.Wrap(err, "scheduling handle")
+	return errors.Wrap(p.scheduler.Schedule(ctx, executor), "scheduling handle")
 }
 
 func (p *CommentEventWorkerProxy) handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
@@ -279,6 +329,17 @@ func partitionRootsByMode(mode valid.WorkflowModeType, cmds []*valid.MergedProje
 	var cfgs []*valid.MergedProjectCfg
 	for _, cmd := range cmds {
 		if cmd.WorkflowMode == mode {
+			cfgs = append(cfgs, cmd)
+		}
+	}
+
+	return cfgs
+}
+
+func partitionRootsByProject(name string, cmds []*valid.MergedProjectCfg) []*valid.MergedProjectCfg {
+	var cfgs []*valid.MergedProjectCfg
+	for _, cmd := range cmds {
+		if cmd.Name == name {
 			cfgs = append(cfgs, cmd)
 		}
 	}

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -137,11 +137,12 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 	}
 
 	if err := p.requirementChecker.Check(ctx, requirement.Criteria{
-		Repo:              event.HeadRepo,
+		Repo:              event.BaseRepo,
 		Branch:            event.Pull.HeadBranch,
 		User:              event.User,
 		InstallationToken: event.InstallationToken,
 		TriggerInfo:       triggerInfo,
+		OptionalPull:      &event.Pull,
 	}); err != nil {
 		return errors.Wrap(err, "checking deploy requirements")
 	}
@@ -155,7 +156,7 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 	}
 
 	opts := deploy.RootDeployOptions{
-		Repo:              event.HeadRepo,
+		Repo:              event.BaseRepo,
 		Branch:            event.Pull.HeadBranch,
 		Revision:          event.Pull.HeadCommit,
 		OptionalPullNum:   event.Pull.Num,

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -567,8 +567,6 @@ func TestCommentEventWorkerProxy_HandleApplyComment_PartialMode(t *testing.T) {
 			},
 		},
 	}
-	testSignaler := &testDeploySignaler{}
-
 	commentEvent := event.Comment{
 		Pull:     testPull,
 		PullNum:  testPull.Num,
@@ -579,6 +577,23 @@ func TestCommentEventWorkerProxy_HandleApplyComment_PartialMode(t *testing.T) {
 		},
 		InstallationToken: 123,
 	}
+	expectedOpts := deploy.RootDeployOptions{
+		Repo:              testRepo,
+		Branch:            testPull.HeadBranch,
+		Revision:          testPull.HeadCommit,
+		OptionalPullNum:   testPull.Num,
+		Sender:            commentEvent.User,
+		InstallationToken: commentEvent.InstallationToken,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type: workflows.ManualTrigger,
+		},
+	}
+	testSignaler := &testDeploySignaler{
+		expectedT:   t,
+		expectedCfg: rootConfigBuilder.rootConfigs[0],
+		expOpts:     expectedOpts,
+	}
+
 	writer := &mockSnsWriter{}
 	allocator := &testAllocator{
 		t:                 t,
@@ -608,7 +623,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_PartialMode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
-	assert.False(t, testSignaler.called)
+	assert.True(t, testSignaler.called)
 	assert.True(t, writer.isCalled)
 }
 

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/config"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/requirement"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
 	"github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
@@ -29,6 +30,20 @@ var testPull = models.PullRequest{
 	HeadBranch: "somebranch",
 	HeadCommit: "1234",
 	Num:        1,
+}
+
+type noopErrorHandler struct{}
+
+func (h noopErrorHandler) WrapWithHandling(ctx context.Context, event event.PREvent, commandName string, executor sync.Executor) sync.Executor {
+	return executor
+}
+
+type requirementsChecker struct {
+	err error
+}
+
+func (a *requirementsChecker) Check(ctx context.Context, criteria requirement.Criteria) error {
+	return a.err
 }
 
 type mockRootConfigBuilder struct {
@@ -119,7 +134,7 @@ func TestCommentEventWorkerProxy_HandleAllocationError(t *testing.T) {
 		expectedToken: 123,
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	commentEvent := event.Comment{
 		Pull:     testPull,
@@ -177,7 +192,7 @@ func TestCommentEventWorkerProxy_HandleForceApply_default(t *testing.T) {
 	}
 
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	commentEvent := event.Comment{
 		Pull:     testPull,
@@ -270,7 +285,7 @@ func TestCommentEventWorkerProxy_HandleForceApply_BothModes(t *testing.T) {
 		expectedT:         t,
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 
 	cmd := &command.Comment{
@@ -363,7 +378,7 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 	}
 	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name:       command.Apply,
@@ -375,6 +390,70 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 	assert.True(t, testSignaler.called())
 	assert.False(t, writer.isCalled)
 	assert.False(t, statusUpdater.isCalled)
+}
+
+func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode_RequirementsFailed(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	scope, _, err := metrics.NewLoggingScope(logger, "")
+	assert.NoError(t, err)
+	rootConfigBuilder := &mockRootConfigBuilder{
+		expectedT: t,
+		expectedCommit: &config.RepoCommit{
+			Repo:          testRepo,
+			Branch:        testPull.HeadBranch,
+			Sha:           testPull.HeadCommit,
+			OptionalPRNum: testPull.Num,
+		},
+		expectedToken: 123,
+		rootConfigs: []*valid.MergedProjectCfg{
+			{
+				Name:         "root1",
+				WorkflowMode: valid.PlatformWorkflowMode,
+			},
+			{
+				Name:         "root2",
+				WorkflowMode: valid.PlatformWorkflowMode,
+			},
+		},
+	}
+	commentEvent := event.Comment{
+		Pull:     testPull,
+		PullNum:  testPull.Num,
+		BaseRepo: testRepo,
+		HeadRepo: testRepo,
+		User: models.User{
+			Username: "someuser",
+		},
+		InstallationToken: 123,
+	}
+	testSignaler := &testDeploySignaler{}
+
+	writer := &mockSnsWriter{}
+	allocator := &testAllocator{
+		t:                 t,
+		expectedFeatureID: feature.PlatformMode,
+		expectedFeatureCtx: feature.FeatureContext{
+			RepoName: repoFullName,
+		},
+		expectedAllocation: true,
+	}
+	scheduler := &sync.SynchronousScheduler{Logger: logger}
+	commentCreator := &mockCommentCreator{}
+	statusUpdater := &mockStatusUpdater{}
+	cfg := valid.NewGlobalCfg("somedir")
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{
+		err: assert.AnError,
+	})
+	bufReq := buildRequest(t)
+	cmd := &command.Comment{
+		Name: command.Apply,
+	}
+	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	assert.Error(t, err)
+	assert.False(t, statusUpdater.isCalled)
+	assert.False(t, commentCreator.isCalled)
+	assert.False(t, testSignaler.called)
+	assert.True(t, writer.isCalled)
 }
 
 func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T) {
@@ -401,7 +480,6 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T
 			},
 		},
 	}
-	testSignaler := &testDeploySignaler{}
 	commentEvent := event.Comment{
 		Pull:     testPull,
 		PullNum:  testPull.Num,
@@ -412,6 +490,32 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T
 		},
 		InstallationToken: 123,
 	}
+	expectedOpts := deploy.RootDeployOptions{
+		Repo:              testRepo,
+		Branch:            testPull.HeadBranch,
+		Revision:          testPull.HeadCommit,
+		OptionalPullNum:   testPull.Num,
+		Sender:            commentEvent.User,
+		InstallationToken: commentEvent.InstallationToken,
+		TriggerInfo: workflows.DeployTriggerInfo{
+			Type: workflows.ManualTrigger,
+		},
+	}
+	testSignaler := &testMultiDeploySignaler{
+		signalers: []*testDeploySignaler{
+			{
+				expectedT:   t,
+				expectedCfg: rootConfigBuilder.rootConfigs[0],
+				expOpts:     expectedOpts,
+			},
+			{
+				expectedT:   t,
+				expectedCfg: rootConfigBuilder.rootConfigs[1],
+				expOpts:     expectedOpts,
+			},
+		},
+	}
+
 	writer := &mockSnsWriter{}
 	allocator := &testAllocator{
 		t:                 t,
@@ -425,7 +529,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
@@ -434,7 +538,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T
 	assert.NoError(t, err)
 	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
-	assert.False(t, testSignaler.called)
+	assert.True(t, testSignaler.called())
 	assert.True(t, writer.isCalled)
 }
 
@@ -495,7 +599,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_PartialMode(t *testing.T) {
 		expectedT:         t,
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
@@ -573,7 +677,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 		},
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
@@ -635,7 +739,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 		},
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
@@ -703,7 +807,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment_BothModes(t *testing.T) {
 		expectedT:         t,
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
@@ -753,7 +857,7 @@ func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 		expectedT:         t,
 	}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	commentEvent := event.Comment{
 		Pull:     testPull,
@@ -899,7 +1003,7 @@ func TestCommentEventWorkerProxy_HandleNoQueuedStatus(t *testing.T) {
 				expectedBody:      "Request received. Adding to the queue...",
 				expectedT:         t,
 			}
-			commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, c.allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder)
+			commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, c.allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 			err := commentEventWorkerProxy.Handle(context.Background(), bufReq, c.event, c.command)
 			assert.NoError(t, err)
 			assert.False(t, statusUpdater.isCalled)

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -51,7 +51,7 @@ func (p *PREventErrorHandler) WrapWithHandling(ctx context.Context, event PREven
 }
 
 func (p *PREventErrorHandler) handleErr(ctx context.Context, event PREvent, commandName string, err error) error {
-	body, e := p.loadTemplate(ctx, event, commandName, err)
+	body, e := p.loadTemplate(event, commandName, err)
 	if e != nil {
 		return errors.Wrap(e, "loading template")
 	}
@@ -62,7 +62,7 @@ func (p *PREventErrorHandler) handleErr(ctx context.Context, event PREvent, comm
 	return nil
 }
 
-func (p *PREventErrorHandler) loadTemplate(ctx context.Context, event PREvent, commandName string, err error) (string, error) {
+func (p *PREventErrorHandler) loadTemplate(event PREvent, commandName string, err error) (string, error) {
 	data := template.PRCommentData{
 		Command:      commandName,
 		ErrorDetails: err.Error(),

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -69,9 +69,10 @@ func (p *PREventErrorHandler) loadTemplate(event PREvent, commandName string, er
 	}
 
 	var forbiddenError requirement.ForbiddenError
-	
+
 	if errors.As(err, &forbiddenError) {
 		data.ForbiddenError = true
+		data.ForbiddenErrorTemplate = forbiddenError.ErrorTemplate()
 	} else {
 		data.InternalError = true
 	}

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -42,7 +42,7 @@ func (p *PREventErrorHandler) WrapWithHandling(ctx context.Context, event PREven
 	return func(ctx context.Context) error {
 		if err := executor(ctx); err != nil {
 			if e := p.handleErr(ctx, event, commandName, err); e != nil {
-				p.logger.ErrorContext(context.WithValue(ctx, contextUtils.ErrKey, err), "handling error")
+				p.logger.ErrorContext(context.WithValue(ctx, contextUtils.ErrKey, e), "handling error")
 			}
 			return err
 		}

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -67,10 +67,12 @@ func (p *PREventErrorHandler) loadTemplate(event PREvent, commandName string, er
 		Command:      commandName,
 		ErrorDetails: err.Error(),
 	}
-	switch err.(type) {
-	case requirement.ForbiddenError:
+
+	var forbiddenError requirement.ForbiddenError
+	
+	if errors.As(err, &forbiddenError) {
 		data.ForbiddenError = true
-	default:
+	} else {
 		data.InternalError = true
 	}
 

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -1,0 +1,78 @@
+package event
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
+	contextUtils "github.com/runatlantis/atlantis/server/neptune/context"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/requirement"
+	"github.com/runatlantis/atlantis/server/neptune/sync"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
+)
+
+type PREvent interface {
+	GetPullNum() int
+	GetInstallationToken() int64
+	GetRepo() models.Repo
+}
+
+func NewPREventErrorHandler(commentCreator *github.CommentCreator, cfg valid.GlobalCfg, logger logging.Logger) *PREventErrorHandler {
+	return &PREventErrorHandler{
+		commentCreator: commentCreator,
+		templateLoader: &template.Loader[template.PRCommentData]{
+			GlobalCfg: cfg,
+		},
+		logger: logger,
+	}
+}
+
+// PREventErrorHandler is used provide additional functionality for handlers that want to provide feedback to the user
+// Currently this feedback is provided through a PR comment.
+type PREventErrorHandler struct {
+	commentCreator *github.CommentCreator
+	templateLoader *template.Loader[template.PRCommentData]
+	logger         logging.Logger
+}
+
+func (p *PREventErrorHandler) WrapWithHandling(ctx context.Context, event PREvent, commandName string, executor sync.Executor) sync.Executor {
+	return func(ctx context.Context) error {
+		if err := executor(ctx); err != nil {
+			if e := p.handleErr(ctx, event, commandName, err); e != nil {
+				p.logger.ErrorContext(context.WithValue(ctx, contextUtils.ErrKey, err), "handling error")
+			}
+			return err
+		}
+		return nil
+	}
+}
+
+func (p *PREventErrorHandler) handleErr(ctx context.Context, event PREvent, commandName string, err error) error {
+	body, e := p.loadTemplate(ctx, event, commandName, err)
+	if e != nil {
+		return errors.Wrap(e, "loading template")
+	}
+	e = p.commentCreator.CreateComment(ctx, event.GetInstallationToken(), event.GetRepo(), event.GetPullNum(), body)
+	if e != nil {
+		return errors.Wrap(e, "commenting on PR")
+	}
+	return nil
+}
+
+func (p *PREventErrorHandler) loadTemplate(ctx context.Context, event PREvent, commandName string, err error) (string, error) {
+	data := template.PRCommentData{
+		Command:      commandName,
+		ErrorDetails: err.Error(),
+	}
+	switch err.(type) {
+	case requirement.BranchRestrictedError, requirement.UserForbiddenError:
+		data.ForbiddenError = true
+	default:
+		data.InternalError = true
+	}
+
+	return p.templateLoader.Load(template.PRComment, event.GetRepo(), data)
+}

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -68,7 +68,7 @@ func (p *PREventErrorHandler) loadTemplate(event PREvent, commandName string, er
 		ErrorDetails: err.Error(),
 	}
 	switch err.(type) {
-	case requirement.BranchRestrictedError, requirement.UserForbiddenError:
+	case requirement.ForbiddenError:
 		data.ForbiddenError = true
 	default:
 		data.InternalError = true

--- a/server/neptune/sync/scheduler.go
+++ b/server/neptune/sync/scheduler.go
@@ -69,8 +69,7 @@ type SynchronousScheduler struct {
 }
 
 func (s *SynchronousScheduler) Schedule(ctx context.Context, f Executor) error {
-
-	if s.PanicRecoveryEnabled == true {
+	if s.PanicRecoveryEnabled {
 		defer func() {
 			if r := recover(); r != nil {
 				stack := recovery.Stack(3)
@@ -78,7 +77,6 @@ func (s *SynchronousScheduler) Schedule(ctx context.Context, f Executor) error {
 			}
 		}()
 	}
-
 	err := f(ctx)
 	if err != nil {
 		s.Logger.ErrorContext(context.WithValue(ctx, contextUtils.ErrKey, err), "error running handle")

--- a/server/neptune/template/loader.go
+++ b/server/neptune/template/loader.go
@@ -48,6 +48,7 @@ type BranchForbiddenData struct {
 type UserForbiddenData struct {
 	User string
 	Team string
+	Org  string
 }
 
 //go:embed templates/pr_comment.tmpl

--- a/server/neptune/template/loader.go
+++ b/server/neptune/template/loader.go
@@ -22,22 +22,42 @@ type Input struct {
 
 // list of all valid template ids
 const (
-	PRComment = Key("pr_comment")
+	PRComment       = Key("pr_comment")
+	BranchForbidden = Key("branch_forbidden")
+	UserForbidden   = Key("user_forbidden")
 )
 
 var defaultTemplates = map[Key]string{
-	PRComment: prCommentTemplate,
+	PRComment:       prCommentTemplate,
+	BranchForbidden: branchForbiddenTemplate,
+	UserForbidden:   userForbiddenTemplate,
 }
 
 type PRCommentData struct {
-	ForbiddenError bool
-	InternalError  bool
-	Command        string
-	ErrorDetails   string
+	ForbiddenError         bool
+	ForbiddenErrorTemplate string
+	InternalError          bool
+	Command                string
+	ErrorDetails           string
+}
+
+type BranchForbiddenData struct {
+	DefaultBranch string
+}
+
+type UserForbiddenData struct {
+	User string
+	Team string
 }
 
 //go:embed templates/pr_comment.tmpl
 var prCommentTemplate string
+
+//go:embed templates/branch_forbidden.tmpl
+var branchForbiddenTemplate string
+
+//go:embed templates/user_forbidden.tmpl
+var userForbiddenTemplate string
 
 type Loader[T any] struct {
 	GlobalCfg valid.GlobalCfg

--- a/server/neptune/template/loader.go
+++ b/server/neptune/template/loader.go
@@ -22,15 +22,22 @@ type Input struct {
 
 // list of all valid template ids
 const (
-	LegacyApplyComment = Key("legacyApply")
+	PRComment = Key("pr_comment")
 )
 
 var defaultTemplates = map[Key]string{
-	LegacyApplyComment: legacyApplyTemplate,
+	PRComment: prCommentTemplate,
 }
 
-//go:embed templates/legacyApply.tmpl
-var legacyApplyTemplate string
+type PRCommentData struct {
+	ForbiddenError bool
+	InternalError  bool
+	Command        string
+	ErrorDetails   string
+}
+
+//go:embed templates/pr_comment.tmpl
+var prCommentTemplate string
 
 type Loader[T any] struct {
 	GlobalCfg valid.GlobalCfg
@@ -41,8 +48,6 @@ func NewLoader[T any](globalCfg valid.GlobalCfg) Loader[T] {
 		GlobalCfg: globalCfg,
 	}
 }
-
-type Template struct{}
 
 func (l Loader[T]) Load(id Key, repo models.Repo, data T) (string, error) {
 	tmpl := template.Must(l.getTemplate(id, repo))

--- a/server/neptune/template/loader_test.go
+++ b/server/neptune/template/loader_test.go
@@ -23,7 +23,7 @@ func TestLoader_TemplateOverride(t *testing.T) {
 			{
 				ID: testRepo.ID(),
 				TemplateOverrides: map[string]string{
-					string(LegacyApplyComment): "testdata/custom.tmpl",
+					string(PRComment): "testdata/custom.tmpl",
 				},
 			},
 		},
@@ -31,10 +31,10 @@ func TestLoader_TemplateOverride(t *testing.T) {
 
 	loader := NewLoader[any](globalCfg)
 
-	output, err := loader.Load(LegacyApplyComment, testRepo, nil)
+	output, err := loader.Load(PRComment, testRepo, nil)
 	assert.NoError(t, err)
 
-	templateContent, err := os.ReadFile(globalCfg.MatchingRepo(testRepo.ID()).TemplateOverrides[string(LegacyApplyComment)])
+	templateContent, err := os.ReadFile(globalCfg.MatchingRepo(testRepo.ID()).TemplateOverrides[string(PRComment)])
 	assert.NoError(t, err)
 
 	assert.Equal(t, output, string(templateContent))
@@ -51,10 +51,10 @@ func TestLoader_NoTemplateOverride(t *testing.T) {
 
 	loader := NewLoader[any](globalCfg)
 
-	output, err := loader.Load(LegacyApplyComment, testRepo, nil)
+	output, err := loader.Load(PRComment, testRepo, nil)
 	assert.NoError(t, err)
 
-	templateContent, err := os.ReadFile(fmt.Sprintf("templates/%s.tmpl", LegacyApplyComment))
+	templateContent, err := os.ReadFile(fmt.Sprintf("templates/%s.tmpl", PRComment))
 	assert.NoError(t, err)
 
 	assert.Equal(t, output, string(templateContent))

--- a/server/neptune/template/loader_test.go
+++ b/server/neptune/template/loader_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -35,26 +34,6 @@ func TestLoader_TemplateOverride(t *testing.T) {
 	assert.NoError(t, err)
 
 	templateContent, err := os.ReadFile(globalCfg.MatchingRepo(testRepo.ID()).TemplateOverrides[string(PRComment)])
-	assert.NoError(t, err)
-
-	assert.Equal(t, output, string(templateContent))
-}
-
-func TestLoader_NoTemplateOverride(t *testing.T) {
-	globalCfg := valid.GlobalCfg{
-		Repos: []valid.Repo{
-			{
-				ID: testRepo.ID(),
-			},
-		},
-	}
-
-	loader := NewLoader[any](globalCfg)
-
-	output, err := loader.Load(PRComment, testRepo, nil)
-	assert.NoError(t, err)
-
-	templateContent, err := os.ReadFile(fmt.Sprintf("templates/%s.tmpl", PRComment))
 	assert.NoError(t, err)
 
 	assert.Equal(t, output, string(templateContent))

--- a/server/neptune/template/templates/branch_forbidden.tmpl
+++ b/server/neptune/template/templates/branch_forbidden.tmpl
@@ -1,0 +1,3 @@
+:no_entry_sign: :raised_hand: Applies are only allowed from the default branch ({{ .DefaultBranch }})
+
+:point_right: Please merge this PR in order to apply your changes.

--- a/server/neptune/template/templates/legacyApply.tmpl
+++ b/server/neptune/template/templates/legacyApply.tmpl
@@ -1,1 +1,0 @@
-Platform mode does not support legacy apply commands. Please merge your PR to apply the changes. 

--- a/server/neptune/template/templates/pr_comment.tmpl
+++ b/server/neptune/template/templates/pr_comment.tmpl
@@ -1,0 +1,25 @@
+{{ if .InternalError }}
+## Internal Error :boom:
+
+An atlantis {{ .Command }}  has resulted in an error.  This is likely a bug and should be reported.
+{{ end }}
+
+{{ if .ForbiddenError }}
+## Forbidden Error :see_no_evil:
+
+Atlantis {{ .Command }} is forbidden for one (or more) of the following reasons:
+* User is not authorized to perform this operation
+* This repository's configuration only allows this operation from a specific branch
+* PR approval is required for this operation to execute.
+
+{{ if eq .Command "apply" }}
+:warning: Note: `atlantis apply` is no longer necessary. Changes will be applied when the PR is merged.
+{{ end }}
+{{ end }}
+
+<details>
+  <summary> Error Details </summary>
+  ```
+  {{ .ErrorDetails }}
+  ```
+</details>

--- a/server/neptune/template/templates/pr_comment.tmpl
+++ b/server/neptune/template/templates/pr_comment.tmpl
@@ -1,27 +1,22 @@
 {{ if .InternalError }}
 ## Internal Error :boom:
 
-An atlantis {{ .Command }}  has resulted in an error.  This is likely a bug and should be reported.
+An `atlantis {{ .Command }}`  has resulted in an error.  This is likely a bug and should be reported.
 {{ end }}
 
 {{ if .ForbiddenError }}
 ## Forbidden Error :see_no_evil:
 
-Atlantis {{ .Command }} is forbidden for one (or more) of the following reasons:
-* User is not authorized to perform this operation
-* This repository's configuration only allows this operation from a specific branch
-* PR approval is required for this operation to execute.
+{{ ErrorTemplate }}
 
-{{ if eq .Command "apply" }}
-:no_entry_sign :raised_hand: Please merge this PR in order to apply your changes.
-{{ end }}
 {{ end }}
 
-<details>
-  <summary> Error Details </summary>
-  ```
+<details><summary> Error Details </summary>
 
-  {{ .ErrorDetails }}
+```
 
-  ```
+{{ .ErrorDetails }}
+
+```
+
 </details>

--- a/server/neptune/template/templates/pr_comment.tmpl
+++ b/server/neptune/template/templates/pr_comment.tmpl
@@ -7,7 +7,7 @@ An `atlantis {{ .Command }}`  has resulted in an error.  This is likely a bug an
 {{ if .ForbiddenError }}
 ## Forbidden Error :see_no_evil:
 
-{{ ErrorTemplate }}
+{{ .ErrorTemplate }}
 
 {{ end }}
 

--- a/server/neptune/template/templates/pr_comment.tmpl
+++ b/server/neptune/template/templates/pr_comment.tmpl
@@ -13,13 +13,15 @@ Atlantis {{ .Command }} is forbidden for one (or more) of the following reasons:
 * PR approval is required for this operation to execute.
 
 {{ if eq .Command "apply" }}
-:warning: Note: `atlantis apply` is no longer necessary. Changes will be applied when the PR is merged.
+:no_entry_sign :raised_hand: Please merge this PR in order to apply your changes.
 {{ end }}
 {{ end }}
 
 <details>
   <summary> Error Details </summary>
   ```
+
   {{ .ErrorDetails }}
+
   ```
 </details>

--- a/server/neptune/template/templates/pr_comment.tmpl
+++ b/server/neptune/template/templates/pr_comment.tmpl
@@ -7,7 +7,7 @@ An `atlantis {{ .Command }}`  has resulted in an error.  This is likely a bug an
 {{ if .ForbiddenError }}
 ## Forbidden Error :see_no_evil:
 
-{{ .ErrorTemplate }}
+{{ .ForbiddenErrorTemplate }}
 
 {{ end }}
 

--- a/server/neptune/template/templates/user_forbidden.tmpl
+++ b/server/neptune/template/templates/user_forbidden.tmpl
@@ -1,3 +1,3 @@
 :no_entry_sign: :raised_hand: @{{ .User }} is forbidden from running `atlantis apply`.  
 
-:point_right: Please contact repository owners to be added to @{{ .Team }}
+:point_right: Please contact repository owners to be added to @{{ .Org }}/{{ .Team }} otherwise merge the PR to automatically apply these changes

--- a/server/neptune/template/templates/user_forbidden.tmpl
+++ b/server/neptune/template/templates/user_forbidden.tmpl
@@ -1,0 +1,3 @@
+:no_entry_sign: :raised_hand: @{{ .User }} is forbidden from running `atlantis apply`.  
+
+:point_right: Please contact repository owners to be added to @{{ .Team }}

--- a/server/vcs/provider/github/comment.go
+++ b/server/vcs/provider/github/comment.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+)
+
+type CommentCreator struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+func (c *CommentCreator) CreateComment(ctx context.Context, installationToken int64, repo models.Repo, pullNum int, body string) error {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return errors.Wrap(err, "creating client")
+	}
+
+	_, _, err = client.Issues.CreateComment(ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{
+		Body: github.String(body),
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "creating comment with body: %s", body)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Introduces the concept of deploy requirements and adds two: 
Team - user must be in the appropriate gh team, we skip if there is no team configured in the apply settings
Branch Restriction - branch restriction setting must be `none` in order to proceed. This ensures that we don't just open up `atlantis apply` to the world 

There's some additional changes here such as a new PR template which will be turned into a comment if there's any error whatsover in the async portion of the gateway request.  I think it's reasonable to have this seeing as the current functionality is to provide no feedback and just drop a log.  This makes our system seem unreliable as the customer thinks atlantis isn't doing anything. 

We can evaluate how this works and if we need to add a status to block the PR for certain cases we can. Right now, since `atlantis apply` comments are necessary anymore anyways, a comment should suffice.


**Note docker desktop is now blocked on my computer it seems so I can't test this locally, we'll need to figure out a new way to test things locally.**

## TODO 

- [x] Requirement unit testing
- [x] Staging Testing