### PR TITLE
Ignore update checkrun status allocator results for gateway

### DIFF
--- a/server/lyft/feature/allocator.go
+++ b/server/lyft/feature/allocator.go
@@ -113,3 +113,10 @@ func (r *PercentageBasedAllocator) ShouldAllocate(featureID Name, featureContext
 func (r *PercentageBasedAllocator) Close() {
 	r.featureFlag.Close()
 }
+
+type AlwaysFalseAllocator struct {
+}
+
+func (a *AlwaysFalseAllocator) ShouldAllocate(featureID Name, featureContext FeatureContext) (bool, error) {
+	return false, nil
+}

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -164,7 +164,11 @@ func NewServer(config Config) (*Server, error) {
 	}
 
 	mergeabilityChecker := vcs.NewLyftPullMergeabilityChecker(config.GithubStatusName)
-	rawGithubClient, err := vcs.NewGithubClient(config.GithubHostname, githubCredentials, ctxLogger, featureAllocator, mergeabilityChecker)
+	// Defaults to false, a bit hacky but a quick way to continue supporting updating check runs
+	// in gateway mode without having to refactor the legacy code too much.
+	// All of this will be removed once we deprecate legacy mode.
+	falseAllocator := &feature.AlwaysFalseAllocator{}
+	rawGithubClient, err := vcs.NewGithubClient(config.GithubHostname, githubCredentials, ctxLogger, falseAllocator, mergeabilityChecker)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We currently still want to update check runs when the request to do so is made within [gateway](https://github.com/lyft/atlantis/blob/release-v0.17.3-lyft.1/server/neptune/gateway/event/legacy_handler.go#L34-L50). This is an easy way to do this without refactoring a lot of legacy code that will be deleted soon.