### PR TITLE
Gate mutation in legacy

### DIFF
--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -406,6 +406,12 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
   true: true
   false: false
   default: false
+  trackEvents: false
+legacy-deprecation:
+  percentage: 100
+  true: true
+  false: false
+  default: false
   trackEvents: false`)
 	if testing.Short() {
 		t.SkipNow()
@@ -562,6 +568,12 @@ func TestGitHubWorkflowWithPolicyCheck(t *testing.T) {
 
 func TestGitHubWorkflowPullRequestsWorkflows(t *testing.T) {
 	featureConfig := feature.StringRetriever(`platform-mode:
+  percentage: 100
+  true: true
+  false: false
+  default: false
+  trackEvents: false
+legacy-deprecation:
   percentage: 100
   true: true
   false: false

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -837,7 +837,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		members: []string{},
 	}
 	reviewDismisser := &mockReviewDismisser{}
-	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, featureAllocator, globalCfg.PolicySets.PolicySets)
+	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, featureAllocator, globalCfg.PolicySets.PolicySets, ctxLogger)
 	conftestExecutor := &policy.ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
 		PolicyFilter: policyFilter,

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -825,7 +825,7 @@ func setupE2E(t *testing.T, repoFixtureDir string, userConfig *server.UserConfig
 		members: []string{},
 	}
 	reviewDismisser := &mockReviewDismisser{}
-	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, globalCfg.PolicySets.PolicySets)
+	policyFilter := events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, featureAllocator, globalCfg.PolicySets.PolicySets)
 	conftestExecutor := &policy.ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
 		PolicyFilter: policyFilter,

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -7,6 +7,7 @@ import (
 	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"path/filepath"
@@ -39,7 +40,7 @@ type ConfTestExecutor struct {
 	PolicyFilter policyFilter
 }
 
-func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets, allocator feature.Allocator) *ConfTestExecutor {
+func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets, allocator feature.Allocator, logger logging.Logger) *ConfTestExecutor {
 	reviewFetcher := &github.PRReviewFetcher{
 		ClientCreator: creator,
 	}
@@ -52,7 +53,7 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.Polic
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamMemberFetcher, allocator, policySets.PolicySets),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamMemberFetcher, allocator, policySets.PolicySets, logger),
 	}
 }
 

--- a/server/core/runtime/policy/conftest_executor.go
+++ b/server/core/runtime/policy/conftest_executor.go
@@ -7,6 +7,7 @@ import (
 	runtime_models "github.com/runatlantis/atlantis/server/core/runtime/models"
 	"github.com/runatlantis/atlantis/server/events"
 	"github.com/runatlantis/atlantis/server/events/metrics"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
 	"path/filepath"
 	"strings"
@@ -38,7 +39,7 @@ type ConfTestExecutor struct {
 	PolicyFilter policyFilter
 }
 
-func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets) *ConfTestExecutor {
+func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.PolicySets, allocator feature.Allocator) *ConfTestExecutor {
 	reviewFetcher := &github.PRReviewFetcher{
 		ClientCreator: creator,
 	}
@@ -51,7 +52,7 @@ func NewConfTestExecutor(creator githubapp.ClientCreator, policySets valid.Polic
 	}
 	return &ConfTestExecutor{
 		Exec:         runtime_models.LocalExec{},
-		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamMemberFetcher, policySets.PolicySets),
+		PolicyFilter: events.NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamMemberFetcher, allocator, policySets.PolicySets),
 	}
 }
 

--- a/server/events/command/vcs_legacy_wrapper.go
+++ b/server/events/command/vcs_legacy_wrapper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 )
 
@@ -16,6 +17,7 @@ type delegate interface {
 type LegacyDeprecationVCSStatusUpdater struct {
 	Delegate  delegate
 	Allocator feature.Allocator
+	Logger    logging.Logger
 }
 
 func (l *LegacyDeprecationVCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error) {
@@ -27,6 +29,7 @@ func (l *LegacyDeprecationVCSStatusUpdater) UpdateCombined(ctx context.Context, 
 	}
 	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
 	if shouldAllocate {
+		l.Logger.InfoContext(ctx, "legacy deprecation feature flag enabled, not updating check runs")
 		return "", nil
 	}
 	return l.Delegate.UpdateCombined(ctx, repo, pull, status, cmdName, statusID, output)
@@ -41,6 +44,7 @@ func (l *LegacyDeprecationVCSStatusUpdater) UpdateCombinedCount(ctx context.Cont
 	}
 	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
 	if shouldAllocate {
+		l.Logger.InfoContext(ctx, "legacy deprecation feature flag enabled, not updating check runs")
 		return "", nil
 	}
 	return l.Delegate.UpdateCombinedCount(ctx, repo, pull, status, cmdName, numSuccess, numTotal, statusID)
@@ -55,6 +59,7 @@ func (l *LegacyDeprecationVCSStatusUpdater) UpdateProject(ctx context.Context, p
 	}
 	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
 	if shouldAllocate {
+		l.Logger.InfoContext(ctx, "legacy deprecation feature flag enabled, not updating project check run")
 		return "", nil
 	}
 	return l.Delegate.UpdateProject(ctx, projectCtx, cmdName, status, url, statusID)

--- a/server/events/command/vcs_legacy_wrapper.go
+++ b/server/events/command/vcs_legacy_wrapper.go
@@ -1,0 +1,61 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+)
+
+type delegate interface {
+	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error)
+	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error)
+	UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.VCSStatus, url string, statusID string) (string, error)
+}
+type LegacyDeprecationVCSStatusUpdater struct {
+	Delegate  delegate
+	Allocator feature.Allocator
+}
+
+func (l *LegacyDeprecationVCSStatusUpdater) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error) {
+	shouldAllocate, err := l.Allocator.ShouldAllocate(feature.LegacyDeprecation, feature.FeatureContext{
+		RepoName: repo.FullName,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "unable to allocate legacy deprecation feature flag")
+	}
+	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
+	if shouldAllocate {
+		return "", nil
+	}
+	return l.Delegate.UpdateCombined(ctx, repo, pull, status, cmdName, statusID, output)
+}
+
+func (l *LegacyDeprecationVCSStatusUpdater) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error) {
+	shouldAllocate, err := l.Allocator.ShouldAllocate(feature.LegacyDeprecation, feature.FeatureContext{
+		RepoName: repo.FullName,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "unable to allocate legacy deprecation feature flag")
+	}
+	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
+	if shouldAllocate {
+		return "", nil
+	}
+	return l.Delegate.UpdateCombinedCount(ctx, repo, pull, status, cmdName, numSuccess, numTotal, statusID)
+}
+
+func (l *LegacyDeprecationVCSStatusUpdater) UpdateProject(ctx context.Context, projectCtx ProjectContext, cmdName fmt.Stringer, status models.VCSStatus, url string, statusID string) (string, error) {
+	shouldAllocate, err := l.Allocator.ShouldAllocate(feature.LegacyDeprecation, feature.FeatureContext{
+		RepoName: projectCtx.HeadRepo.FullName,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "unable to allocate legacy deprecation feature flag")
+	}
+	// if legacy deprecation is enabled, don't mutate check runs in legacy workflow
+	if shouldAllocate {
+		return "", nil
+	}
+	return l.Delegate.UpdateProject(ctx, projectCtx, cmdName, status, url, statusID)
+}

--- a/server/events/command/vcs_legacy_wrapper_test.go
+++ b/server/events/command/vcs_legacy_wrapper_test.go
@@ -1,0 +1,108 @@
+package command_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLegacyDeprecationVCSStatusUpdater_NotAllocated(t *testing.T) {
+	testID := "abc"
+	delegate := &testDelegate{ID: testID}
+	subject := command.LegacyDeprecationVCSStatusUpdater{
+		Allocator: &testFeatureAllocator{},
+		Delegate:  delegate,
+	}
+	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
+	assert.NoError(t, err)
+	assert.Equal(t, id, testID)
+	assert.True(t, delegate.Called)
+
+	id, err = subject.UpdateCombined(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, id, testID)
+	assert.True(t, delegate.Called)
+
+	id, err = subject.UpdateProject(context.Background(), command.ProjectContext{}, command.Plan, models.QueuedVCSStatus, "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, id, testID)
+	assert.True(t, delegate.Called)
+}
+
+func TestLegacyDeprecationVCSStatusUpdater_Allocated(t *testing.T) {
+	delegate := &testDelegate{}
+	subject := command.LegacyDeprecationVCSStatusUpdater{
+		Allocator: &testFeatureAllocator{Enabled: true},
+		Delegate:  delegate,
+	}
+	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
+	assert.NoError(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+
+	id, err = subject.UpdateCombined(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, "", "")
+	assert.NoError(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+
+	id, err = subject.UpdateProject(context.Background(), command.ProjectContext{}, command.Plan, models.QueuedVCSStatus, "", "")
+	assert.NoError(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+}
+
+func TestLegacyDeprecationVCSStatusUpdater_AllocatorError(t *testing.T) {
+	delegate := &testDelegate{}
+	subject := command.LegacyDeprecationVCSStatusUpdater{
+		Allocator: &testFeatureAllocator{Err: assert.AnError},
+		Delegate:  delegate,
+	}
+	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
+	assert.Error(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+
+	id, err = subject.UpdateCombined(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, "", "")
+	assert.Error(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+
+	id, err = subject.UpdateProject(context.Background(), command.ProjectContext{}, command.Plan, models.QueuedVCSStatus, "", "")
+	assert.Error(t, err)
+	assert.Empty(t, id)
+	assert.False(t, delegate.Called)
+}
+
+type testDelegate struct {
+	ID     string
+	Err    error
+	Called bool
+}
+
+func (d *testDelegate) UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error) {
+	d.Called = true
+	return d.ID, d.Err
+}
+
+func (d *testDelegate) UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error) {
+	d.Called = true
+	return d.ID, d.Err
+}
+
+func (d *testDelegate) UpdateProject(ctx context.Context, projectCtx command.ProjectContext, cmdName fmt.Stringer, status models.VCSStatus, url string, statusID string) (string, error) {
+	d.Called = true
+	return d.ID, d.Err
+}
+
+type testFeatureAllocator struct {
+	Enabled bool
+	Err     error
+}
+
+func (t *testFeatureAllocator) ShouldAllocate(featureID feature.Name, featureCtx feature.FeatureContext) (bool, error) {
+	return t.Enabled, t.Err
+}

--- a/server/events/command/vcs_legacy_wrapper_test.go
+++ b/server/events/command/vcs_legacy_wrapper_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -16,6 +17,7 @@ func TestLegacyDeprecationVCSStatusUpdater_NotAllocated(t *testing.T) {
 	subject := command.LegacyDeprecationVCSStatusUpdater{
 		Allocator: &testFeatureAllocator{},
 		Delegate:  delegate,
+		Logger:    logging.NewNoopCtxLogger(t),
 	}
 	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
 	assert.NoError(t, err)
@@ -38,6 +40,7 @@ func TestLegacyDeprecationVCSStatusUpdater_Allocated(t *testing.T) {
 	subject := command.LegacyDeprecationVCSStatusUpdater{
 		Allocator: &testFeatureAllocator{Enabled: true},
 		Delegate:  delegate,
+		Logger:    logging.NewNoopCtxLogger(t),
 	}
 	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
 	assert.NoError(t, err)
@@ -60,6 +63,7 @@ func TestLegacyDeprecationVCSStatusUpdater_AllocatorError(t *testing.T) {
 	subject := command.LegacyDeprecationVCSStatusUpdater{
 		Allocator: &testFeatureAllocator{Err: assert.AnError},
 		Delegate:  delegate,
+		Logger:    logging.NewNoopCtxLogger(t),
 	}
 	id, err := subject.UpdateCombinedCount(context.Background(), models.Repo{}, models.PullRequest{}, models.QueuedVCSStatus, command.Plan, 0, 0, "")
 	assert.Error(t, err)

--- a/server/events/policy_filter.go
+++ b/server/events/policy_filter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 )
 
@@ -29,6 +30,7 @@ type ApprovedPolicyFilter struct {
 	teamMemberFetcher teamMemberFetcher
 	allocator         feature.Allocator
 	policies          []valid.PolicySet
+	logger            logging.Logger
 }
 
 func NewApprovedPolicyFilter(
@@ -36,13 +38,15 @@ func NewApprovedPolicyFilter(
 	prReviewDismisser prReviewDismisser,
 	teamMemberFetcher teamMemberFetcher,
 	allocator feature.Allocator,
-	policySets []valid.PolicySet) *ApprovedPolicyFilter {
+	policySets []valid.PolicySet,
+	logger logging.Logger) *ApprovedPolicyFilter {
 	return &ApprovedPolicyFilter{
 		prReviewFetcher:   prReviewFetcher,
 		prReviewDismisser: prReviewDismisser,
 		teamMemberFetcher: teamMemberFetcher,
 		policies:          policySets,
 		allocator:         allocator,
+		logger:            logger,
 	}
 }
 
@@ -91,6 +95,7 @@ func (p *ApprovedPolicyFilter) dismissStalePRReviews(ctx context.Context, instal
 	}
 	// if legacy deprecation is enabled, don't dismiss stale PR reviews in legacy workflow
 	if shouldAllocate {
+		p.logger.InfoContext(ctx, "legacy deprecation feature flag enabled, not dismissing stale PR reviews")
 		return nil
 	}
 

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -33,7 +34,7 @@ func TestFilter_Approved(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -62,7 +63,7 @@ func TestFilter_NotApproved(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -88,7 +89,7 @@ func TestFilter_DismissalBlockedByFeatureAllocator(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{Enabled: true}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{Enabled: true}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -114,7 +115,7 @@ func TestFilter_NotApproved_Dismissal(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -134,7 +135,7 @@ func TestFilter_NoFailedPolicies(t *testing.T) {
 	reviewDismisser := &mockReviewDismisser{}
 
 	var failedPolicies []valid.PolicySet
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -154,7 +155,7 @@ func TestFilter_FailedListLatestApprovalUsernames(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -174,7 +175,7 @@ func TestFilter_FailedListApprovalReviews(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -196,7 +197,7 @@ func TestFilter_FailedTeamMemberFetch(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -224,7 +225,7 @@ func TestFilter_FailedDismiss(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies, logging.NewNoopCtxLogger(t))
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)

--- a/server/events/policy_filter_test.go
+++ b/server/events/policy_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
+	"github.com/runatlantis/atlantis/server/lyft/feature"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -32,7 +33,7 @@ func TestFilter_Approved(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -61,12 +62,38 @@ func TestFilter_NotApproved(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
 	assert.True(t, reviewFetcher.listApprovalsIsCalled)
 	assert.True(t, teamFetcher.isCalled)
+	assert.False(t, reviewDismisser.isCalled)
+	assert.Equal(t, failedPolicies, filteredPolicies)
+}
+
+func TestFilter_DismissalBlockedByFeatureAllocator(t *testing.T) {
+	reviewFetcher := &mockReviewFetcher{
+		reviews: []*github.PullRequestReview{
+			{
+				User: &github.User{Login: github.String(ownerA)},
+			},
+		},
+	}
+	teamFetcher := &mockTeamMemberFetcher{
+		members: []string{ownerA},
+	}
+	reviewDismisser := &mockReviewDismisser{}
+	failedPolicies := []valid.PolicySet{
+		{Name: policyName, Owner: policyOwner},
+	}
+
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{Enabled: true}, failedPolicies)
+	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
+	assert.NoError(t, err)
+	assert.False(t, reviewFetcher.listUsernamesIsCalled)
+	assert.False(t, reviewFetcher.listApprovalsIsCalled)
+	assert.False(t, teamFetcher.isCalled)
 	assert.False(t, reviewDismisser.isCalled)
 	assert.Equal(t, failedPolicies, filteredPolicies)
 }
@@ -87,7 +114,7 @@ func TestFilter_NotApproved_Dismissal(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -107,7 +134,7 @@ func TestFilter_NoFailedPolicies(t *testing.T) {
 	reviewDismisser := &mockReviewDismisser{}
 
 	var failedPolicies []valid.PolicySet
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.NoError(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -127,7 +154,7 @@ func TestFilter_FailedListLatestApprovalUsernames(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -147,7 +174,7 @@ func TestFilter_FailedListApprovalReviews(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.CommentTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -169,7 +196,7 @@ func TestFilter_FailedTeamMemberFetch(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.PRReviewTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.True(t, reviewFetcher.listUsernamesIsCalled)
@@ -197,7 +224,7 @@ func TestFilter_FailedDismiss(t *testing.T) {
 		{Name: policyName, Owner: policyOwner},
 	}
 
-	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, failedPolicies)
+	policyFilter := NewApprovedPolicyFilter(reviewFetcher, reviewDismisser, teamFetcher, &testFeatureAllocator{}, failedPolicies)
 	filteredPolicies, err := policyFilter.Filter(context.Background(), 0, models.Repo{}, 0, command.AutoTrigger, failedPolicies)
 	assert.Error(t, err)
 	assert.False(t, reviewFetcher.listUsernamesIsCalled)
@@ -245,4 +272,13 @@ type mockTeamMemberFetcher struct {
 func (m *mockTeamMemberFetcher) ListTeamMembers(_ context.Context, _ int64, _ string) ([]string, error) {
 	m.isCalled = true
 	return m.members, m.error
+}
+
+type testFeatureAllocator struct {
+	Enabled bool
+	Err     error
+}
+
+func (t *testFeatureAllocator) ShouldAllocate(featureID feature.Name, featureCtx feature.FeatureContext) (bool, error) {
+	return t.Enabled, t.Err
 }

--- a/server/neptune/gateway/pr/signaler.go
+++ b/server/neptune/gateway/pr/signaler.go
@@ -169,6 +169,7 @@ func generatePRModeEnvSteps(cfg *valid.MergedProjectCfg, validateEnvs ValidateEn
 		},
 	}
 	if t, ok := cfg.Tags[Manifest]; ok {
+		//this is a Lyft specific env var
 		steps = append(steps, workflows.PRStep{
 			StepName:    EnvStep,
 			EnvVarName:  "MANIFEST_FILEPATH",

--- a/server/server.go
+++ b/server/server.go
@@ -358,6 +358,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			},
 			DefaultDetailsURL: userConfig.DefaultCheckrunDetailsURL,
 		},
+		Logger: ctxLogger,
 	}
 
 	binDir, err := mkSubDir(userConfig.DataDir, BinDirName)
@@ -592,7 +593,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 	}
 
 	conftestEnsurer := policy.NewConfTestVersionEnsurer(ctxLogger, binDir, &terraform.DefaultDownloader{})
-	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets, featureAllocator)
+	conftestExecutor := policy.NewConfTestExecutor(clientCreator, globalCfg.PolicySets, featureAllocator, ctxLogger)
 	policyCheckStepRunner, err := runtime.NewPolicyCheckStepRunner(
 		defaultTfVersion,
 		conftestEnsurer,


### PR DESCRIPTION
Code wraps atlantis mutations on UX experience (i.e. creating/updating check runs and dismissing stale PR reviews). Next PR will do the same for pr mode, but will instead check to see if the feature flag is not allocated.