### PR TITLE
Make platform mode the new default

### DIFF
--- a/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-apply-reqs/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
+workflow_mode_type: pr
 projects:
 - dir: .
   workspace: default

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-diff-owner/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
+workflow_mode_type: pr
 projects:
 - dir: .
   workspace: default

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-extra-args/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
+workflow_mode_type: pr
 projects:
 - dir: .
   workspace: default

--- a/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks-multi-projects/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
+workflow_mode_type: pr
 projects:
 - dir: dir1
   name: dir1

--- a/server/controllers/events/testfixtures/test-repos/policy-checks/atlantis.yaml
+++ b/server/controllers/events/testfixtures/test-repos/policy-checks/atlantis.yaml
@@ -1,4 +1,5 @@
 version: 3
+workflow_mode_type: pr
 projects:
 - dir: .
   workspace: default

--- a/server/core/config/raw/repo_cfg.go
+++ b/server/core/config/raw/repo_cfg.go
@@ -81,10 +81,10 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 }
 
 func toWorkflowModeType(workflowModeType string) valid.WorkflowModeType {
-	result := valid.DefaultWorkflowMode
+	result := valid.PlatformWorkflowMode
 	switch workflowModeType {
-	case "platform":
-		result = valid.PlatformWorkflowMode
+	case "pr":
+		result = valid.DefaultWorkflowMode
 	}
 	return result
 }

--- a/server/core/config/valid/global_cfg.go
+++ b/server/core/config/valid/global_cfg.go
@@ -41,8 +41,8 @@ var NonOverrideableApplyReqs = []string{PoliciesPassedApplyReq}
 type WorkflowModeType int
 
 const (
-	DefaultWorkflowMode WorkflowModeType = iota
-	PlatformWorkflowMode
+	PlatformWorkflowMode WorkflowModeType = iota
+	DefaultWorkflowMode
 )
 
 type BackendType string

--- a/server/events/project_command_runner_test.go
+++ b/server/events/project_command_runner_test.go
@@ -447,6 +447,7 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 				IsApproved: false,
 			},
 		},
+		WorkflowModeType: valid.DefaultWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
@@ -533,6 +534,7 @@ func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
 			Mergeable: false,
 		},
 		ApplyRequirements: []string{"mergeable"},
+		WorkflowModeType:  valid.DefaultWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
@@ -556,6 +558,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	}
 	prjCtx := command.ProjectContext{
 		ApplyRequirements: []string{"undiverged"},
+		WorkflowModeType:  valid.DefaultWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()


### PR DESCRIPTION
I decided to keep the name "DefaultWorkflowMode" now for PR since we are going to get rid of all of this soon too.