### PR TITLE
Add PR mode envs to PR workflow validate step

### DIFF
--- a/server/neptune/gateway/event/pull_request_handler.go
+++ b/server/neptune/gateway/event/pull_request_handler.go
@@ -147,6 +147,8 @@ func (p *ModifiedPullHandler) handlePlatformMode(ctx context.Context, event Pull
 		Repo:              event.Pull.HeadRepo,
 		InstallationToken: event.InstallationToken,
 		Branch:            event.Pull.HeadBranch,
+		// TODO: gate populating field with a config since this is Lyft specific
+		ValidateEnvs: buildValidateEnvs(event),
 	}
 	run, err := p.PRSignaler.SignalWithStartWorkflow(ctx, roots, prRequest)
 	if err != nil {
@@ -156,4 +158,16 @@ func (p *ModifiedPullHandler) handlePlatformMode(ctx context.Context, event Pull
 		"workflow-id": run.GetID(), "run-id": run.GetRunID(),
 	})
 	return nil
+}
+
+func buildValidateEnvs(event PullRequest) []pr.ValidateEnvs {
+	return []pr.ValidateEnvs{
+		{
+			Username:       event.User.Username,
+			PullNum:        event.Pull.Num,
+			PullAuthor:     event.Pull.Author,
+			HeadCommit:     event.Pull.HeadCommit,
+			BaseBranchName: event.Pull.HeadRepo.DefaultBranch,
+		},
+	}
 }

--- a/server/neptune/gateway/event/pull_request_handler_test.go
+++ b/server/neptune/gateway/event/pull_request_handler_test.go
@@ -50,6 +50,7 @@ func TestModifiedPullHandler_Handle_SignalerFailure(t *testing.T) {
 		Name:         "platform",
 		WorkflowMode: valid.PlatformWorkflowMode,
 	}
+	prRequest := pr.Request{ValidateEnvs: []pr.ValidateEnvs{{}}}
 	pullHandler := event.ModifiedPullHandler{
 		Logger:             logger,
 		Scheduler:          &sync.SynchronousScheduler{Logger: logger},
@@ -65,9 +66,10 @@ func TestModifiedPullHandler_Handle_SignalerFailure(t *testing.T) {
 			expectedT:        t,
 		},
 		PRSignaler: &mockPRSignaler{
-			error:         assert.AnError,
-			expectedRoots: []*valid.MergedProjectCfg{root},
-			expectedT:     t,
+			error:             assert.AnError,
+			expectedRoots:     []*valid.MergedProjectCfg{root},
+			expectedT:         t,
+			expectedPRRequest: prRequest,
 		},
 		Allocator: &testFeatureAllocator{Enabled: true},
 	}
@@ -121,6 +123,12 @@ func TestModifiedPullHandler_Handle_BranchStrategy(t *testing.T) {
 		Repo:              testRepo,
 		InstallationToken: 0,
 		Branch:            "branch",
+		ValidateEnvs: []pr.ValidateEnvs{
+			{
+				HeadCommit:     "sha",
+				BaseBranchName: testRepo.DefaultBranch,
+			},
+		},
 	}
 	signaler := &mockPRSignaler{
 		expectedRoots:     []*valid.MergedProjectCfg{},
@@ -164,6 +172,12 @@ func TestModifiedPullHandler_Handle_MergeStrategy(t *testing.T) {
 		Repo:              testRepo,
 		InstallationToken: 0,
 		Branch:            "branch",
+		ValidateEnvs: []pr.ValidateEnvs{
+			{
+				HeadCommit:     "sha",
+				BaseBranchName: testRepo.DefaultBranch,
+			},
+		},
 	}
 	signaler := &mockPRSignaler{
 		expectedRoots:     []*valid.MergedProjectCfg{root},


### PR DESCRIPTION
These envs are useful for us when running the Validate step. Rather than inject all of this PR mode metadata into the child Terraform workflow, since these env variables are really only useful to Lyft's PR mode atlantis workflows, I wanted to prepend these as extra env steps that will eventually be generated when a config enables it.

Alternative would be to modify the Terraform workflow to now also receive more PR level metadata to inject as default env values when its parent is a PR workflow. This approach seemed cleaner and easier to implement will less invasive changes.