### PR TITLE
Remove deploy dependencies from pr workflow

### DIFF
--- a/server/neptune/workflows/internal/pr/request/converter/repo.go
+++ b/server/neptune/workflows/internal/pr/request/converter/repo.go
@@ -1,0 +1,18 @@
+package converter
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/request"
+)
+
+func Repo(external request.Repo) github.Repo {
+	return github.Repo{
+		Name:  external.Name,
+		Owner: external.Owner,
+		URL:   external.URL,
+		Credentials: github.AppCredentials{
+			InstallationToken: external.Credentials.InstallationToken,
+		},
+		DefaultBranch: external.DefaultBranch,
+	}
+}

--- a/server/neptune/workflows/internal/pr/request/converter/root.go
+++ b/server/neptune/workflows/internal/pr/request/converter/root.go
@@ -1,0 +1,46 @@
+package converter
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/execute"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/request"
+)
+
+func Root(external request.Root) terraform.Root {
+	return terraform.Root{
+		Name: external.Name,
+		Plan: terraform.PlanJob{
+			Job: execute.Job{
+				Steps: steps(external.Plan.Steps)},
+			Mode: mode(external.PlanMode),
+		},
+		Validate: execute.Job{
+			Steps: steps(external.Validate.Steps),
+		},
+		Path:      external.RepoRelPath,
+		TfVersion: external.TfVersion,
+	}
+}
+
+func mode(mode request.PlanMode) *terraform.PlanMode {
+	switch mode {
+	case request.DestroyPlanMode:
+		return terraform.NewDestroyPlanMode()
+	}
+
+	return nil
+}
+
+func steps(requestSteps []request.Step) []execute.Step {
+	var terraformSteps []execute.Step
+	for _, step := range requestSteps {
+		terraformSteps = append(terraformSteps, execute.Step{
+			StepName:    step.StepName,
+			ExtraArgs:   step.ExtraArgs,
+			RunCommand:  step.RunCommand,
+			EnvVarName:  step.EnvVarName,
+			EnvVarValue: step.EnvVarValue,
+		})
+	}
+	return terraformSteps
+}

--- a/server/neptune/workflows/internal/pr/request/repo.go
+++ b/server/neptune/workflows/internal/pr/request/repo.go
@@ -1,0 +1,20 @@
+package request
+
+type Repo struct {
+	// FullName is the owner and repo name separated
+	// by a "/"
+	FullName      string
+	Owner         string
+	Name          string
+	URL           string
+	DefaultBranch string
+	Credentials   AppCredentials
+}
+
+type AppCredentials struct {
+	InstallationToken int64
+}
+
+type User struct {
+	Name string
+}

--- a/server/neptune/workflows/internal/pr/request/root.go
+++ b/server/neptune/workflows/internal/pr/request/root.go
@@ -1,0 +1,34 @@
+package request
+
+type PlanMode string
+
+const (
+	DestroyPlanMode PlanMode = "destroy"
+	NormalPlanMode  PlanMode = "normal"
+)
+
+type Root struct {
+	Name        string
+	Plan        Job
+	Validate    Job
+	RepoRelPath string
+	TfVersion   string
+	PlanMode    PlanMode
+}
+
+type Job struct {
+	Steps []Step
+}
+
+type Step struct {
+	StepName  string
+	ExtraArgs []string
+	// RunCommand is either a custom run step or the command to run
+	// during an env step to populate the environment variable dynamically.
+	RunCommand string
+	// EnvVarName is the name of the
+	// environment variable that should be set by this step.
+	EnvVarName string
+	// EnvVarValue is the value to set EnvVarName to.
+	EnvVarValue string
+}

--- a/server/neptune/workflows/internal/pr/revision/revision.go
+++ b/server/neptune/workflows/internal/pr/revision/revision.go
@@ -3,9 +3,9 @@ package revision
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request/converter"
 	workflowMetrics "github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/request"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/request/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -19,7 +19,7 @@ type Receiver struct {
 	scope workflowMetrics.Scope
 }
 
-type NewTerraformCommitRequest struct {
+type NewTerraformRevisionRequest struct {
 	Repo     request.Repo
 	Revision string
 	Roots    []request.Root
@@ -47,7 +47,7 @@ func (r *Receiver) Receive(c workflow.ReceiveChannel, more bool) Revision {
 		MaximumAttempts: 5,
 	})
 
-	var request NewTerraformCommitRequest
+	var request NewTerraformRevisionRequest
 	c.Receive(ctx, &request)
 
 	repo := converter.Repo(request.Repo)

--- a/server/neptune/workflows/internal/pr/runner_test.go
+++ b/server/neptune/workflows/internal/pr/runner_test.go
@@ -51,12 +51,12 @@ func TestWorkflowRunner_Run(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(revisionID, revision.NewTerraformCommitRequest{
+		env.SignalWorkflow(revisionID, revision.NewTerraformRevisionRequest{
 			Revision: "abc",
 		})
 	}, 2*time.Second)
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(revisionID, revision.NewTerraformCommitRequest{
+		env.SignalWorkflow(revisionID, revision.NewTerraformRevisionRequest{
 			Revision: "def",
 		})
 	}, 4*time.Second)

--- a/server/neptune/workflows/pr.go
+++ b/server/neptune/workflows/pr.go
@@ -2,10 +2,14 @@ package workflows
 
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"go.temporal.io/sdk/workflow"
 )
 
 var PRTaskQueue = pr.TaskQueue
+var PRTerraformRevisionSignalID = revision.TerraformRevisionSignalID
+
+type PRNewRevisionSignalRequest = revision.NewTerraformRevisionRequest
 
 type PRRequest = pr.Request
 

--- a/server/neptune/workflows/pr.go
+++ b/server/neptune/workflows/pr.go
@@ -2,6 +2,7 @@ package workflows
 
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"go.temporal.io/sdk/workflow"
 )
@@ -9,7 +10,16 @@ import (
 var PRTaskQueue = pr.TaskQueue
 var PRTerraformRevisionSignalID = revision.TerraformRevisionSignalID
 
+const PRDestroyPlanMode = request.DestroyPlanMode
+const PRNormalPlanMode = request.NormalPlanMode
+
 type PRNewRevisionSignalRequest = revision.NewTerraformRevisionRequest
+type PRRepo = request.Repo
+type PRRoot = request.Root
+type PRJob = request.Job
+type PRStep = request.Step
+type PRPlanMode = request.PlanMode
+type PRAppCredentials = request.AppCredentials
 
 type PRRequest = pr.Request
 


### PR DESCRIPTION
There are slight differences between some of these resources, but I think it'll be easier to understand if we keep the PR and Deploy workflows from using each others structs. The only thing they should share is the Terraform workflow/request setup.