### PR TITLE
Implement shutdown checker

### DIFF
--- a/server/neptune/workflows/activities/github/client.go
+++ b/server/neptune/workflows/activities/github/client.go
@@ -112,3 +112,11 @@ func (c *Client) ListPullRequests(ctx Context, owner, repo, base, state, sortBy,
 
 	return gh_helper.Iterate(ctx, run)
 }
+
+func (c *Client) GetPullRequest(ctx Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating client from installation")
+	}
+	return client.PullRequests.Get(ctx, owner, repo, number)
+}

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -285,6 +285,10 @@ type testGithubClient struct {
 	DeploymentID string
 }
 
+func (c *testGithubClient) GetPullRequest(ctx internalGithub.Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	return &github.PullRequest{}, &github.Response{}, nil
+}
+
 func (c *testGithubClient) CreateCheckRun(ctx internalGithub.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
 	c.DeploymentID = opts.GetExternalID()
 	return &github.CheckRun{

--- a/server/neptune/workflows/internal/pr/shutdown.go
+++ b/server/neptune/workflows/internal/pr/shutdown.go
@@ -1,14 +1,37 @@
 package pr
 
 import (
+	"context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"go.temporal.io/sdk/workflow"
 )
 
+const ClosedState = "closed"
+
+type githubActivities interface {
+	GithubGetPullRequestState(ctx context.Context, request activities.GetPullRequestStateRequest) (activities.GetPullRequestStateResponse, error)
+}
+
 type ShutdownStateChecker struct {
+	GithubActivities githubActivities
+	PRNumber         int
 }
 
 func (s ShutdownStateChecker) ShouldShutdown(ctx workflow.Context, prRevision revision.Revision) bool {
-	//TODO implement me
+	req := activities.GetPullRequestStateRequest{
+		Repo:     prRevision.Repo,
+		PRNumber: s.PRNumber,
+	}
+	var resp activities.GetPullRequestStateResponse
+	err := workflow.ExecuteActivity(ctx, s.GithubActivities.GithubGetPullRequestState, req).Get(ctx, &resp)
+	if err != nil {
+		workflow.GetLogger(ctx).Error(err.Error())
+		return false
+	}
+	if resp.State == ClosedState {
+		workflow.GetLogger(ctx).Info("pr is closed, shutting down")
+		return true
+	}
 	return false
 }

--- a/server/neptune/workflows/internal/pr/shutdown_test.go
+++ b/server/neptune/workflows/internal/pr/shutdown_test.go
@@ -1,0 +1,133 @@
+package pr_test
+
+import (
+	"context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	"testing"
+	"time"
+)
+
+type request struct {
+	TestPRNumber int
+	TestRepo     github.Repo
+	ga           *testGithubActivities
+}
+
+type response struct {
+	ShouldShutdown bool
+}
+
+func testWorkflow(ctx workflow.Context, r request) (response, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: time.Minute,
+	})
+	shutdownChecker := pr.ShutdownStateChecker{
+		GithubActivities: r.ga,
+		PRNumber:         r.TestPRNumber,
+	}
+	shouldShutdown := shutdownChecker.ShouldShutdown(ctx, revision.Revision{
+		Repo: r.TestRepo,
+	})
+	return response{ShouldShutdown: shouldShutdown}, nil
+}
+func TestShutdownStateChecker_ShouldShutdown(t *testing.T) {
+	testRepo := github.Repo{
+		Owner: "owner",
+		Name:  "name",
+	}
+	testPRNum := 10
+
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	ga := &testGithubActivities{
+		expectedRepo:     testRepo,
+		expectedPRNumber: testPRNum,
+		state:            pr.ClosedState,
+		t:                t,
+	}
+	env.RegisterActivity(ga)
+	env.ExecuteWorkflow(testWorkflow, request{
+		TestPRNumber: testPRNum,
+		TestRepo:     testRepo,
+		ga:           ga,
+	})
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+	assert.True(t, resp.ShouldShutdown)
+}
+
+func TestShutdownStateChecker_ShouldNotShutdown(t *testing.T) {
+	testRepo := github.Repo{
+		Owner: "owner",
+		Name:  "name",
+	}
+	testPRNum := 10
+
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	ga := &testGithubActivities{
+		expectedRepo:     testRepo,
+		expectedPRNumber: testPRNum,
+		state:            "open",
+		t:                t,
+	}
+	env.RegisterActivity(ga)
+	env.ExecuteWorkflow(testWorkflow, request{
+		TestPRNumber: testPRNum,
+		TestRepo:     testRepo,
+		ga:           ga,
+	})
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+	assert.False(t, resp.ShouldShutdown)
+}
+
+func TestShutdownStateChecker_Error(t *testing.T) {
+	testRepo := github.Repo{
+		Owner: "owner",
+		Name:  "name",
+	}
+	testPRNum := 10
+
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+	ga := &testGithubActivities{
+		expectedRepo:     testRepo,
+		expectedPRNumber: testPRNum,
+		state:            pr.ClosedState,
+		error:            assert.AnError,
+		t:                t,
+	}
+	env.RegisterActivity(ga)
+	env.ExecuteWorkflow(testWorkflow, request{
+		TestPRNumber: testPRNum,
+		TestRepo:     testRepo,
+		ga:           ga,
+	})
+	var resp response
+	err := env.GetWorkflowResult(&resp)
+	assert.NoError(t, err)
+	assert.False(t, resp.ShouldShutdown)
+}
+
+type testGithubActivities struct {
+	error            error
+	state            string
+	t                *testing.T
+	expectedPRNumber int
+	expectedRepo     github.Repo
+}
+
+func (g *testGithubActivities) GithubGetPullRequestState(_ context.Context, request activities.GetPullRequestStateRequest) (activities.GetPullRequestStateResponse, error) {
+	assert.Equal(g.t, g.expectedPRNumber, request.PRNumber)
+	assert.Equal(g.t, g.expectedRepo, request.Repo)
+	return activities.GetPullRequestStateResponse{State: g.state}, g.error
+}

--- a/server/neptune/workflows/internal/pr/workflow.go
+++ b/server/neptune/workflows/internal/pr/workflow.go
@@ -35,6 +35,6 @@ func Workflow(ctx workflow.Context, request Request, tfWorkflow revision.TFWorkf
 			Mode:                 tfModel.PR,
 		},
 	}
-	runner := newRunner(ctx, scope, tfWorkflow, notifiers)
+	runner := newRunner(ctx, scope, tfWorkflow, request.PRNum, notifiers)
 	return runner.Run(ctx)
 }


### PR DESCRIPTION
Uses github state to determine if we are able to shutdown the PR workflow (i.e. if PR is in a closed state)