### PR TITLE
Add inactivity timeout to PR workflow

### DIFF
--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -147,8 +147,6 @@ func (r *Runner) Run(ctx workflow.Context) error {
 			shutdownPollCancel, _ = s.AddTimeout(ctx, r.ShutdownPollTick, onShutdownPollTick)
 			continue
 		}
-		workflow.GetLogger(ctx).Info("pr is closed, shutting down")
-		r.state = complete
 		revisionCancel()
 		return nil
 	}

--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -67,12 +67,15 @@ func newRunner(ctx workflow.Context, scope workflowMetrics.Scope, tfWorkflow rev
 		TFStateReceiver: &stateReceiver,
 		PolicyHandler:   &revision.FailedPolicyHandler{},
 	}
+	shutdownChecker := ShutdownStateChecker{}
 	return &Runner{
 		RevisionSignalChannel: workflow.GetSignalChannel(ctx, revision.TerraformRevisionSignalID),
 		RevisionReceiver:      &revisionReceiver,
 		ShutdownSignalChannel: workflow.GetSignalChannel(ctx, ShutdownSignalID),
 		Scope:                 scope,
 		RevisionProcessor:     &revisionProcessor,
+		ShutdownChecker:       &shutdownChecker,
+
 		// TODO: make these configurations
 		InactivityTimeout: time.Hour * 24 * 7,
 		ShutdownPollTick:  time.Hour * 24,

--- a/server/neptune/workflows/internal/pr/runner_test.go
+++ b/server/neptune/workflows/internal/pr/runner_test.go
@@ -13,7 +13,8 @@ import (
 type request struct {
 	mockRevisionProcessor testRevisionProcessor
 	scope                 metrics.Scope
-	inactivityTimeout     time.Duration
+	InactivityTimeout     time.Duration
+	ShutdownPollTick      time.Duration
 	T                     *testing.T
 }
 
@@ -37,7 +38,8 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		RevisionReceiver:      &revisionReceiver,
 		ShutdownSignalChannel: workflow.GetSignalChannel(ctx, shutdownID),
 		RevisionProcessor:     mockRevisionProcessor,
-		InactivityTimeout:     r.inactivityTimeout,
+		InactivityTimeout:     r.InactivityTimeout,
+		ShutdownPollTick:      r.ShutdownPollTick,
 		cancel:                func() {},
 	}
 	err := runner.Run(ctx)
@@ -49,7 +51,8 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 func TestWorkflowRunner_Run(t *testing.T) {
 	req := request{
 		mockRevisionProcessor: testRevisionProcessor{},
-		inactivityTimeout:     time.Minute,
+		InactivityTimeout:     time.Minute,
+		ShutdownPollTick:      time.Hour,
 	}
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
@@ -76,7 +79,8 @@ func TestWorkflowRunner_Run(t *testing.T) {
 func TestWorkflowRunner_Run_InactivityTimeout(t *testing.T) {
 	req := request{
 		mockRevisionProcessor: testRevisionProcessor{},
-		inactivityTimeout:     time.Second,
+		InactivityTimeout:     time.Second,
+		ShutdownPollTick:      time.Hour,
 	}
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()

--- a/server/neptune/workflows/internal/pr/runner_test.go
+++ b/server/neptune/workflows/internal/pr/runner_test.go
@@ -137,8 +137,5 @@ type testShutdownChecker struct {
 
 func (c *testShutdownChecker) ShouldShutdown(ctx workflow.Context, prRevision revision.Revision) bool {
 	c.calls++
-	if c.calls == c.ShouldShutdownAfterNTicks {
-		return true
-	}
-	return false
+	return c.calls == c.ShouldShutdownAfterNTicks
 }

--- a/server/neptune/workflows/internal/pr/runner_test.go
+++ b/server/neptune/workflows/internal/pr/runner_test.go
@@ -45,7 +45,6 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		ShutdownChecker:       mockShutdownChecker,
 		InactivityTimeout:     r.InactivityTimeout,
 		ShutdownPollTick:      r.ShutdownPollTime,
-		cancel:                func() {},
 	}
 	err := runner.Run(ctx)
 	return response{

--- a/server/neptune/workflows/internal/pr/shutdown.go
+++ b/server/neptune/workflows/internal/pr/shutdown.go
@@ -1,0 +1,14 @@
+package pr
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
+	"go.temporal.io/sdk/workflow"
+)
+
+type ShutdownStateChecker struct {
+}
+
+func (s ShutdownStateChecker) ShouldShutdown(ctx workflow.Context, prRevision revision.Revision) bool {
+	//TODO implement me
+	return false
+}


### PR DESCRIPTION
Adds more detail to the PR workflow shutdown logic. Here we add a shutdown timeout from inactivity in the workflow (ex. PR is abandoned, but never closed). Also creates skeleton setup detailing how we will eventually also poll to determine if we can shutdown the workflow.

Next steps to complete shutdown logic:
* implement `shouldShutdown` (this will most likely be interfaced out to a something like a `ShutdownChecker` that fetches PR state using a temporal activity and returns true if PR is closed)
* move new `time.Duration` Runner parameters out to be tunable atlantis configurations
* bonus: consider sending message to PR if inactivity timeout is met (still unsure about if this is necessary since theoretically the last state change = source of truth and any new code changes should automatically trigger a new workflow to start; it would just be useful for approvals)
