### PR TITLE
Deprecate autoplan validator in favor of new root config builder

### DIFF
--- a/server/neptune/gateway/deploy/requirement/aggregate.go
+++ b/server/neptune/gateway/deploy/requirement/aggregate.go
@@ -63,6 +63,20 @@ func NewAggregate(cfg valid.GlobalCfg, teamFetcher *github.TeamMemberFetcher, re
 	)
 }
 
+func NewPRAggregate(globalCfg valid.GlobalCfg) *Aggregate {
+	return NewAggregateWithRequirements(
+		// overrideable
+		[]Requirement{},
+		// non-overrideable
+		[]Requirement{
+			pull{},
+			baseBranch{
+				GlobalCfg: globalCfg,
+			},
+		},
+	)
+}
+
 func (a *Aggregate) Check(ctx context.Context, criteria Criteria) error {
 	for _, d := range a.nonOverrideableRequirements {
 		if err := d.Check(ctx, criteria); err != nil {

--- a/server/neptune/gateway/deploy/requirement/base_branch.go
+++ b/server/neptune/gateway/deploy/requirement/base_branch.go
@@ -1,0 +1,19 @@
+package requirement
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+)
+
+type baseBranch struct {
+	GlobalCfg valid.GlobalCfg
+}
+
+func (b baseBranch) Check(ctx context.Context, criteria Criteria) error {
+	repo := b.GlobalCfg.MatchingRepo(criteria.OptionalPull.BaseRepo.ID())
+	if !repo.BranchMatches(criteria.OptionalPull.BaseBranch) {
+		return errors.New("command was run on a pull request which doesn't match base branches")
+	}
+	return nil
+}

--- a/server/neptune/gateway/deploy/requirement/base_branch_test.go
+++ b/server/neptune/gateway/deploy/requirement/base_branch_test.go
@@ -1,0 +1,46 @@
+package requirement
+
+import (
+	"context"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+var regex = regexp.MustCompile(`abc`)
+
+func TestBaseBranch(t *testing.T) {
+	globalCfg := valid.GlobalCfg{
+		Repos: []valid.Repo{
+			{
+				ID:          "/owner",
+				BranchRegex: regex,
+			},
+		},
+	}
+	t.Run("success", func(t *testing.T) {
+		subject := baseBranch{GlobalCfg: globalCfg}
+		expectedCriteria := Criteria{
+			OptionalPull: &models.PullRequest{
+				BaseRepo:   models.Repo{FullName: "owner"},
+				BaseBranch: "abc",
+			},
+		}
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.NoError(t, err)
+	})
+	t.Run("failure", func(t *testing.T) {
+		subject := baseBranch{GlobalCfg: globalCfg}
+		expectedCriteria := Criteria{
+			OptionalPull: &models.PullRequest{
+				BaseRepo:   models.Repo{FullName: "owner"},
+				BaseBranch: "def",
+			},
+		}
+		err := subject.Check(context.Background(), expectedCriteria)
+		assert.Error(t, err)
+	})
+
+}

--- a/server/neptune/gateway/event/pull_request_handler.go
+++ b/server/neptune/gateway/event/pull_request_handler.go
@@ -1,8 +1,13 @@
 package event
 
 import (
-	"bytes"
 	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/config"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy/requirement"
+	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,7 +16,26 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
-// PullRequestEvent is our internal representation of a vcs based pr event
+type vcsStatusUpdater interface {
+	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error)
+	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error)
+}
+
+type workerProxy interface {
+	Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error
+}
+
+type ModifiedPullHandler struct {
+	WorkerProxy        workerProxy
+	Logger             logging.Logger
+	Scheduler          scheduler
+	RootConfigBuilder  rootConfigBuilder
+	GlobalCfg          valid.GlobalCfg
+	VCSStatusUpdater   vcsStatusUpdater
+	RequirementChecker requirementChecker
+}
+
+// PullRequest is our internal representation of a vcs based pr event
 type PullRequest struct {
 	Pull              models.PullRequest
 	User              models.User
@@ -20,84 +44,113 @@ type PullRequest struct {
 	InstallationToken int64
 }
 
-func NewAutoplannerValidatorProxy(
-	autoplanValidator Validator,
-	logger logging.Logger,
-	workerProxy *PullEventWorkerProxy,
-	scheduler scheduler,
-) *AutoplannerValidatorProxy {
-	return &AutoplannerValidatorProxy{
-		autoplanValidator: autoplanValidator,
-		workerProxy:       workerProxy,
-		logger:            logger,
-		scheduler:         scheduler,
+func NewModifiedPullHandler(logger logging.Logger, workerProxy *PullSNSWorkerProxy, scheduler scheduler, rootConfigBuilder rootConfigBuilder, globalCfg valid.GlobalCfg, updater vcsStatusUpdater, requirementChecker requirementChecker) *ModifiedPullHandler {
+	return &ModifiedPullHandler{
+		WorkerProxy:        workerProxy,
+		Logger:             logger,
+		Scheduler:          scheduler,
+		RootConfigBuilder:  rootConfigBuilder,
+		GlobalCfg:          globalCfg,
+		VCSStatusUpdater:   updater,
+		RequirementChecker: requirementChecker,
 	}
 }
 
-type Validator interface {
-	InstrumentedIsValid(ctx context.Context, logger logging.Logger, baseRepo models.Repo, headRepo models.Repo, pull models.PullRequest, user models.User) bool
-}
-
-type Writer interface {
-	WriteWithContext(ctx context.Context, payload []byte) error
-}
-
-type AutoplannerValidatorProxy struct {
-	autoplanValidator Validator
-	workerProxy       *PullEventWorkerProxy
-	logger            logging.Logger
-	scheduler         scheduler
-}
-
-func (p *AutoplannerValidatorProxy) handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
-	if ok := p.autoplanValidator.InstrumentedIsValid(
-		ctx,
-		p.logger,
-		event.Pull.BaseRepo,
-		event.Pull.HeadRepo,
-		event.Pull,
-		event.User); ok {
-		return p.workerProxy.Handle(ctx, request, event)
-	}
-
-	p.logger.WarnContext(ctx, "request isn't valid and will not be proxied to sns")
-
-	return nil
-}
-
-func (p *AutoplannerValidatorProxy) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
-	return p.scheduler.Schedule(ctx, func(ctx context.Context) error {
+func (p *ModifiedPullHandler) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
+	return p.Scheduler.Schedule(ctx, func(ctx context.Context) error {
 		return p.handle(ctx, request, event)
 	})
 }
 
-func NewPullEventWorkerProxy(
-	snsWriter Writer,
-	logger logging.Logger,
-) *PullEventWorkerProxy {
-	return &PullEventWorkerProxy{
-		snsWriter: snsWriter,
-		logger:    logger,
+func (p *ModifiedPullHandler) handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
+	criteria := requirement.Criteria{
+		User:              event.User,
+		Branch:            event.Pull.HeadBranch,
+		Repo:              event.Pull.HeadRepo,
+		OptionalPull:      &event.Pull,
+		InstallationToken: event.InstallationToken,
 	}
+	if err := p.RequirementChecker.Check(ctx, criteria); err != nil {
+		return errors.Wrap(err, "checking pr requirements")
+	}
+
+	commit := &config.RepoCommit{
+		Repo:          event.Pull.HeadRepo,
+		Branch:        event.Pull.HeadBranch,
+		Sha:           event.Pull.HeadCommit,
+		OptionalPRNum: event.Pull.Num,
+	}
+
+	// set clone depth to 1 for repos with a branch checkout strategy
+	cloneDepth := 0
+	matchingRepo := p.GlobalCfg.MatchingRepo(event.Pull.HeadRepo.ID())
+	if matchingRepo != nil && matchingRepo.CheckoutStrategy == "branch" {
+		cloneDepth = 1
+	}
+	builderOptions := config.BuilderOptions{
+		RepoFetcherOptions: &github.RepoFetcherOptions{
+			CloneDepth: cloneDepth,
+		},
+	}
+
+	rootCfgs, err := p.RootConfigBuilder.Build(ctx, commit, event.InstallationToken, builderOptions)
+	if err != nil {
+		return errors.Wrap(err, "generating roots")
+	}
+
+	var legacyModeRoots []*valid.MergedProjectCfg
+	var platformModeRoots []*valid.MergedProjectCfg
+	for _, rootCfg := range rootCfgs {
+		if rootCfg.WorkflowMode == valid.PlatformWorkflowMode {
+			platformModeRoots = append(platformModeRoots, rootCfg)
+		} else {
+			legacyModeRoots = append(legacyModeRoots, rootCfg)
+		}
+	}
+
+	// TODO: remove when we deprecate legacy mode
+	if err := p.handleLegacyMode(ctx, request, event, rootCfgs, legacyModeRoots); err != nil {
+		return errors.Wrap(err, "handling legacy mode")
+	}
+	if err := p.handlePlatformMode(ctx, event, platformModeRoots); err != nil {
+		return errors.Wrap(err, "handling platform mode")
+	}
+	return nil
 }
 
-type PullEventWorkerProxy struct {
-	snsWriter Writer
-	logger    logging.Logger
+func (p *ModifiedPullHandler) handleLegacyMode(ctx context.Context, request *http.BufferedRequest, event PullRequest, allRoots []*valid.MergedProjectCfg, legacyRoots []*valid.MergedProjectCfg) error {
+	// mark legacy statuses as successful if there are no roots in general
+	// this is processed here to make it easy to clean up when we deprecate legacy mode
+	if len(allRoots) == 0 {
+		for _, cmd := range []command.Name{command.Plan, command.Apply, command.PolicyCheck} {
+			if _, statusErr := p.VCSStatusUpdater.UpdateCombinedCount(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, cmd, 0, 0, ""); statusErr != nil {
+				p.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
+			}
+		}
+		return nil
+	}
+
+	// mark apply status as successful if there are no legacy roots
+	if len(legacyRoots) == 0 {
+		if _, statusErr := p.VCSStatusUpdater.UpdateCombined(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, command.Apply, "", PlatformModeApplyStatusMessage); statusErr != nil {
+			p.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
+		}
+	}
+
+	// mark plan status as queued
+	if _, err := p.VCSStatusUpdater.UpdateCombined(ctx, event.Pull.HeadRepo, event.Pull, models.QueuedVCSStatus, command.Plan, "", "Request received. Adding to the queue..."); err != nil {
+		p.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
+	}
+
+	// forward to sns
+	err := p.WorkerProxy.Handle(ctx, request, event)
+	if err != nil {
+		return errors.Wrap(err, "proxying request to sns")
+	}
+	return nil
 }
 
-func (p *PullEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
-	buffer := bytes.NewBuffer([]byte{})
-
-	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
-		return errors.Wrap(err, "writing request to buffer")
-	}
-
-	if err := p.snsWriter.WriteWithContext(ctx, buffer.Bytes()); err != nil {
-		return errors.Wrap(err, "writing buffer to sns")
-	}
-
-	p.logger.InfoContext(ctx, "proxied request to sns")
-
+func (p *ModifiedPullHandler) handlePlatformMode(_ context.Context, _ PullRequest, _ []*valid.MergedProjectCfg) error {
+	// TODO: handle platform mode
 	return nil
 }

--- a/server/neptune/gateway/event/pull_request_handler_test.go
+++ b/server/neptune/gateway/event/pull_request_handler_test.go
@@ -1,0 +1,220 @@
+package event_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/http"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/config"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
+	"github.com/runatlantis/atlantis/server/neptune/sync"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestModifiedPullHandler_Handle_CriteriaFailure(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          valid.GlobalCfg{},
+		RequirementChecker: &requirementsChecker{err: assert.AnError},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestModifiedPullHandler_Handle_RootBuilderFailure(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          valid.GlobalCfg{},
+		RequirementChecker: &requirementsChecker{},
+		RootConfigBuilder: &mockConfigBuilder{
+			expectedCommit: &config.RepoCommit{},
+			expectedT:      t,
+			error:          assert.AnError,
+		},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestModifiedPullHandler_Handle_NoRoots(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	statusUpdater := &mockVCSStatusUpdater{
+		combinedCountCalls: 1,
+	}
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          valid.GlobalCfg{},
+		RequirementChecker: &requirementsChecker{},
+		VCSStatusUpdater:   statusUpdater,
+		RootConfigBuilder: &mockConfigBuilder{
+			expectedCommit: &config.RepoCommit{},
+			expectedT:      t,
+		},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
+	assert.NoError(t, err)
+}
+
+func TestModifiedPullHandler_Handle_WorkerProxyFailure(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	statusUpdater := &mockVCSStatusUpdater{
+		combinedCountCalls: 1,
+	}
+	legacyRoot := &valid.MergedProjectCfg{
+		Name:         "legacy",
+		WorkflowMode: valid.DefaultWorkflowMode,
+	}
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          valid.GlobalCfg{},
+		RequirementChecker: &requirementsChecker{},
+		VCSStatusUpdater:   statusUpdater,
+		WorkerProxy:        &mockWorkerProxy{err: assert.AnError},
+		RootConfigBuilder: &mockConfigBuilder{
+			expectedCommit: &config.RepoCommit{},
+			expectedT:      t,
+			rootConfigs:    []*valid.MergedProjectCfg{legacyRoot},
+		},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestModifiedPullHandler_Handle_LegacyRoots(t *testing.T) {
+	logger := logging.NewNoopCtxLogger(t)
+	statusUpdater := &mockVCSStatusUpdater{
+		combinedCountCalls: 1,
+	}
+	legacyRoot := &valid.MergedProjectCfg{
+		Name:         "legacy",
+		WorkflowMode: valid.DefaultWorkflowMode,
+	}
+	workerProxy := &mockWorkerProxy{}
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          valid.GlobalCfg{},
+		RequirementChecker: &requirementsChecker{},
+		VCSStatusUpdater:   statusUpdater,
+		WorkerProxy:        workerProxy,
+		RootConfigBuilder: &mockConfigBuilder{
+			expectedCommit: &config.RepoCommit{},
+			expectedT:      t,
+			rootConfigs:    []*valid.MergedProjectCfg{legacyRoot},
+		},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
+	assert.NoError(t, err)
+	assert.True(t, workerProxy.called)
+}
+
+func TestModifiedPullHandler_Handle_BranchStrategy(t *testing.T) {
+	testRepo := models.Repo{
+		FullName: "owner/repo",
+		VCSHost: models.VCSHost{
+			Hostname: "github.com",
+		},
+	}
+	pullRequest := models.PullRequest{
+		HeadCommit: "sha",
+		HeadBranch: "branch",
+		BaseBranch: "main",
+		BaseRepo:   testRepo,
+		HeadRepo:   testRepo,
+	}
+	logger := logging.NewNoopCtxLogger(t)
+	statusUpdater := &mockVCSStatusUpdater{
+		combinedCountCalls: 1,
+	}
+	legacyRoot := &valid.MergedProjectCfg{
+		Name:         "legacy",
+		WorkflowMode: valid.DefaultWorkflowMode,
+	}
+	globalCfg := valid.GlobalCfg{
+		Repos: []valid.Repo{
+			{
+				ID:               "github.com/owner/repo",
+				CheckoutStrategy: "branch",
+			},
+		},
+	}
+	workerProxy := &mockWorkerProxy{}
+	expectedCommit := &config.RepoCommit{
+		Repo:   testRepo,
+		Branch: "branch",
+		Sha:    "sha",
+	}
+	pullHandler := event.ModifiedPullHandler{
+		Logger:             logger,
+		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
+		GlobalCfg:          globalCfg,
+		RequirementChecker: &requirementsChecker{},
+		VCSStatusUpdater:   statusUpdater,
+		WorkerProxy:        workerProxy,
+		RootConfigBuilder: &mockConfigBuilder{
+			expectedCommit:     expectedCommit,
+			expectedCloneDepth: 1,
+			expectedT:          t,
+			rootConfigs:        []*valid.MergedProjectCfg{legacyRoot},
+		},
+	}
+	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{
+		Pull: pullRequest,
+	})
+	assert.NoError(t, err)
+	assert.True(t, workerProxy.called)
+}
+
+type mockConfigBuilder struct {
+	expectedCommit     *config.RepoCommit
+	expectedToken      int64
+	expectedCloneDepth int
+	expectedT          *testing.T
+	rootConfigs        []*valid.MergedProjectCfg
+	error              error
+}
+
+func (r *mockConfigBuilder) Build(_ context.Context, commit *config.RepoCommit, installationToken int64, opts ...config.BuilderOptions) ([]*valid.MergedProjectCfg, error) {
+	assert.Equal(r.expectedT, r.expectedCommit, commit)
+	assert.Equal(r.expectedT, r.expectedToken, installationToken)
+	assert.Len(r.expectedT, opts, 1)
+	assert.Equal(r.expectedT, r.expectedCloneDepth, opts[0].RepoFetcherOptions.CloneDepth)
+	return r.rootConfigs, r.error
+}
+
+type mockVCSStatusUpdater struct {
+	combinedCalls int
+	combinedError error
+
+	combinedCountError error
+	combinedCountCalls int
+}
+
+func (m *mockVCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error) {
+	m.combinedCalls++
+	return "", m.combinedError
+}
+
+func (m *mockVCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error) {
+	m.combinedCountCalls++
+	return "", m.combinedCountError
+}
+
+type mockWorkerProxy struct {
+	called bool
+	err    error
+}
+
+func (w *mockWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event event.PullRequest) error {
+	w.called = true
+	return w.err
+}

--- a/server/neptune/gateway/event/sns_worker_proxy.go
+++ b/server/neptune/gateway/event/sns_worker_proxy.go
@@ -1,0 +1,41 @@
+package event
+
+// TODO: delete when legacy mode is deprecated
+import (
+	"bytes"
+	"context"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/http"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type Writer interface {
+	WriteWithContext(ctx context.Context, payload []byte) error
+}
+
+type PullSNSWorkerProxy struct {
+	snsWriter Writer
+	logger    logging.Logger
+}
+
+func NewSNSWorkerProxy(snsWriter Writer, logger logging.Logger) *PullSNSWorkerProxy {
+	return &PullSNSWorkerProxy{
+		snsWriter: snsWriter,
+		logger:    logger,
+	}
+}
+
+func (p *PullSNSWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error {
+	buffer := bytes.NewBuffer([]byte{})
+
+	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
+		return errors.Wrap(err, "writing request to buffer")
+	}
+
+	if err := p.snsWriter.WriteWithContext(ctx, buffer.Bytes()); err != nil {
+		return errors.Wrap(err, "writing buffer to sns")
+	}
+
+	p.logger.InfoContext(ctx, "proxied request to sns")
+	return nil
+}


### PR DESCRIPTION
Let's migrate gateway away from using the autoplan validator when identifying if a PR has Terraform changes.