### PR TITLE
Filter out deploy statuses in mergeability checker.

### DIFF
--- a/server/events/vcs/inject.go
+++ b/server/events/vcs/inject.go
@@ -22,8 +22,11 @@ func newValidChecksFilters(vcsStatusPrefix string) []ValidChecksFilter {
 	applyChecksFilter := &ApplyChecksFilter{
 		statusTitleMatcher: titleMatcher,
 	}
+	deployChecksFilter := &DeployChecksFilter{
+		statusTitleMatcher: titleMatcher,
+	}
 	return []ValidChecksFilter{
-		SuccessConclusionFilter, SkippedConclusionFilter, applyChecksFilter,
+		SuccessConclusionFilter, SkippedConclusionFilter, applyChecksFilter, deployChecksFilter,
 	}
 }
 

--- a/server/events/vcs/mergeability.go
+++ b/server/events/vcs/mergeability.go
@@ -51,6 +51,24 @@ type ValidChecksFilter interface {
 }
 
 // ApplyChecksFilter filters statuses that correspond to atlantis apply
+type DeployChecksFilter struct {
+	statusTitleMatcher StatusTitleMatcher
+}
+
+func (d DeployChecksFilter) Filter(checks []*github.CheckRun) []*github.CheckRun {
+	var filtered []*github.CheckRun
+	for _, check := range checks {
+		if d.statusTitleMatcher.MatchesCommand(*check.Name, "deploy") {
+			continue
+		}
+
+		filtered = append(filtered, check)
+	}
+
+	return filtered
+}
+
+// ApplyChecksFilter filters statuses that correspond to atlantis apply
 type ApplyChecksFilter struct {
 	statusTitleMatcher StatusTitleMatcher
 }


### PR DESCRIPTION
Projects that support legacy and neptune roots are failing to be applied.