### PR TITLE
Clean up legacy roots from comment handler

### DIFF
--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -63,7 +63,7 @@ func NewVCSEventsController(
 	pullEventSNSProxy := gateway_handlers.NewSNSWorkerProxy(
 		snsWriter, logger,
 	)
-	legacyHandler := &gateway_handlers.LegacyHandler{
+	legacyHandler := &gateway_handlers.LegacyPullHandler{
 		Logger:           logger,
 		WorkerProxy:      pullEventSNSProxy,
 		VCSStatusUpdater: vcsStatusUpdater,
@@ -109,14 +109,13 @@ func NewVCSEventsController(
 		repoAllowlistChecker,
 		vcsClient,
 		gateway_handlers.NewCommentEventWorkerProxy(
-			logger, scope.SubScope("comment"),
+			logger,
 			snsWriter,
-			featureAllocator, asyncScheduler,
+			asyncScheduler,
 			deploySignaler, vcsClient,
-			vcsStatusUpdater, globalCfg,
+			vcsStatusUpdater,
 			rootConfigBuilder, errorHandler,
-			requirementChecker,
-		),
+			requirementChecker),
 		logger,
 	)
 

--- a/server/lyft/gateway/events_controller.go
+++ b/server/lyft/gateway/events_controller.go
@@ -113,7 +113,7 @@ func NewVCSEventsController(
 			snsWriter,
 			asyncScheduler,
 			deploySignaler, vcsClient,
-			vcsStatusUpdater,
+			vcsStatusUpdater, globalCfg,
 			rootConfigBuilder, errorHandler,
 			requirementChecker),
 		logger,

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -1,30 +1,24 @@
 package event
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/runatlantis/atlantis/server/core/config/valid"
-	"github.com/runatlantis/atlantis/server/lyft/feature"
-	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
-	"github.com/runatlantis/atlantis/server/neptune/sync"
-	"github.com/runatlantis/atlantis/server/neptune/workflows"
-	"github.com/uber-go/tally/v4"
-
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/http"
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/config"
+	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/requirement"
+	"github.com/runatlantis/atlantis/server/neptune/sync"
+	"github.com/runatlantis/atlantis/server/neptune/workflows"
 )
 
 const warningMessage = "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and confirm the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n"
-
-type LegacyApplyCommentInput struct{}
 
 type statusUpdater interface {
 	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error)
@@ -71,33 +65,17 @@ func (c Comment) GetRepo() models.Repo {
 	return c.BaseRepo
 }
 
-func NewCommentEventWorkerProxy(
-	logger logging.Logger,
-	scope tally.Scope,
-	snsWriter Writer,
-	allocator feature.Allocator,
-	scheduler scheduler,
-	signaler deploySignaler,
-	commentCreator commentCreator,
-	vcsStatusUpdater statusUpdater,
-	globalCfg valid.GlobalCfg,
-	rootConfigBuilder rootConfigBuilder,
-	errorHandler errorHandler,
-	requirementChecker requirementChecker,
-) *CommentEventWorkerProxy {
+func NewCommentEventWorkerProxy(logger logging.Logger, snsWriter Writer, scheduler scheduler, deploySignaler deploySignaler, commentCreator commentCreator, vcsStatusUpdater statusUpdater, rootConfigBuilder rootConfigBuilder, errorHandler errorHandler, requirementChecker requirementChecker) *CommentEventWorkerProxy {
 	return &CommentEventWorkerProxy{
 		logger:    logger,
-		allocator: allocator,
 		scheduler: scheduler,
-		snsWorkerProxy: &SNSWorkerProxy{
-			logger:           logger,
-			vcsStatusUpdater: vcsStatusUpdater,
-			snsWriter:        snsWriter,
-			globalCfg:        globalCfg,
+		legacyHandler: &LegacyCommentHandler{
+			logger:    logger,
+			snsWriter: snsWriter,
 		},
 		neptuneWorkerProxy: &NeptuneWorkerProxy{
 			logger:             logger,
-			signaler:           signaler,
+			deploySignaler:     deploySignaler,
 			commentCreator:     commentCreator,
 			requirementChecker: requirementChecker,
 		},
@@ -109,13 +87,14 @@ func NewCommentEventWorkerProxy(
 
 type NeptuneWorkerProxy struct {
 	logger             logging.Logger
-	signaler           deploySignaler
+	deploySignaler     deploySignaler
 	commentCreator     commentCreator
 	requirementChecker requirementChecker
 }
 
-func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg) error {
+func (p *NeptuneWorkerProxy) Handle(ctx context.Context, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg) error {
 	// currently the only comments on platform mode are applies, we can add to this as necessary.
+	// TODO: in followup PR, we will modify this to support both plan and applies
 	if cmd.Name != command.Apply {
 		return nil
 	}
@@ -125,13 +104,11 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 		Force: cmd.ForceApply,
 	}
 
-	platformModeRoots := partitionRootsByMode(valid.PlatformWorkflowMode, roots)
-
 	if cmd.IsForSpecificProject() {
-		platformModeRoots = partitionRootsByProject(cmd.ProjectName, platformModeRoots)
+		roots = partitionRootsByProject(cmd.ProjectName, roots)
 	}
 
-	if len(platformModeRoots) == 0 {
+	if len(roots) == 0 {
 		p.logger.WarnContext(ctx, "no platform mode roots detected")
 		return nil
 	}
@@ -143,14 +120,12 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 		InstallationToken: event.InstallationToken,
 		TriggerInfo:       triggerInfo,
 		OptionalPull:      &event.Pull,
-		Roots:             platformModeRoots,
+		Roots:             roots,
 	}); err != nil {
 		return errors.Wrap(err, "checking deploy requirements")
 	}
 
-	// let's only post a force apply comment on the PR, if we are only operating on project OR if we are operating on all projects and
-	// if we're fully on platform mode, otherwise there will be duplicates from the legacy worker and this.
-	if cmd.ForceApply && (cmd.IsForSpecificProject() || len(platformModeRoots) == len(roots)) {
+	if cmd.ForceApply {
 		if err := p.commentCreator.CreateComment(event.BaseRepo, event.PullNum, warningMessage, ""); err != nil {
 			p.logger.ErrorContext(ctx, err.Error())
 		}
@@ -166,8 +141,8 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 		TriggerInfo:       triggerInfo,
 	}
 
-	for _, r := range platformModeRoots {
-		_, err := p.signaler.SignalWithStartWorkflow(ctx, r, opts)
+	for _, r := range roots {
+		_, err := p.deploySignaler.SignalWithStartWorkflow(ctx, r, opts)
 		if err != nil {
 			return errors.Wrap(err, "signalling workflow")
 		}
@@ -175,108 +150,20 @@ func (p *NeptuneWorkerProxy) Handle(ctx context.Context, request *http.BufferedR
 	return nil
 }
 
-type SNSWorkerProxy struct {
-	logger           logging.Logger
-	vcsStatusUpdater statusUpdater
-	snsWriter        Writer
-	globalCfg        valid.GlobalCfg
-}
-
-func (p *SNSWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg) error {
-	defaultModeRoots := partitionRootsByMode(valid.DefaultWorkflowMode, roots)
-
-	// cut off force applies here itself, since the legacy worker doesn't check the root workflow mode type before attempting
-	// a force apply
-	if len(defaultModeRoots) == 0 && cmd.ForceApply {
-		p.logger.InfoContext(ctx, "no default mode roots to force apply")
-		return nil
-	}
-
-	// only set queued status if we have default mode roots, we don't currently need this in the temporal world
-	// but this is subject to change
-	if len(defaultModeRoots) > 0 {
-		p.SetQueuedStatus(ctx, event, cmd)
-	}
-
-	// forward everything to sns for now since platform mode doesn't do anything w.r.t to comments atm.
-	if err := p.ForwardToSns(ctx, request); err != nil {
-		return errors.Wrap(err, "forwarding request through sns")
-	}
-	return nil
-}
-
-func (p *SNSWorkerProxy) ForwardToSns(ctx context.Context, request *http.BufferedRequest) error {
-	buffer := bytes.NewBuffer([]byte{})
-	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
-		return errors.Wrap(err, "writing request to buffer")
-	}
-
-	if err := p.snsWriter.WriteWithContext(ctx, buffer.Bytes()); err != nil {
-		return errors.Wrap(err, "writing buffer to sns")
-	}
-	p.logger.InfoContext(ctx, "proxied request to sns")
-
-	return nil
-}
-
-func (p *SNSWorkerProxy) SetQueuedStatus(ctx context.Context, event Comment, cmd *command.Comment) {
-	if p.shouldMarkEventQueued(event, cmd) {
-		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Request received. Adding to the queue..."); err != nil {
-			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
-		}
-	}
-}
-
-func (p *SNSWorkerProxy) shouldMarkEventQueued(event Comment, cmd *command.Comment) bool {
-	// pending status should only be for plan and apply step
-	if cmd.Name != command.Plan && cmd.Name != command.Apply {
-		return false
-	}
-	// pull event should not be from a fork
-	if event.Pull.HeadRepo.Owner != event.Pull.BaseRepo.Owner {
-		return false
-	}
-	// pull event should not be from closed PR
-	if event.Pull.State == models.ClosedPullState {
-		return false
-	}
-	// pull event should not use an invalid base branch
-	repo := p.globalCfg.MatchingRepo(event.Pull.BaseRepo.ID())
-	return repo.BranchMatches(event.Pull.BaseBranch)
-}
-
 type CommentEventWorkerProxy struct {
 	logger             logging.Logger
-	allocator          feature.Allocator
 	scheduler          scheduler
 	vcsStatusUpdater   statusUpdater
 	rootConfigBuilder  rootConfigBuilder
-	snsWorkerProxy     *SNSWorkerProxy
+	legacyHandler      *LegacyCommentHandler
 	neptuneWorkerProxy *NeptuneWorkerProxy
 	errorHandler       errorHandler
 }
 
 func (p *CommentEventWorkerProxy) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
-	shouldAllocate, err := p.allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{
-		RepoName: event.BaseRepo.FullName,
-	})
-
-	// typically we shouldn't be failing if we can't figure out the feature, however, there is some complex logic
-	// that depends on us knowing which mode we are running on so in order to prevent unintended consequences, let's just
-	// bail if this happens.
-	if err != nil {
-		p.logger.ErrorContext(ctx, "unable to allocate platform mode")
-		return errors.Wrap(err, "unable to allocate platform mode feature")
-	}
-
-	if !shouldAllocate {
-		return p.handleLegacyComment(ctx, request, event, cmd)
-	}
-
 	executor := p.errorHandler.WrapWithHandling(ctx, event, cmd.CommandName().String(), func(ctx context.Context) error {
 		return p.handle(ctx, request, event, cmd)
 	})
-
 	return errors.Wrap(p.scheduler.Schedule(ctx, executor), "scheduling handle")
 }
 
@@ -301,16 +188,17 @@ func (p *CommentEventWorkerProxy) handle(ctx context.Context, request *http.Buff
 		return nil
 	}
 
-	if err := p.snsWorkerProxy.Handle(ctx, request, event, cmd, roots); err != nil {
+	if err := p.legacyHandler.Handle(ctx, request, cmd); err != nil {
 		return errors.Wrap(err, "handling event in legacy sns worker handler")
 	}
-	if err := p.neptuneWorkerProxy.Handle(ctx, request, event, cmd, roots); err != nil {
+	if err := p.neptuneWorkerProxy.Handle(ctx, event, cmd, roots); err != nil {
 		return errors.Wrap(err, "handling event in signal temporal worker handler")
 	}
 
 	return nil
 }
 
+// TODO: do we need to keep marking plan as successful after legacy deprecation?
 func (p *CommentEventWorkerProxy) markSuccessStatuses(ctx context.Context, event Comment, cmd *command.Comment) {
 	if cmd.Name == command.Plan {
 		for _, name := range []command.Name{command.Plan, command.PolicyCheck, command.Apply} {
@@ -327,17 +215,6 @@ func (p *CommentEventWorkerProxy) markSuccessStatuses(ctx context.Context, event
 	}
 }
 
-func partitionRootsByMode(mode valid.WorkflowModeType, cmds []*valid.MergedProjectCfg) []*valid.MergedProjectCfg {
-	var cfgs []*valid.MergedProjectCfg
-	for _, cmd := range cmds {
-		if cmd.WorkflowMode == mode {
-			cfgs = append(cfgs, cmd)
-		}
-	}
-
-	return cfgs
-}
-
 func partitionRootsByProject(name string, cmds []*valid.MergedProjectCfg) []*valid.MergedProjectCfg {
 	var cfgs []*valid.MergedProjectCfg
 	for _, cmd := range cmds {
@@ -345,11 +222,5 @@ func partitionRootsByProject(name string, cmds []*valid.MergedProjectCfg) []*val
 			cfgs = append(cfgs, cmd)
 		}
 	}
-
 	return cfgs
-}
-
-func (p *CommentEventWorkerProxy) handleLegacyComment(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
-	p.snsWorkerProxy.SetQueuedStatus(ctx, event, cmd)
-	return p.snsWorkerProxy.ForwardToSns(ctx, request)
 }

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -3,15 +3,12 @@ package event_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/lyft/feature"
-	"github.com/runatlantis/atlantis/server/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/config"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
@@ -106,204 +103,8 @@ func (d *testDeploySignaler) SignalWithStartWorkflow(ctx context.Context, cfg *v
 	return nil, nil
 }
 
-func TestCommentEventWorkerProxy_HandleAllocationError(t *testing.T) {
+func TestCommentEventWorkerProxy_HandleForceApply(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
-	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedError: assert.AnError,
-	}
-	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{}
-	testSignaler := &testDeploySignaler{}
-	rootConfigBuilder := &mockRootConfigBuilder{
-		expectedT: t,
-		expectedCommit: &config.RepoCommit{
-			Repo:          testRepo,
-			Branch:        testPull.HeadBranch,
-			Sha:           testPull.HeadCommit,
-			OptionalPRNum: testPull.Num,
-		},
-		expectedToken: 123,
-	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-	bufReq := buildRequest(t)
-	commentEvent := event.Comment{
-		Pull:     testPull,
-		BaseRepo: testRepo,
-	}
-	cmd := &command.Comment{
-		Name: command.Plan,
-	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
-	assert.Error(t, err)
-}
-
-func TestCommentEventWorkerProxy_HandleForceApply_default(t *testing.T) {
-	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
-	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-	}
-	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	testSignaler := &mockDeploySignaler{}
-	rootConfigBuilder := &mockRootConfigBuilder{
-		expectedT: t,
-		expectedCommit: &config.RepoCommit{
-			Repo:          testRepo,
-			Branch:        testPull.HeadBranch,
-			Sha:           testPull.HeadCommit,
-			OptionalPRNum: testPull.Num,
-		},
-		expectedToken: 123,
-		rootConfigs: []*valid.MergedProjectCfg{
-			{
-				Name:         "root1",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
-			{
-				Name:         "root2",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
-		},
-	}
-	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Apply.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
-
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-	bufReq := buildRequest(t)
-	commentEvent := event.Comment{
-		Pull:     testPull,
-		BaseRepo: testRepo,
-	}
-	cmd := &command.Comment{
-		Name:       command.Apply,
-		ForceApply: true,
-	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
-	assert.NoError(t, err)
-	assert.True(t, statusUpdater.isCalled)
-	assert.False(t, commentCreator.isCalled)
-	assert.False(t, testSignaler.called)
-	assert.True(t, writer.isCalled)
-}
-
-func TestCommentEventWorkerProxy_HandleForceApply_BothModes(t *testing.T) {
-	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
-	commentEvent := event.Comment{
-		Pull:     testPull,
-		PullNum:  testPull.Num,
-		BaseRepo: testRepo,
-		HeadRepo: testRepo,
-		User: models.User{
-			Username: "someuser",
-		},
-		InstallationToken: 123,
-	}
-	expectedOpts := deploy.RootDeployOptions{
-		Repo:              testRepo,
-		Branch:            testPull.HeadBranch,
-		Revision:          testPull.HeadCommit,
-		OptionalPullNum:   testPull.Num,
-		Sender:            commentEvent.User,
-		InstallationToken: commentEvent.InstallationToken,
-		TriggerInfo: workflows.DeployTriggerInfo{
-			Type:  workflows.ManualTrigger,
-			Force: true,
-		},
-	}
-	rootConfigBuilder := &mockRootConfigBuilder{
-		expectedT: t,
-		expectedCommit: &config.RepoCommit{
-			Repo:          testRepo,
-			Branch:        testPull.HeadBranch,
-			Sha:           testPull.HeadCommit,
-			OptionalPRNum: testPull.Num,
-		},
-		expectedToken: 123,
-		rootConfigs: []*valid.MergedProjectCfg{
-			{
-				Name:         "root1",
-				WorkflowMode: valid.PlatformWorkflowMode,
-			},
-			{
-				Name:         "root2",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
-		},
-	}
-	testSignaler := &testMultiDeploySignaler{
-		signalers: []*testDeploySignaler{
-			{
-				expectedT:   t,
-				expectedCfg: rootConfigBuilder.rootConfigs[0],
-				expOpts:     expectedOpts,
-			},
-		},
-	}
-	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
-	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Apply.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-	bufReq := buildRequest(t)
-
-	cmd := &command.Comment{
-		Name:       command.Apply,
-		ForceApply: true,
-	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
-	assert.NoError(t, err)
-	assert.False(t, commentCreator.isCalled)
-	assert.True(t, testSignaler.called())
-	assert.True(t, writer.isCalled)
-	assert.True(t, statusUpdater.isCalled)
-}
-
-func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
-	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	commentEvent := event.Comment{
 		Pull:     testPull,
 		PullNum:  testPull.Num,
@@ -361,14 +162,6 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 		},
 	}
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{
 		expectedT:       t,
@@ -377,14 +170,13 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 		expectedMessage: "⚠️ WARNING ⚠️\n\n You are force applying changes from your PR instead of merging into your default branch 🚀. This can have unpredictable consequences 🙏🏽 and should only be used in an emergency 🆘.\n\n To confirm behavior, review and confirm the plan within the generated atlantis/deploy GH check below.\n\n 𝐓𝐡𝐢𝐬 𝐚𝐜𝐭𝐢𝐨𝐧 𝐰𝐢𝐥𝐥 𝐛𝐞 𝐚𝐮𝐝𝐢𝐭𝐞𝐝.\n",
 	}
 	statusUpdater := &mockStatusUpdater{}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name:       command.Apply,
 		ForceApply: true,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
 	assert.True(t, commentCreator.isCalled)
 	assert.True(t, testSignaler.called())
@@ -392,10 +184,8 @@ func TestCommentEventWorkerProxy_HandleForceApply_AllPlatform(t *testing.T) {
 	assert.False(t, statusUpdater.isCalled)
 }
 
-func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode_RequirementsFailed(t *testing.T) {
+func TestCommentEventWorkerProxy_HandleApplyComment_RequirementsFailed(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -429,37 +219,26 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode_Requirements
 	testSignaler := &testDeploySignaler{}
 
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &mockStatusUpdater{}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{
 		err: assert.AnError,
 	})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.Error(t, err)
 	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
-	assert.True(t, writer.isCalled)
+	assert.False(t, writer.isCalled)
 }
 
-func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T) {
+func TestCommentEventWorkerProxy_HandleApplyComment(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -517,120 +296,24 @@ func TestCommentEventWorkerProxy_HandleApplyComment_AllPlatformMode(t *testing.T
 	}
 
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &mockStatusUpdater{}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
 	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.True(t, testSignaler.called())
-	assert.True(t, writer.isCalled)
-}
-
-func TestCommentEventWorkerProxy_HandleApplyComment_PartialMode(t *testing.T) {
-	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
-
-	rootConfigBuilder := &mockRootConfigBuilder{
-		expectedT: t,
-		expectedCommit: &config.RepoCommit{
-			Repo:          testRepo,
-			Branch:        testPull.HeadBranch,
-			Sha:           testPull.HeadCommit,
-			OptionalPRNum: testPull.Num,
-		},
-		expectedToken: 123,
-		rootConfigs: []*valid.MergedProjectCfg{
-			{
-				Name:         "root1",
-				WorkflowMode: valid.PlatformWorkflowMode,
-			},
-			{
-				Name:         "root2",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
-		},
-	}
-	commentEvent := event.Comment{
-		Pull:     testPull,
-		PullNum:  testPull.Num,
-		BaseRepo: testRepo,
-		HeadRepo: testRepo,
-		User: models.User{
-			Username: "someuser",
-		},
-		InstallationToken: 123,
-	}
-	expectedOpts := deploy.RootDeployOptions{
-		Repo:              testRepo,
-		Branch:            testPull.HeadBranch,
-		Revision:          testPull.HeadCommit,
-		OptionalPullNum:   testPull.Num,
-		Sender:            commentEvent.User,
-		InstallationToken: commentEvent.InstallationToken,
-		TriggerInfo: workflows.DeployTriggerInfo{
-			Type: workflows.ManualTrigger,
-		},
-	}
-	testSignaler := &testDeploySignaler{
-		expectedT:   t,
-		expectedCfg: rootConfigBuilder.rootConfigs[0],
-		expOpts:     expectedOpts,
-	}
-
-	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
-	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Apply.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-	bufReq := buildRequest(t)
-	cmd := &command.Comment{
-		Name: command.Apply,
-	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
-	assert.NoError(t, err)
-	assert.True(t, statusUpdater.isCalled)
-	assert.False(t, commentCreator.isCalled)
-	assert.True(t, testSignaler.called)
-	assert.True(t, writer.isCalled)
+	assert.False(t, writer.isCalled)
 }
 
 func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -653,14 +336,6 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 		InstallationToken: 123,
 	}
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &multiMockStatusUpdater{
@@ -691,13 +366,12 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 			},
 		},
 	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
 	assert.True(t, statusUpdater.AllCalled())
 	assert.False(t, commentCreator.isCalled)
@@ -707,8 +381,6 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 
 func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -731,14 +403,6 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 		InstallationToken: 123,
 	}
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &multiMockStatusUpdater{
@@ -753,13 +417,12 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 			},
 		},
 	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
 	assert.True(t, statusUpdater.AllCalled())
 	assert.False(t, commentCreator.isCalled)
@@ -767,10 +430,8 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 	assert.False(t, writer.isCalled)
 }
 
-func TestCommentEventWorkerProxy_HandlePlanComment_BothModes(t *testing.T) {
+func TestCommentEventWorkerProxy_HandlePlanComment(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -781,10 +442,6 @@ func TestCommentEventWorkerProxy_HandlePlanComment_BothModes(t *testing.T) {
 		},
 		expectedToken: 123,
 		rootConfigs: []*valid.MergedProjectCfg{
-			{
-				Name:         "root1",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
 			{
 				Name:         "root2",
 				WorkflowMode: valid.PlatformWorkflowMode,
@@ -803,33 +460,19 @@ func TestCommentEventWorkerProxy_HandlePlanComment_BothModes(t *testing.T) {
 		InstallationToken: 123,
 	}
 	writer := &mockSnsWriter{}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-		expectedAllocation: true,
-	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Plan.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
+		expectedT: t,
 	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
 	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
-	assert.True(t, statusUpdater.isCalled)
+	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
 	assert.True(t, writer.isCalled)
@@ -837,8 +480,6 @@ func TestCommentEventWorkerProxy_HandlePlanComment_BothModes(t *testing.T) {
 
 func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
 	rootConfigBuilder := &mockRootConfigBuilder{
 		expectedT: t,
 		expectedCommit: &config.RepoCommit{
@@ -848,205 +489,44 @@ func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 			OptionalPRNum: testPull.Num,
 		},
 		expectedToken: 123,
-	}
-	testSignaler := &testDeploySignaler{}
-	writer := &mockSnsWriter{
-		err: assert.AnError,
-	}
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-	}
-	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	rootDeployer := &mockRootDeployer{}
-	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Plan.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
-	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-	bufReq := buildRequest(t)
-	commentEvent := event.Comment{
-		Pull:     testPull,
-		BaseRepo: testRepo,
-	}
-	cmd := &command.Comment{
-		Name: command.Plan,
-	}
-	err = commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
-	assert.Error(t, err)
-	assert.True(t, statusUpdater.isCalled)
-	assert.False(t, commentCreator.isCalled)
-	assert.False(t, rootDeployer.isCalled)
-	assert.True(t, writer.isCalled)
-}
-
-func TestCommentEventWorkerProxy_HandleNoQueuedStatus(t *testing.T) {
-	logger := logging.NewNoopCtxLogger(t)
-	scope, _, err := metrics.NewLoggingScope(logger, "")
-	assert.NoError(t, err)
-	rootConfigBuilder := &mockRootConfigBuilder{
-		expectedT: t,
-		expectedCommit: &config.RepoCommit{
-			Repo:          testRepo,
-			Branch:        testPull.HeadBranch,
-			Sha:           testPull.HeadCommit,
-			OptionalPRNum: testPull.Num,
-		},
 		rootConfigs: []*valid.MergedProjectCfg{
-			{
-				Name:         "root1",
-				WorkflowMode: valid.DefaultWorkflowMode,
-			},
 			{
 				Name:         "root2",
 				WorkflowMode: valid.PlatformWorkflowMode,
 			},
 		},
 	}
-
+	testSignaler := &testDeploySignaler{}
+	writer := &mockSnsWriter{
+		err: assert.AnError,
+	}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
-	cfg := valid.NewGlobalCfg("somedir")
-	// add branch regex
-	cfg.Repos = []valid.Repo{
-		{
-			ID:          "/repo",
-			BranchRegex: regexp.MustCompile("regex"),
-		},
+	rootDeployer := &mockRootDeployer{}
+	commentCreator := &mockCommentCreator{}
+	statusUpdater := &mockStatusUpdater{
+		expectedT: t,
 	}
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, testSignaler, commentCreator, statusUpdater, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
-	allocator := &testAllocator{
-		t:                 t,
-		expectedFeatureID: feature.PlatformMode,
-		expectedFeatureCtx: feature.FeatureContext{
-			RepoName: repoFullName,
-		},
-	}
-
-	forkedPull := models.PullRequest{
+	commentEvent := event.Comment{
+		Pull:     testPull,
+		PullNum:  testPull.Num,
 		BaseRepo: testRepo,
-		HeadRepo: models.Repo{
-			Owner: "new-owner",
+		HeadRepo: testRepo,
+		User: models.User{
+			Username: "someuser",
 		},
+		InstallationToken: 123,
 	}
-	closedPull := models.PullRequest{
-		BaseRepo: testRepo,
-		State:    models.ClosedPullState,
+	cmd := &command.Comment{
+		Name: command.Plan,
 	}
-	cases := []struct {
-		descriptor string
-		allocator  *testAllocator
-		command    *command.Comment
-		event      event.Comment
-	}{
-		{
-			descriptor: "non-plan/apply comment",
-			allocator:  allocator,
-			command:    &command.Comment{Name: command.Unlock},
-			event: event.Comment{
-				Pull:     testPull,
-				PullNum:  testPull.Num,
-				BaseRepo: testRepo,
-			},
-		},
-		{
-			descriptor: "apply comment but platform mode enabled",
-			allocator: &testAllocator{
-				t:                 t,
-				expectedFeatureID: feature.PlatformMode,
-				expectedFeatureCtx: feature.FeatureContext{
-					RepoName: repoFullName,
-				},
-				expectedAllocation: true,
-			},
-			command: &command.Comment{Name: command.Apply},
-			event: event.Comment{
-				Pull:     testPull,
-				PullNum:  testPull.Num,
-				BaseRepo: testRepo,
-			},
-		},
-		{
-			descriptor: "forked PR",
-			allocator:  allocator,
-			command:    &command.Comment{Name: command.Plan},
-			event: event.Comment{
-				Pull:     forkedPull,
-				PullNum:  forkedPull.Num,
-				BaseRepo: testRepo,
-			},
-		},
-		{
-			descriptor: "closed PR",
-			allocator:  allocator,
-			command:    &command.Comment{Name: command.Plan},
-			event: event.Comment{
-				Pull:     closedPull,
-				PullNum:  closedPull.Num,
-				BaseRepo: testRepo,
-			},
-		},
-		{
-			descriptor: "invalid base branch",
-			allocator:  allocator,
-			command:    &command.Comment{Name: command.Plan},
-			event: event.Comment{
-				Pull:     testPull,
-				PullNum:  testPull.Num,
-				BaseRepo: testRepo,
-			},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.descriptor, func(t *testing.T) {
-			writer := &mockSnsWriter{}
-			expectedOpts := deploy.RootDeployOptions{
-				Repo:              c.event.BaseRepo,
-				Branch:            c.event.Pull.HeadBranch,
-				Revision:          c.event.Pull.HeadCommit,
-				OptionalPullNum:   c.event.Pull.Num,
-				Sender:            c.event.User,
-				InstallationToken: c.event.InstallationToken,
-				TriggerInfo: workflows.DeployTriggerInfo{
-					Type: workflows.ManualTrigger,
-				},
-			}
-			testSignaler := &testDeploySignaler{
-				expectedT:   t,
-				expectedCfg: rootConfigBuilder.rootConfigs[1],
-				expOpts:     expectedOpts,
-			}
-			commentCreator := &mockCommentCreator{}
-			statusUpdater := &mockStatusUpdater{
-				expectedRepo:      testRepo,
-				expectedPull:      testPull,
-				expectedVCSStatus: models.QueuedVCSStatus,
-				expectedCmd:       command.Plan.String(),
-				expectedBody:      "Request received. Adding to the queue...",
-				expectedT:         t,
-			}
-			commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, scope, writer, c.allocator, scheduler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
-			err := commentEventWorkerProxy.Handle(context.Background(), bufReq, c.event, c.command)
-			assert.NoError(t, err)
-			assert.False(t, statusUpdater.isCalled)
-			assert.False(t, commentCreator.isCalled)
-
-			if c.command.Name == command.Apply {
-				assert.True(t, testSignaler.called)
-			} else {
-				assert.False(t, testSignaler.called)
-			}
-			assert.True(t, writer.isCalled)
-		})
-	}
+	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
+	assert.Error(t, err)
+	assert.False(t, statusUpdater.isCalled)
+	assert.False(t, commentCreator.isCalled)
+	assert.False(t, rootDeployer.isCalled)
+	assert.True(t, writer.isCalled)
 }
 
 type mockCommentCreator struct {

--- a/server/neptune/gateway/event/legacy_comment_handler.go
+++ b/server/neptune/gateway/event/legacy_comment_handler.go
@@ -3,27 +3,59 @@ package event
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/core/config/valid"
 	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/http"
 	"github.com/runatlantis/atlantis/server/logging"
 )
 
 type LegacyCommentHandler struct {
-	logger    logging.Logger
-	snsWriter Writer
+	logger           logging.Logger
+	vcsStatusUpdater statusUpdater
+	snsWriter        Writer
+	globalCfg        valid.GlobalCfg
 }
 
-func (p *LegacyCommentHandler) Handle(ctx context.Context, request *http.BufferedRequest, cmd *command.Comment) error {
+func (p *LegacyCommentHandler) Handle(ctx context.Context, request *http.BufferedRequest, event Comment, cmd *command.Comment) error {
 	// legacy mode should not be handling any type of apply command anymore
 	if cmd.Name == command.Apply {
 		return nil
 	}
+	p.SetQueuedStatus(ctx, event, cmd)
 	// forward everything to sns for now since platform mode doesn't do anything w.r.t to comments atm.
 	if err := p.ForwardToSns(ctx, request); err != nil {
 		return errors.Wrap(err, "forwarding request through sns")
 	}
 	return nil
+}
+
+func (p *LegacyCommentHandler) SetQueuedStatus(ctx context.Context, event Comment, cmd *command.Comment) {
+	if p.shouldMarkEventQueued(event, cmd) {
+		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Request received. Adding to the queue..."); err != nil {
+			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
+		}
+	}
+}
+
+func (p *LegacyCommentHandler) shouldMarkEventQueued(event Comment, cmd *command.Comment) bool {
+	// pending status should only be for plan and apply step
+	if cmd.Name != command.Plan && cmd.Name != command.Apply {
+		return false
+	}
+	// pull event should not be from a fork
+	if event.Pull.HeadRepo.Owner != event.Pull.BaseRepo.Owner {
+		return false
+	}
+	// pull event should not be from closed PR
+	if event.Pull.State == models.ClosedPullState {
+		return false
+	}
+	// pull event should not use an invalid base branch
+	repo := p.globalCfg.MatchingRepo(event.Pull.BaseRepo.ID())
+	return repo.BranchMatches(event.Pull.BaseBranch)
 }
 
 func (p *LegacyCommentHandler) ForwardToSns(ctx context.Context, request *http.BufferedRequest) error {

--- a/server/neptune/gateway/event/legacy_comment_handler.go
+++ b/server/neptune/gateway/event/legacy_comment_handler.go
@@ -1,0 +1,41 @@
+package event
+
+import (
+	"bytes"
+	"context"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/http"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+type LegacyCommentHandler struct {
+	logger    logging.Logger
+	snsWriter Writer
+}
+
+func (p *LegacyCommentHandler) Handle(ctx context.Context, request *http.BufferedRequest, cmd *command.Comment) error {
+	// legacy mode should not be handling any type of apply command anymore
+	if cmd.Name == command.Apply {
+		return nil
+	}
+	// forward everything to sns for now since platform mode doesn't do anything w.r.t to comments atm.
+	if err := p.ForwardToSns(ctx, request); err != nil {
+		return errors.Wrap(err, "forwarding request through sns")
+	}
+	return nil
+}
+
+func (p *LegacyCommentHandler) ForwardToSns(ctx context.Context, request *http.BufferedRequest) error {
+	buffer := bytes.NewBuffer([]byte{})
+	if err := request.GetRequestWithContext(ctx).Write(buffer); err != nil {
+		return errors.Wrap(err, "writing request to buffer")
+	}
+
+	if err := p.snsWriter.WriteWithContext(ctx, buffer.Bytes()); err != nil {
+		return errors.Wrap(err, "writing buffer to sns")
+	}
+	p.logger.InfoContext(ctx, "proxied request to sns")
+
+	return nil
+}

--- a/server/neptune/gateway/event/legacy_comment_handler.go
+++ b/server/neptune/gateway/event/legacy_comment_handler.go
@@ -41,8 +41,8 @@ func (p *LegacyCommentHandler) SetQueuedStatus(ctx context.Context, event Commen
 }
 
 func (p *LegacyCommentHandler) shouldMarkEventQueued(event Comment, cmd *command.Comment) bool {
-	// pending status should only be for plan and apply step
-	if cmd.Name != command.Plan && cmd.Name != command.Apply {
+	// pending status should only be for plan step
+	if cmd.Name != command.Plan {
 		return false
 	}
 	// pull event should not be from a fork

--- a/server/neptune/gateway/event/legacy_pull_handler.go
+++ b/server/neptune/gateway/event/legacy_pull_handler.go
@@ -20,13 +20,13 @@ type workerProxy interface {
 	Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest) error
 }
 
-type LegacyHandler struct {
+type LegacyPullHandler struct {
 	VCSStatusUpdater vcsStatusUpdater
 	WorkerProxy      workerProxy
 	Logger           logging.Logger
 }
 
-func (l *LegacyHandler) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest, allRoots []*valid.MergedProjectCfg, legacyRoots []*valid.MergedProjectCfg) error {
+func (l *LegacyPullHandler) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest, allRoots []*valid.MergedProjectCfg, legacyRoots []*valid.MergedProjectCfg) error {
 	// mark legacy statuses as successful if there are no roots in general
 	// this is processed here to make it easy to clean up when we deprecate legacy mode
 	if len(allRoots) == 0 {

--- a/server/neptune/gateway/event/legacy_pull_handler_test.go
+++ b/server/neptune/gateway/event/legacy_pull_handler_test.go
@@ -16,7 +16,7 @@ func TestLegacyHandler_Handle_NoRoots(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)
 	statusUpdater := &mockVCSStatusUpdater{}
 	workerProxy := &mockWorkerProxy{}
-	legacyHandler := event.LegacyHandler{
+	legacyHandler := event.LegacyPullHandler{
 		Logger:           logger,
 		VCSStatusUpdater: statusUpdater,
 		WorkerProxy:      workerProxy,
@@ -35,7 +35,7 @@ func TestLegacyHandler_Handle_WorkerProxyFailure(t *testing.T) {
 		Name:         "legacy",
 		WorkflowMode: valid.DefaultWorkflowMode,
 	}
-	legacyHandler := event.LegacyHandler{
+	legacyHandler := event.LegacyPullHandler{
 		Logger:           logger,
 		VCSStatusUpdater: statusUpdater,
 		WorkerProxy:      &mockWorkerProxy{err: assert.AnError},
@@ -54,7 +54,7 @@ func TestLegacyHandler_Handle_WorkerProxySuccess(t *testing.T) {
 		Name:         "legacy",
 		WorkflowMode: valid.DefaultWorkflowMode,
 	}
-	legacyHandler := event.LegacyHandler{
+	legacyHandler := event.LegacyPullHandler{
 		Logger:           logger,
 		VCSStatusUpdater: statusUpdater,
 		WorkerProxy:      workerProxy,
@@ -74,7 +74,7 @@ func TestLegacyHandler_Handle_WorkerProxySuccess_Platform(t *testing.T) {
 		Name:         "platform",
 		WorkflowMode: valid.PlatformWorkflowMode,
 	}
-	legacyHandler := event.LegacyHandler{
+	legacyHandler := event.LegacyPullHandler{
 		Logger:           logger,
 		VCSStatusUpdater: statusUpdater,
 		WorkerProxy:      workerProxy,


### PR DESCRIPTION
Before I setup the comment handler to signal the pr workflow, I wanted to first clean up logic we don't need anymore:

- renamed and moved SNSWorkerProxy to a separate file (called LegacyCommentHandler to make it easy to know what to delete)
- all roots = platform mode so we should no longer partition them
- removed platform mode feature allocator check
- renamed legacy handler to LegacyPullHandler

Next PR will do the same as the pull event and send signals to both the sns worker and pr workflow for plan comments