### PR TITLE
Modify where project workflow mode type is overriden.

### DIFF
--- a/server/core/config/raw/project.go
+++ b/server/core/config/raw/project.go
@@ -73,7 +73,7 @@ func (p Project) Validate() error {
 	)
 }
 
-func (p Project) ToValid() valid.Project {
+func (p Project) ToValid(defaultWorkflowModeType valid.WorkflowModeType) valid.Project {
 	var v valid.Project
 	// Prepend ./ and then run .Clean() so we're guaranteed to have a relative
 	// directory. This is necessary because we use this dir without sanitation
@@ -90,8 +90,9 @@ func (p Project) ToValid() valid.Project {
 	v.WorkflowName = p.Workflow
 	v.PullRequestWorkflowName = p.PullRequestWorkflowName
 	v.DeploymentWorkflowName = p.DeploymentWorkflowName
+	v.WorkflowModeType = defaultWorkflowModeType
 	if p.WorkflowModeType != nil {
-		v.WorkflowModeType = p.WorkflowModeType
+		v.WorkflowModeType = toWorkflowModeType(*p.WorkflowModeType)
 	}
 	if p.TerraformVersion != nil {
 		v.TerraformVersion, _ = version.NewVersion(*p.TerraformVersion)

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -314,7 +314,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		// Directories.
@@ -330,7 +330,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -360,7 +360,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -376,7 +376,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -391,7 +391,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -406,7 +406,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -421,7 +421,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 
@@ -438,7 +438,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.DefaultWorkflowMode,
 			},
 		},
 	}

--- a/server/core/config/raw/project_test.go
+++ b/server/core/config/raw/project_test.go
@@ -268,6 +268,7 @@ func TestProject_ToValid(t *testing.T) {
 				},
 				ApplyRequirements: nil,
 				Name:              nil,
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -296,7 +297,7 @@ func TestProject_ToValid(t *testing.T) {
 				},
 				ApplyRequirements: []string{"approved"},
 				Name:              String("myname"),
-				WorkflowModeType:  String("platform"),
+				WorkflowModeType:  valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -313,6 +314,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		// Directories.
@@ -328,6 +330,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -342,6 +345,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -356,6 +360,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -371,6 +376,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -385,6 +391,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -399,6 +406,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 		{
@@ -413,6 +421,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 
@@ -429,12 +438,13 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
+				WorkflowModeType:  valid.DefaultWorkflowMode,
 			},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			Equals(t, c.exp, c.input.ToValid())
+			Equals(t, c.exp, c.input.ToValid(valid.DefaultWorkflowMode))
 		})
 	}
 }

--- a/server/core/config/raw/repo_cfg.go
+++ b/server/core/config/raw/repo_cfg.go
@@ -52,9 +52,11 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		validWorkflows[k] = v.ToValid(k)
 	}
 
+	workflowModeType := toWorkflowModeType(r.WorkflowModeType)
+
 	var validProjects []valid.Project
 	for _, p := range r.Projects {
-		validProjects = append(validProjects, p.ToValid())
+		validProjects = append(validProjects, p.ToValid(workflowModeType))
 	}
 
 	parallelApply := DefaultParallelApply
@@ -67,12 +69,6 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		parallelPlan = *r.ParallelPlan
 	}
 
-	workflowModeType := valid.DefaultWorkflowMode
-	switch r.WorkflowModeType {
-	case "platform":
-		workflowModeType = valid.PlatformWorkflowMode
-	}
-
 	return valid.RepoCfg{
 		Version:             *r.Version,
 		Projects:            validProjects,
@@ -82,4 +78,13 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		ParallelPolicyCheck: parallelPlan,
 		WorkflowModeType:    workflowModeType,
 	}
+}
+
+func toWorkflowModeType(workflowModeType string) valid.WorkflowModeType {
+	result := valid.DefaultWorkflowMode
+	switch workflowModeType {
+	case "platform":
+		result = valid.PlatformWorkflowMode
+	}
+	return result
 }

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -372,18 +372,6 @@ func (g GlobalCfg) MergeProjectCfg(repoID string, proj Project, rCfg RepoCfg) Me
 		}
 	}
 
-	// TODO: remove when platform mode rollout is complete
-	// if project has a specific workflow mode setting configured, override the repo level setting
-	workflowModeType := rCfg.WorkflowModeType
-	if proj.WorkflowModeType != nil {
-		switch *proj.WorkflowModeType {
-		case "platform":
-			workflowModeType = PlatformWorkflowMode
-		case "default":
-			workflowModeType = DefaultWorkflowMode
-		}
-	}
-
 	return MergedProjectCfg{
 		ApplyRequirements:   applyReqs,
 		Workflow:            workflow,
@@ -398,7 +386,7 @@ func (g GlobalCfg) MergeProjectCfg(repoID string, proj Project, rCfg RepoCfg) Me
 		RepoCfgVersion:      rCfg.Version,
 		PolicySets:          g.PolicySets,
 		Tags:                proj.Tags,
-		WorkflowMode:        workflowModeType,
+		WorkflowMode:        proj.WorkflowModeType,
 	}
 }
 

--- a/server/core/config/valid/global_cfg_test.go
+++ b/server/core/config/valid/global_cfg_test.go
@@ -950,7 +950,7 @@ repos:
 					WhenModified: []string{".tf"},
 					Enabled:      true,
 				},
-				WorkflowModeType: String("platform"),
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 			exp: valid.MergedProjectCfg{
 				ApplyRequirements: []string{},

--- a/server/core/config/valid/project.go
+++ b/server/core/config/valid/project.go
@@ -26,7 +26,7 @@ type Project struct {
 	Autoplan                Autoplan
 	ApplyRequirements       []string
 	Tags                    map[string]string
-	WorkflowModeType        *string
+	WorkflowModeType        WorkflowModeType
 }
 
 // GetName returns the name of the project or an empty string if there is no


### PR DESCRIPTION
This was initially to ensure that passing "pr" wouldn't fail since that's what we expect for the global key.

But i don't think we should be overriding project config when we are merging the repo config with the global config.  Repo config should be created with the defaults/values at that point already.