### PR TITLE
Rename check run to pr mode

### DIFF
--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -151,7 +151,7 @@ func (n *CheckRunNotifier) updateCheckRun(ctx workflow.Context, workflowState *s
 	if n.Mode == terraform.Deploy {
 		title = BuildDeployCheckRunTitle(info.RootName)
 	} else {
-		title = BuildPlanCheckRunTitle(info.RootName)
+		title = BuildPRCheckRunTitle(info.RootName)
 	}
 
 	request := GithubCheckRunRequest{
@@ -221,6 +221,6 @@ func BuildDeployCheckRunTitle(rootName string) string {
 	return fmt.Sprintf("atlantis/deploy: %s", rootName)
 }
 
-func BuildPlanCheckRunTitle(rootName string) string {
-	return fmt.Sprintf("atlantis/plan: %s", rootName)
+func BuildPRCheckRunTitle(rootName string) string {
+	return fmt.Sprintf("atlantis/pr: %s", rootName)
 }


### PR DESCRIPTION
Easier to monitor and compare both legacy and new check run modes during rollout + may be confusing for users to keep old check run name but give it new functionalities.