### PR TITLE
Fix plan rejection error handling and modify to skipped.

### DIFF
--- a/server/neptune/workflows/activities/github/checks.go
+++ b/server/neptune/workflows/activities/github/checks.go
@@ -51,6 +51,7 @@ const (
 	CheckRunTimeout        CheckRunState = "timed_out"
 	CheckRunPending        CheckRunState = "in_progress"
 	CheckRunQueued         CheckRunState = "queued"
+	CheckRunSkipped        CheckRunState = "skipped"
 	CheckRunActionRequired CheckRunState = "action_required"
 	CheckRunUnknown        CheckRunState = ""
 

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -46,6 +46,7 @@ type checkrunTemplateData struct {
 	SchedulingTimeout       bool
 	HeartbeatTimeout        bool
 	PRMode                  bool
+	Skipped                 bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -60,6 +61,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	activityDurationTimeout := workflowState.Result.Reason == state.ActivityDurationTimeoutError
 	schedulingTimeout := workflowState.Result.Reason == state.SchedulingTimeoutError
 	hearbeatTimeout := workflowState.Result.Reason == state.HeartbeatTimeoutError
+	skipped := workflowState.Result.Reason == state.SkippedCompletionReason
 	var prMode bool
 	if workflowState.Mode != nil {
 		prMode = *workflowState.Mode == terraform.PR
@@ -84,6 +86,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 		SchedulingTimeout:       schedulingTimeout,
 		HeartbeatTimeout:        hearbeatTimeout,
 		ApplyActionsSummary:     applyActionsSummary,
+		Skipped:                 skipped,
 	})
 }
 

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -17,6 +17,10 @@ Please `confirm` or `reject` the Terraform plan.
 | Apply | {{ if .ApplyStatus }}`{{.ApplyStatus}}`{{else}}N/A{{end}} |{{ if .ApplyLogURL }}[Click Here]({{.ApplyLogURL}}){{else}}N/A{{end}} |
 {{end}}
 
+{{ if .Skipped }} 
+## Skipped :dash:
+Deployment has been skipped due to a plan rejection
+{{ end }} 
 {{if .InternalError }}
 ## Deployment Error :boom:
 :point_right: An error has been encountered from either of the following:

--- a/server/neptune/workflows/activities/github/markdown/templates/planconfirm.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/planconfirm.tmpl
@@ -1,6 +1,6 @@
-Requested Revision has diverged from deployed revision `{{ .RevisionURL }}`{{ if ne .Pull 0}}([#{{ .Pull }}]({{ .PullURL }})){{ end }}{{ if .User }} triggered by @{{ .User }}{{ end }}
+Requested Revision has diverged from deployed revision {{ .RevisionURL }}{{ if ne .Pull 0}}([#{{ .Pull }}]({{ .PullURL }})){{ end }}{{ if .User }} triggered by @{{ .User }}{{ end }}
 {{ if and (not .OnDefaultBranch) .LatestOnDefaultBranch }}
 :point_right: Please rebase onto the default branch to pull in the latest changes.
 {{ else }}
-Deployed revision contains unmerged changes.  Deploying this revision could cause an outage, please confirm with revision owner{{ if .User }} @{{ .User }}{{ end }} whether this is desirable.
+:point_right: Deployed revision contains unmerged changes.  Deploying this revision could cause an outage, please confirm with revision owner{{ if .User }} @{{ .User }}{{ end }} whether this is desirable.
 {{ end }}

--- a/server/neptune/workflows/internal/deploy/terraform/plan_approval_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/plan_approval_test.go
@@ -18,7 +18,7 @@ func TestPlanAppr_Non_Default(t *testing.T) {
 		Commit:         github.Commit{Branch: "test", Revision: "rev"},
 	}, &deployment.Info{Branch: "main"}, activities.DirectionDiverged, metrics.NewNullableScope())
 
-	assert.Equal(t, "Requested Revision has diverged from deployed revision `[rev](https://github.com/owner/nish/commit/rev)` triggered by @nishkrishnan\n\n:point_right: Please rebase onto the default branch to pull in the latest changes.\n\n", output.Reason)
+	assert.Equal(t, "Requested Revision has diverged from deployed revision [rev](https://github.com/owner/nish/commit/rev) triggered by @nishkrishnan\n\n:point_right: Please rebase onto the default branch to pull in the latest changes.\n\n", output.Reason)
 }
 
 func TestPlanAppr_Default(t *testing.T) {
@@ -28,5 +28,5 @@ func TestPlanAppr_Default(t *testing.T) {
 		Commit:         github.Commit{Branch: "main", Revision: "rev"},
 	}, &deployment.Info{Branch: "main"}, activities.DirectionDiverged, metrics.NewNullableScope())
 
-	assert.Equal(t, "Requested Revision has diverged from deployed revision `[rev](https://github.com/owner/nish/commit/rev)` triggered by @nishkrishnan\n\nDeployed revision contains unmerged changes.  Deploying this revision could cause an outage, please confirm with revision owner @nishkrishnan whether this is desirable.\n\n", output.Reason)
+	assert.Equal(t, "Requested Revision has diverged from deployed revision [rev](https://github.com/owner/nish/commit/rev) triggered by @nishkrishnan\n\n:point_right: Deployed revision contains unmerged changes.  Deploying this revision could cause an outage, please confirm with revision owner @nishkrishnan whether this is desirable.\n\n", output.Reason)
 }

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -12,6 +12,7 @@ import (
 )
 
 const DivergedMetric = "diverged"
+const PlanRejected = "planrejected"
 
 type PlanRejectionError struct {
 	msg string
@@ -119,7 +120,11 @@ func (r *WorkflowRunner) awaitWorkflow(ctx workflow.Context, future workflow.Chi
 			msg = "plan has been rejected"
 		}
 		if appErr.Type() == terraform.PlanRejectedErrorType {
-			return PlanRejectionError{msg: msg}
+			v := workflow.GetVersion(ctx, PlanRejected, workflow.DefaultVersion, workflow.Version(1))
+			if v == workflow.DefaultVersion {
+				return PlanRejectionError{msg: msg}
+			}
+			return NewPlanRejectionError(msg)
 		}
 	}
 

--- a/server/neptune/workflows/internal/deploy/terraform/runner_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner_test.go
@@ -81,7 +81,7 @@ func parentWorkflow(ctx workflow.Context, r request) (response, error) {
 	}
 
 	if err := runner.Run(ctx, r.Info, r.PlanApproval, metrics.NewNullableScope()); err != nil {
-		if _, ok := err.(internalTerraform.PlanRejectionError); ok {
+		if _, ok := err.(*internalTerraform.PlanRejectionError); ok {
 			return response{
 				PlanRejection: true,
 			}, nil
@@ -174,6 +174,8 @@ func TestWorkflowRunner_RunWithDivergedCommit(t *testing.T) {
 func TestWorkflowRunner_PlanRejected(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
+
+	env.OnGetVersion(internalTerraform.PlanRejected, workflow.DefaultVersion, workflow.Version(1)).Return(workflow.Version(1))
 
 	env.RegisterWorkflow(testTerraformWorklfowWithPlanRejectionError)
 

--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -193,6 +193,10 @@ func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState 
 		return github.CheckRunSuccess
 	}
 
+	if workflowState.Result.Reason == state.SkippedCompletionReason {
+		return github.CheckRunSkipped
+	}
+
 	timeouts := []state.WorkflowCompletionReason{
 		state.TimeoutError,
 		state.ActivityDurationTimeoutError,

--- a/server/neptune/workflows/internal/notifier/github_test.go
+++ b/server/neptune/workflows/internal/notifier/github_test.go
@@ -362,6 +362,24 @@ func TestCheckRunNotifier(t *testing.T) {
 			},
 			ExpectedCheckRunState: github.CheckRunSuccess,
 		},
+		{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.SuccessJobStatus,
+				},
+				Apply: &state.Job{
+					Output: jobOutput,
+					Status: state.RejectedJobStatus,
+				},
+				Result: state.WorkflowResult{
+					Status: state.CompleteWorkflowStatus,
+					Reason: state.SkippedCompletionReason,
+				},
+				Mode: &deployMode,
+			},
+			ExpectedCheckRunState: github.CheckRunSkipped,
+		},
 	}
 
 	for _, c := range cases {

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -37,6 +37,7 @@ const (
 	SchedulingTimeoutError
 	HeartbeatTimeoutError
 	ActivityDurationTimeoutError
+	SkippedCompletionReason
 )
 
 type JobOutput struct {

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -938,7 +938,7 @@ func TestPlanRejection(t *testing.T) {
 				},
 			},
 			Result: state.WorkflowResult{
-				Reason: state.InternalServiceError,
+				Reason: state.SkippedCompletionReason,
 				Status: state.CompleteWorkflowStatus,
 			},
 		},


### PR DESCRIPTION
We weren't error checking on the pointer before, this happens in multiple places (https://github.com/lyft/atlantis/blob/91a3bc7f2bb7a1c01b05c0fb46d42252b1a81220/server/neptune/workflows/internal/deploy/revision/queue/deployer.go#L92-L95, https://github.com/lyft/atlantis/blob/91a3bc7f2bb7a1c01b05c0fb46d42252b1a81220/server/neptune/workflows/internal/deploy/revision/queue/worker.go#L220-L221) so i just decided to version where we are creating it instead.

Additionally, also modified the gh status check to be skipped when we reject a plan since this isn't technically a failure.