### PR TITLE
Add metrics to PR workflow

### DIFF
--- a/server/events/metrics/common.go
+++ b/server/events/metrics/common.go
@@ -10,8 +10,9 @@ const (
 	FilterAbsentMetric  = "absent"
 	FilterErrorMetric   = "error"
 
-	RootTag = "root"
-	RepoTag = "repo"
+	RootTag     = "root"
+	RepoTag     = "repo"
+	RevisionTag = "revision"
 
 	ActivityExecutionSuccess = "activity_execution_success"
 	ActivityExecutionFailure = "activity_execution_failure"
@@ -20,6 +21,7 @@ const (
 	ActivityExecutionLatency = "activity_execution_latency"
 
 	SignalNameTag = "signal_name"
+	PollNameTag   = "poll_name"
 
 	// Signal handling metrics before it is added to a buffered channel
 	SignalHandleSuccess = "signal_handle_success"
@@ -28,6 +30,10 @@ const (
 
 	// Signal receive is when we receive it off the channel
 	SignalReceive = "signal_receive"
+	PollTick      = "poll_tick"
+
+	// Forced shutdown timeout when a workflow is suspected to be abandoned
+	ShutdownTimeout = "shutdown_timeout"
 
 	// Metrics are scoped to workflow namespaces anyways so let's
 	// keep these metrics simple.

--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -3,8 +3,10 @@ package policy
 import (
 	"context"
 	"github.com/google/go-github/v45/github"
+	metricNames "github.com/runatlantis/atlantis/server/events/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	gh "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	temporalInternal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
@@ -34,6 +36,7 @@ type FailedPolicyHandler struct {
 	GithubActivities      githubActivities
 	PRNumber              int
 	Org                   string
+	Scope                 metrics.Scope
 }
 
 type Action int64
@@ -44,7 +47,8 @@ const (
 )
 
 func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Revision, workflowResponses []terraform.Response) {
-	failedPolicies := dedup(workflowResponses)
+	scope := f.Scope.SubScopeWithTags(map[string]string{metricNames.RevisionTag: revision.Revision})
+	failedPolicies := dedup(workflowResponses, scope)
 	if len(failedPolicies) == 0 {
 		return
 	}
@@ -62,10 +66,16 @@ func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Rev
 		}
 		var request NewApproveSignalRequest
 		c.Receive(ctx, &request)
+		scope.SubScopeWithTags(map[string]string{metricNames.SignalNameTag: "pr-approval"}).
+			Counter(metricNames.SignalReceive).
+			Inc(1)
 	})
 	onTimeout := func(f workflow.Future) {
 		_ = f.Get(ctx, nil)
 		action = onPollTick
+		scope.SubScopeWithTags(map[string]string{metricNames.PollNameTag: "pr-approval"}).
+			Counter(metricNames.PollTick).
+			Inc(1)
 	}
 	cancelTimer, _ := s.AddTimeout(ctx, 5*time.Minute, onTimeout)
 
@@ -129,12 +139,16 @@ func (f *FailedPolicyHandler) fetchTeamMembers(ctx workflow.Context, repo gh.Rep
 	return listTeamMembersResponse.Members, err
 }
 
-func dedup(workflowResponses []terraform.Response) []activities.PolicySet {
+func dedup(workflowResponses []terraform.Response, scope metrics.Scope) []activities.PolicySet {
 	var failedPolicies []activities.PolicySet
 	for _, response := range workflowResponses {
 		for _, validationResult := range response.ValidationResults {
-			if validationResult.Status == activities.Fail {
+			switch validationResult.Status {
+			case activities.Fail:
 				failedPolicies = append(failedPolicies, validationResult.PolicySet)
+				scope.SubScope(validationResult.PolicySet.Name).Counter(metricNames.ExecutionFailureMetric).Inc(1)
+			case activities.Success:
+				scope.SubScope(validationResult.PolicySet.Name).Counter(metricNames.ExecutionSuccessMetric).Inc(1)
 			}
 		}
 	}

--- a/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	gh "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision/policy"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
@@ -59,6 +60,7 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		PolicyFilter:          filter,
 		GithubActivities:      r.GithubActivities,
 		PRNumber:              1,
+		Scope:                 metrics.NewNullableScope(),
 	}
 	handler.Handle(ctx, r.Revision, r.WorkflowResponses)
 	return response{

--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -1,6 +1,7 @@
 package pr
 
 import (
+	metricNames "github.com/runatlantis/atlantis/server/events/metrics"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	workflowMetrics "github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -79,6 +80,7 @@ func newRunner(ctx workflow.Context, scope workflowMetrics.Scope, org string, tf
 			Dismisser:             &dismisser,
 			PolicyFilter:          &policy.Filter{},
 			Org:                   org,
+			Scope:                 scope.SubScope("policies"),
 		},
 	}
 	shutdownChecker := ShutdownStateChecker{
@@ -115,12 +117,16 @@ func (r *Runner) Run(ctx workflow.Context) error {
 			return
 		}
 		action = onTimeout
+		r.Scope.Counter(metricNames.ShutdownTimeout).Inc(1)
 	}
 	inactivityTimeoutCancel, _ := s.AddTimeout(ctx, r.InactivityTimeout, onInactivityTimeout)
 
 	s.AddReceive(r.RevisionSignalChannel, func(c workflow.ReceiveChannel, more bool) {
 		prRevision = r.RevisionReceiver.Receive(c, more)
 		action = onNewRevision
+		r.Scope.SubScopeWithTags(map[string]string{metricNames.SignalNameTag: revision.TerraformRevisionSignalID}).
+			Counter(metricNames.SignalReceive).
+			Inc(1)
 	})
 	s.AddReceive(r.ShutdownSignalChannel, func(c workflow.ReceiveChannel, more bool) {
 		defer func() {
@@ -131,10 +137,16 @@ func (r *Runner) Run(ctx workflow.Context) error {
 		}
 		var request NewShutdownRequest
 		c.Receive(ctx, &request)
+		r.Scope.SubScopeWithTags(map[string]string{metricNames.SignalNameTag: ShutdownSignalID}).
+			Counter(metricNames.SignalReceive).
+			Inc(1)
 	})
 
 	onShutdownPollTick := func(f workflow.Future) {
 		action = onShutdownPoll
+		r.Scope.SubScopeWithTags(map[string]string{metricNames.PollNameTag: ShutdownSignalID}).
+			Counter(metricNames.PollTick).
+			Inc(1)
 	}
 	shutdownPollCancel, _ := s.AddTimeout(ctx, r.ShutdownPollTick, onShutdownPollTick)
 

--- a/server/neptune/workflows/internal/pr/runner_test.go
+++ b/server/neptune/workflows/internal/pr/runner_test.go
@@ -45,6 +45,7 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		ShutdownChecker:       mockShutdownChecker,
 		InactivityTimeout:     r.InactivityTimeout,
 		ShutdownPollTick:      r.ShutdownPollTime,
+		Scope:                 metrics.NewNullableScope(),
 	}
 	err := runner.Run(ctx)
 	return response{


### PR DESCRIPTION
Wanted to add some counters around the signals/poll events we can get in this workflow as well as the successes/failures of each policy test.