### PR TITLE
Support policies passed apply req in neptune pr apply.

### DIFF
--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -91,7 +91,7 @@ func NewVCSEventsController(
 		ClientCreator: clientCreator,
 	}
 
-	requirementChecker := requirement.NewAggregate(globalCfg, teamMemberFetcher, reviewFetcher, logger)
+	requirementChecker := requirement.NewAggregate(globalCfg, teamMemberFetcher, reviewFetcher, checkRunFetcher, logger)
 	commentHandler := handlers.NewCommentEventWithCommandHandler(
 		commentParser,
 		repoAllowlistChecker,

--- a/server/neptune/gateway/deploy/requirement/aggregate.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate.go
@@ -24,7 +24,7 @@ func NewAggregateWithRequirements(overrideableRequirements []Requirement, nonOve
 	}
 }
 
-func NewAggregate(cfg valid.GlobalCfg, teamFetcher *github.TeamMemberFetcher, reviewFetcher *github.PRReviewFetcher, logger logging.Logger) *Aggregate {
+func NewAggregate(cfg valid.GlobalCfg, teamFetcher *github.TeamMemberFetcher, reviewFetcher *github.PRReviewFetcher, checkRunFetcher *github.CheckRunsFetcher, logger logging.Logger) *Aggregate {
 	return NewAggregateWithRequirements(
 
 		// overrideable
@@ -53,6 +53,14 @@ func NewAggregate(cfg valid.GlobalCfg, teamFetcher *github.TeamMemberFetcher, re
 					logger: logger,
 					loader: template.Loader[template.Input]{GlobalCfg: cfg},
 				},
+			},
+			&planValidationResult{
+				cfg: cfg,
+				errorGenerator: errorGenerator[template.PlanValidationSuccessData]{
+					logger: logger,
+					loader: template.Loader[template.PlanValidationSuccessData]{GlobalCfg: cfg},
+				},
+				fetcher: checkRunFetcher,
 			},
 		},
 

--- a/server/neptune/gateway/deploy/requirement/plan_validation_result.go
+++ b/server/neptune/gateway/deploy/requirement/plan_validation_result.go
@@ -1,0 +1,74 @@
+package requirement
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+)
+
+var checkRunRegex = regexp.MustCompile("atlantis/policy_check: (?P<name>.+)")
+
+type checkRunFetcher interface {
+	ListFailedPolicyCheckRuns(ctx context.Context, installationToken int64, repo models.Repo, ref string) ([]*github.CheckRun, error)
+}
+
+type planValidationResult struct {
+	cfg            valid.GlobalCfg
+	errorGenerator errGenerator[template.PlanValidationSuccessData]
+	fetcher        checkRunFetcher
+}
+
+func (a planValidationResult) Check(ctx context.Context, criteria Criteria) error {
+	match := a.cfg.MatchingRepo(criteria.Repo.ID())
+
+	shouldCheck := match.ApplySettings.ContainsPRRequirement(valid.PoliciesPassedApplyReq)
+
+	if !shouldCheck || criteria.OptionalPull == nil {
+		return nil
+	}
+
+	checkRuns, err := a.fetcher.ListFailedPolicyCheckRuns(ctx, criteria.InstallationToken, criteria.Repo, criteria.OptionalPull.HeadCommit)
+	if err != nil {
+		return errors.Wrap(err, "listing failed policy check runs")
+	}
+
+	rootsByName := make(map[string]*valid.MergedProjectCfg)
+	for _, r := range criteria.Roots {
+		rootsByName[r.Name] = r
+	}
+
+	var forbiddenCheckRuns []template.CheckRun
+	// if failing check run is a root that we are intending to apply, let's forbid it.
+	for _, c := range checkRuns {
+		matches := checkRunRegex.FindStringSubmatch(c.GetName())
+		if len(matches) != 2 {
+			return fmt.Errorf("unable to determine root name from check run: %s", c)
+		}
+		rootName := matches[checkRunRegex.SubexpIndex("name")]
+		if _, ok := rootsByName[rootName]; ok {
+			forbiddenCheckRuns = append(forbiddenCheckRuns, template.CheckRun{
+				Name: c.GetName(),
+				URL:  c.GetDetailsURL(),
+			})
+		}
+	}
+
+	if len(forbiddenCheckRuns) > 0 {
+		return a.errorGenerator.GenerateForbiddenError(
+			ctx,
+			template.PlanValidationSuccess,
+			criteria.Repo,
+			template.PlanValidationSuccessData{CheckRuns: forbiddenCheckRuns},
+			"plan validation steps must be successful",
+		)
+	}
+
+	return nil
+
+}

--- a/server/neptune/gateway/deploy/requirement/plan_validation_result_test.go
+++ b/server/neptune/gateway/deploy/requirement/plan_validation_result_test.go
@@ -1,0 +1,131 @@
+package requirement
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/neptune/template"
+	"github.com/stretchr/testify/assert"
+)
+
+type testCheckRunFetcher struct {
+	checks []*github.CheckRun
+	err    error
+}
+
+func (f *testCheckRunFetcher) ListFailedPolicyCheckRuns(ctx context.Context, installationToken int64, repo models.Repo, ref string) ([]*github.CheckRun, error) {
+	return f.checks, f.err
+}
+
+func TestPlanValidationResult(t *testing.T) {
+	t.Run("requirement not specified", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo:         models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch:       "main",
+			OptionalPull: &models.PullRequest{},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		subject := &planValidationResult{
+			cfg:            globalCfg,
+			errorGenerator: testErrGenerator[template.PlanValidationSuccessData]{},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+
+	t.Run("pull not specified", func(t *testing.T) {
+		expectedCriteria := Criteria{
+			Repo:   models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch: "main",
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		globalCfg.Repos[0].ApplySettings.PRRequirements = []string{valid.PoliciesPassedApplyReq}
+		subject := &planValidationResult{
+			cfg:            globalCfg,
+			errorGenerator: testErrGenerator[template.PlanValidationSuccessData]{},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+
+	t.Run("failed checks", func(t *testing.T) {
+		root := "root1"
+		detailsURL := "www.details.com"
+		expectedCriteria := Criteria{
+			Repo:         models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch:       "main",
+			OptionalPull: &models.PullRequest{Num: 1},
+			Roots: []*valid.MergedProjectCfg{
+				{
+					Name: root,
+				},
+			},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		globalCfg.Repos[0].ApplySettings.PRRequirements = []string{valid.PoliciesPassedApplyReq}
+
+		expectedError := ForbiddenError{details: "hi"}
+
+		subject := &planValidationResult{
+			cfg:            globalCfg,
+			errorGenerator: testErrGenerator[template.PlanValidationSuccessData]{err: expectedError},
+			fetcher: &testCheckRunFetcher{
+				checks: []*github.CheckRun{
+					{
+						Name:       github.String(fmt.Sprintf("atlantis/policy_check: %s", root)),
+						DetailsURL: github.String(detailsURL),
+					},
+				},
+			},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+
+		var target ForbiddenError
+		assert.ErrorAs(t, err, &target)
+		assert.Equal(t, expectedError, target)
+	})
+
+	t.Run("no failing checks for root1", func(t *testing.T) {
+		root := "root1"
+		detailsURL := "www.details.com"
+		expectedCriteria := Criteria{
+			Repo:         models.Repo{Name: "hi", DefaultBranch: "main"},
+			Branch:       "main",
+			OptionalPull: &models.PullRequest{Num: 1},
+			Roots: []*valid.MergedProjectCfg{
+				{
+					Name: root,
+				},
+			},
+		}
+
+		globalCfg := valid.NewGlobalCfg("")
+		globalCfg.Repos[0].ApplySettings.PRRequirements = []string{valid.PoliciesPassedApplyReq}
+
+		subject := &planValidationResult{
+			cfg:            globalCfg,
+			errorGenerator: testErrGenerator[template.PlanValidationSuccessData]{},
+			fetcher: &testCheckRunFetcher{
+				checks: []*github.CheckRun{
+					{
+						Name:       github.String("atlantis/policy_check: root2"),
+						DetailsURL: github.String(detailsURL),
+					},
+				},
+			},
+		}
+
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+}

--- a/server/neptune/gateway/deploy/requirement/team.go
+++ b/server/neptune/gateway/deploy/requirement/team.go
@@ -17,6 +17,7 @@ type Criteria struct {
 	OptionalPull      *models.PullRequest
 	InstallationToken int64
 	TriggerInfo       workflows.DeployTriggerInfo
+	Roots             []*valid.MergedProjectCfg
 }
 
 type fetcher interface {

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -143,6 +143,7 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 		InstallationToken: event.InstallationToken,
 		TriggerInfo:       triggerInfo,
 		OptionalPull:      &event.Pull,
+		Roots:             platformModeRoots,
 	}); err != nil {
 		return errors.Wrap(err, "checking deploy requirements")
 	}

--- a/server/neptune/gateway/event/pull_request_review_handler.go
+++ b/server/neptune/gateway/event/pull_request_review_handler.go
@@ -26,7 +26,7 @@ type PullRequestReview struct {
 }
 
 type fetcher interface {
-	ListFailedPolicyCheckRuns(ctx context.Context, installationToken int64, repo models.Repo, ref string) ([]string, error)
+	ListFailedPolicyCheckRunNames(ctx context.Context, installationToken int64, repo models.Repo, ref string) ([]string, error)
 }
 
 type PullRequestReviewWorkerProxy struct {
@@ -49,7 +49,7 @@ func (p *PullRequestReviewWorkerProxy) handle(ctx context.Context, event PullReq
 	}
 
 	// Ignore PRs without failing policy checks
-	failedPolicyCheckRuns, err := p.CheckRunFetcher.ListFailedPolicyCheckRuns(ctx, event.InstallationToken, event.Repo, event.Ref)
+	failedPolicyCheckRuns, err := p.CheckRunFetcher.ListFailedPolicyCheckRunNames(ctx, event.InstallationToken, event.Repo, event.Ref)
 	if err != nil {
 		p.Logger.ErrorContext(ctx, "unable to list failed policy check runs")
 		return err

--- a/server/neptune/gateway/event/pull_request_review_handler_test.go
+++ b/server/neptune/gateway/event/pull_request_review_handler_test.go
@@ -148,7 +148,7 @@ type mockCheckRunFetcher struct {
 	isCalled       bool
 }
 
-func (f *mockCheckRunFetcher) ListFailedPolicyCheckRuns(_ context.Context, _ int64, _ models.Repo, _ string) ([]string, error) {
+func (f *mockCheckRunFetcher) ListFailedPolicyCheckRunNames(_ context.Context, _ int64, _ models.Repo, _ string) ([]string, error) {
 	f.isCalled = true
 	return f.failedPolicies, f.err
 }

--- a/server/neptune/template/loader.go
+++ b/server/neptune/template/loader.go
@@ -22,17 +22,19 @@ type Input struct {
 
 // list of all valid template ids
 const (
-	PRComment        = Key("pr_comment")
-	BranchForbidden  = Key("branch_forbidden")
-	UserForbidden    = Key("user_forbidden")
-	ApprovalRequired = Key("approval_required")
+	PRComment             = Key("pr_comment")
+	BranchForbidden       = Key("branch_forbidden")
+	UserForbidden         = Key("user_forbidden")
+	ApprovalRequired      = Key("approval_required")
+	PlanValidationSuccess = Key("plan_validation_success")
 )
 
 var defaultTemplates = map[Key]string{
-	PRComment:        prCommentTemplate,
-	BranchForbidden:  branchForbiddenTemplate,
-	UserForbidden:    userForbiddenTemplate,
-	ApprovalRequired: approvalRequiredTemplate,
+	PRComment:             prCommentTemplate,
+	BranchForbidden:       branchForbiddenTemplate,
+	UserForbidden:         userForbiddenTemplate,
+	ApprovalRequired:      approvalRequiredTemplate,
+	PlanValidationSuccess: planValidationSuccessTemplate,
 }
 
 type PRCommentData struct {
@@ -41,6 +43,15 @@ type PRCommentData struct {
 	InternalError          bool
 	Command                string
 	ErrorDetails           string
+}
+
+type CheckRun struct {
+	Name string
+	URL  string
+}
+
+type PlanValidationSuccessData struct {
+	CheckRuns []CheckRun
 }
 
 type BranchForbiddenData struct {
@@ -64,6 +75,9 @@ var userForbiddenTemplate string
 
 //go:embed templates/approval_required.tmpl
 var approvalRequiredTemplate string
+
+//go:embed templates/plan_validation_success.tmpl
+var planValidationSuccessTemplate string
 
 type Loader[T any] struct {
 	GlobalCfg valid.GlobalCfg

--- a/server/neptune/template/templates/plan_validation_success.tmpl
+++ b/server/neptune/template/templates/plan_validation_success.tmpl
@@ -1,0 +1,8 @@
+:no_entry_sign: :raised_hand: Applies are only allowed for a set of roots once their policies are all passing
+
+Failing policies:
+  {{ range .CheckRuns}}
+    [{{ .Name }}]({{ .URL }})
+  {{ end }}
+
+:point_right: Please fix these failures and try again.


### PR DESCRIPTION
Figured out an easier way to add this without adding a dependency on our legacy system directly.  This check will need to be modified for when we support the new temporal PR workflow though.