### PR TITLE
Extract PR revision workflow execution as a plugin.

### DIFF
--- a/server/neptune/lyft/README.md
+++ b/server/neptune/lyft/README.md
@@ -1,0 +1,4 @@
+## Lyft Specific Code
+
+All the code that exists here is specific to Lyft.  Ideally none of this should exist in this repo and we should find a way to inject this as part of consumption of this repository.
+However, until that happens, at least we can standardize on keeping company specific code within this package so that it's easy to to track and easy to extract.

--- a/server/neptune/lyft/activities/audit.go
+++ b/server/neptune/lyft/activities/audit.go
@@ -85,7 +85,7 @@ type AuditJobRequest struct {
 	Tags           map[string]string
 }
 
-func NewActivities(snsTopicArn string) (*Activities, error) {
+func NewAuditActivity(snsTopicArn string) (*Audit, error) {
 	var snsWriter io.Writer
 	if snsTopicArn != "" {
 		session, err := session.NewSession()
@@ -100,22 +100,16 @@ func NewActivities(snsTopicArn string) (*Activities, error) {
 		snsWriter = io.Discard
 	}
 
-	return &Activities{
-		auditActivities: &auditActivities{
-			SnsWriter: snsWriter,
-		},
+	return &Audit{
+		SnsWriter: snsWriter,
 	}, nil
 }
 
-type Activities struct {
-	*auditActivities
-}
-
-type auditActivities struct {
+type Audit struct {
 	SnsWriter io.Writer
 }
 
-func (a *auditActivities) AuditJob(ctx context.Context, req AuditJobRequest) error {
+func (a *Audit) AuditJob(ctx context.Context, req AuditJobRequest) error {
 	atlantisJobEvent := &AtlantisJobEvent{
 		Version:        1,
 		ID:             req.JobID,

--- a/server/neptune/lyft/activities/github.go
+++ b/server/neptune/lyft/activities/github.go
@@ -1,0 +1,154 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/palantir/go-githubapp/githubapp"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/pkg/errors"
+	internal "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+)
+
+type Github struct {
+	ClientCreator githubapp.ClientCreator
+}
+
+type ListPRsRequest struct {
+	Repo    internal.Repo
+	State   internal.PullRequestState
+	SortKey internal.SortKey
+	Order   internal.Order
+}
+
+type ListPRsResponse struct {
+	PullRequests []internal.PullRequest
+}
+
+func (a *Github) GithubListPRs(ctx context.Context, request ListPRsRequest) (ListPRsResponse, error) {
+	prs, err := a.listPullRequests(
+		ctx, request.Repo.Credentials.InstallationToken,
+		request.Repo.Owner,
+		request.Repo.Name,
+		request.Repo.DefaultBranch,
+		string(request.State),
+		string(request.SortKey),
+		string(request.Order),
+	)
+	if err != nil {
+		return ListPRsResponse{}, errors.Wrap(err, "listing open pull requests")
+	}
+
+	pullRequests := []internal.PullRequest{}
+	for _, pullRequest := range prs {
+		pullRequests = append(pullRequests, internal.PullRequest{
+			Number:    pullRequest.GetNumber(),
+			UpdatedAt: pullRequest.GetUpdatedAt(),
+		})
+	}
+
+	return ListPRsResponse{
+		PullRequests: pullRequests,
+	}, nil
+}
+
+type ListModifiedFilesRequest struct {
+	Repo        internal.Repo
+	PullRequest internal.PullRequest
+}
+
+type ListModifiedFilesResponse struct {
+	FilePaths []string
+}
+
+func (a *Github) GithubListModifiedFiles(ctx context.Context, request ListModifiedFilesRequest) (ListModifiedFilesResponse, error) {
+	files, err := a.listModifiedFiles(
+		ctx, request.Repo.Credentials.InstallationToken,
+		request.Repo.Owner,
+		request.Repo.Name,
+		request.PullRequest.Number,
+	)
+	if err != nil {
+		return ListModifiedFilesResponse{}, errors.Wrap(err, "listing modified files in pr")
+	}
+
+	filepaths := []string{}
+	for _, file := range files {
+		filepaths = append(filepaths, file.GetFilename())
+
+		// account for previous file name as well if the file has moved across roots
+		if file.GetStatus() == "renamed" {
+			filepaths = append(filepaths, file.GetPreviousFilename())
+		}
+	}
+
+	// strings are utf-8 encoded of size 1 to 4 bytes, assuming each file path is of length 100, max size of a filepath = 4 * 100 = 400 bytes
+	// upper limit of 2Mb can accomodate (2*1024*1024)/400 = 524k filepaths which is >> max number of results supported by the GH API 3000.
+	return ListModifiedFilesResponse{
+		FilePaths: filepaths,
+	}, nil
+}
+
+func (c *Github) listModifiedFiles(ctx context.Context, installationToken int64, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	run := func(ctx context.Context, nextPage int) ([]*github.CommitFile, *github.Response, error) {
+		listOptions := github.ListOptions{
+			PerPage: 100,
+		}
+		listOptions.Page = nextPage
+		return client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, &listOptions)
+	}
+
+	return iterate(ctx, run)
+}
+
+func (c *Github) listPullRequests(ctx context.Context, installationToken int64, owner, repo, base, state, sortBy, order string) ([]*github.PullRequest, error) {
+	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating client from installation")
+	}
+
+	run := func(ctx context.Context, nextPage int) ([]*github.PullRequest, *github.Response, error) {
+		prListOptions := github.PullRequestListOptions{
+			State: state,
+			Base:  base,
+			ListOptions: github.ListOptions{
+				PerPage: 100,
+			},
+			Sort:      sortBy,
+			Direction: order,
+		}
+		prListOptions.ListOptions.Page = nextPage
+		return client.PullRequests.List(ctx, owner, repo, &prListOptions)
+	}
+
+	return iterate(ctx, run)
+}
+
+func iterate[T interface{}](
+	ctx context.Context,
+	runFunc func(ctx context.Context, nextPage int) ([]T, *github.Response, error)) ([]T, error) {
+	var output []T
+	nextPage := 0
+	for {
+		results, resp, err := runFunc(ctx, nextPage)
+		if err != nil {
+			return nil, errors.Wrap(err, "error running gh api call")
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("not ok status running gh api call: %s", resp.Status)
+		}
+		output = append(output, results...)
+		if resp.NextPage == 0 {
+			break
+		}
+		nextPage = resp.NextPage
+	}
+	return output, nil
+}

--- a/server/neptune/lyft/activities/github.go
+++ b/server/neptune/lyft/activities/github.go
@@ -91,8 +91,8 @@ func (a *Github) GithubListModifiedFiles(ctx context.Context, request ListModifi
 	}, nil
 }
 
-func (c *Github) listModifiedFiles(ctx context.Context, installationToken int64, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
-	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+func (a *Github) listModifiedFiles(ctx context.Context, installationToken int64, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
+	client, err := a.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client from installation")
 	}
@@ -108,8 +108,8 @@ func (c *Github) listModifiedFiles(ctx context.Context, installationToken int64,
 	return iterate(ctx, run)
 }
 
-func (c *Github) listPullRequests(ctx context.Context, installationToken int64, owner, repo, base, state, sortBy, order string) ([]*github.PullRequest, error) {
-	client, err := c.ClientCreator.NewInstallationClient(installationToken)
+func (a *Github) listPullRequests(ctx context.Context, installationToken int64, owner, repo, base, state, sortBy, order string) ([]*github.PullRequest, error) {
+	client, err := a.ClientCreator.NewInstallationClient(installationToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client from installation")
 	}

--- a/server/neptune/lyft/executor/postdeploy.go
+++ b/server/neptune/lyft/executor/postdeploy.go
@@ -1,0 +1,34 @@
+package executor
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/lyft/workflows"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/workflow"
+)
+
+type PRRevisionWorkflowExecutor struct {
+	TaskQueue string
+}
+
+func (p *PRRevisionWorkflowExecutor) Execute(ctx workflow.Context, deployment plugins.TerraformDeploymentInfo) error {
+	// Let's only execute this workflow if we're on the default branch
+	if deployment.Commit.Branch != deployment.Repo.DefaultBranch {
+		return nil
+	}
+
+	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		TaskQueue: p.TaskQueue,
+
+		// configuring this ensures the child workflow will continue execution when the parent workflow terminates
+		ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
+	})
+
+	future := workflow.ExecuteChildWorkflow(ctx, workflows.PRRevision, workflows.PRRevisionRevisionRequest{
+		Repo:     deployment.Repo,
+		Root:     deployment.Root,
+		Revision: deployment.Commit.Revision,
+	})
+
+	return future.GetChildWorkflowExecution().Get(ctx, nil)
+}

--- a/server/neptune/lyft/workflows/metrics/scope.go
+++ b/server/neptune/lyft/workflows/metrics/scope.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/temporal"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Scope is an interface that attempts to wrap temporal's MetricsHandler with additional
+// functionality to build namespaces using NamespacedMetricsHandler
+type Scope interface {
+	SubScope(namespace ...string) Scope
+	SubScopeWithTags(tags map[string]string) Scope
+	Counter(name string) client.MetricsCounter
+	Gauge(name string) client.MetricsGauge
+}
+
+type WorkflowScope struct {
+	handler client.MetricsHandler
+}
+
+func NewScopeWithHandler(handler client.MetricsHandler, namespaces ...string) *WorkflowScope {
+	return &WorkflowScope{
+		handler: toNamespacedHandler(handler, namespaces...),
+	}
+}
+
+func NewScope(ctx workflow.Context, namespaces ...string) *WorkflowScope {
+	return &WorkflowScope{
+		handler: toNamespacedHandler(workflow.GetMetricsHandler(ctx), namespaces...),
+	}
+}
+
+func toNamespacedHandler(handler client.MetricsHandler, namespaces ...string) client.MetricsHandler {
+	if len(namespaces) == 0 {
+		return handler
+	}
+	switch h := handler.(type) {
+	case *temporal.NamespacedMetricsHandler:
+		return h.WithNamespace(namespaces...)
+	default:
+		return temporal.NewNamespacedMetricsHandler(h, namespaces...)
+	}
+}
+
+// NewNullableScope should only be used for testing purposes since it just drops metrics
+func NewNullableScope() *WorkflowScope {
+	return NewScopeWithHandler(client.MetricsNopHandler)
+}
+
+func (s *WorkflowScope) SubScope(namespaces ...string) Scope {
+	return NewScopeWithHandler(s.handler, namespaces...)
+}
+
+func (s *WorkflowScope) SubScopeWithTags(tags map[string]string) Scope {
+	return &WorkflowScope{
+		handler: s.handler.WithTags(tags),
+	}
+}
+
+func (s *WorkflowScope) Counter(name string) client.MetricsCounter {
+	return s.handler.Counter(name)
+}
+
+func (s *WorkflowScope) Gauge(name string) client.MetricsGauge {
+	return s.handler.Gauge(name)
+}

--- a/server/neptune/lyft/workflows/metrics/scope_test.go
+++ b/server/neptune/lyft/workflows/metrics/scope_test.go
@@ -1,0 +1,91 @@
+package metrics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/lyft/workflows/metrics"
+	"go.temporal.io/sdk/client"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+type testHandler struct {
+	t                 *testing.T
+	called            bool
+	expectedTags      map[string]string
+	expectedNamespace string
+}
+
+func (h testHandler) WithTags(tags map[string]string) client.MetricsHandler {
+	assert.Equal(h.t, h.expectedTags, tags)
+	return testHandler{
+		t:                 h.t,
+		expectedNamespace: h.expectedNamespace,
+		called:            true,
+	}
+}
+func (h testHandler) Counter(namespace string) client.MetricsCounter {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+func (h testHandler) Gauge(namespace string) client.MetricsGauge {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+func (h testHandler) Timer(namespace string) client.MetricsTimer {
+	assert.Equal(h.t, h.expectedNamespace, namespace)
+	return testHandler{
+		called: true,
+	}
+}
+
+func (h testHandler) Inc(int64)            {}
+func (h testHandler) Update(float64)       {}
+func (h testHandler) Record(time.Duration) {}
+
+func TestScope(t *testing.T) {
+	t.Run("subscope", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "some.namespace.nish.hi",
+			t:                 t,
+		}
+		_ = metrics.NewScopeWithHandler(handler, "some", "namespace").
+			SubScope("nish").
+			Counter("hi")
+	})
+	t.Run("gauge", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "nish.hi",
+			t:                 t,
+		}
+		_ = metrics.NewScopeWithHandler(handler, "nish").
+			Gauge("hi")
+	})
+
+	t.Run("tags", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "nish.hi",
+			expectedTags:      map[string]string{"hello": "world"},
+			t:                 t,
+		}
+		_ = metrics.NewScopeWithHandler(handler, "nish").
+			SubScopeWithTags(map[string]string{"hello": "world"}).
+			Gauge("hi")
+	})
+
+	t.Run("tags_then_scope", func(t *testing.T) {
+		handler := testHandler{
+			expectedNamespace: "nish.hi.there.hi",
+			expectedTags:      map[string]string{"hello": "world"},
+			t:                 t,
+		}
+		_ = metrics.NewScopeWithHandler(handler, "nish").
+			SubScopeWithTags(map[string]string{"hello": "world"}).
+			SubScope("hi", "there").
+			Gauge("hi")
+	})
+}

--- a/server/neptune/lyft/workflows/pr_revision.go
+++ b/server/neptune/lyft/workflows/pr_revision.go
@@ -1,7 +1,7 @@
 package workflows
 
 import (
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/workflows/prrevision"
 	"go.temporal.io/sdk/workflow"
 )
 

--- a/server/neptune/lyft/workflows/prrevision/workflow_test.go
+++ b/server/neptune/lyft/workflows/prrevision/workflow_test.go
@@ -147,8 +147,10 @@ func TestMinRevisionSetter_NoOpenPR(t *testing.T) {
 	}
 
 	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
-		Repo:  req.Repo,
-		State: github.OpenPullRequest,
+		Repo:    req.Repo,
+		State:   github.OpenPullRequest,
+		SortKey: github.Updated,
+		Order:   github.Descending,
 	}).Return(activities.ListPRsResponse{
 		PullRequests: []github.PullRequest{},
 	}, nil)
@@ -264,8 +266,10 @@ func TestMinRevisionSetter_ListModifiedFilesErr(t *testing.T) {
 	}
 
 	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
-		Repo:  req.Repo,
-		State: github.OpenPullRequest,
+		Repo:    req.Repo,
+		State:   github.OpenPullRequest,
+		SortKey: github.Updated,
+		Order:   github.Descending,
 	}).Return(activities.ListPRsResponse{
 		PullRequests: pullRequests,
 	}, nil)
@@ -313,8 +317,10 @@ func TestMinRevisionSetter_OpenPR_PatternMatchErr(t *testing.T) {
 	}
 
 	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
-		Repo:  req.Repo,
-		State: github.OpenPullRequest,
+		Repo:    req.Repo,
+		State:   github.OpenPullRequest,
+		SortKey: github.Updated,
+		Order:   github.Descending,
 	}).Return(activities.ListPRsResponse{
 		PullRequests: pullRequests,
 	}, nil)

--- a/server/neptune/lyft/workflows/prrevision/workflow_test.go
+++ b/server/neptune/lyft/workflows/prrevision/workflow_test.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/runatlantis/atlantis/server/core/config/raw"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/activities"
+	"github.com/runatlantis/atlantis/server/neptune/lyft/workflows/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/activity"
@@ -133,7 +132,6 @@ func testSetMiminumValidRevisionForRootWorkflow(ctx workflow.Context, r Request,
 func TestMinRevisionSetter_NoOpenPR(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
-	env.OnGetVersion(version.MultiQueue, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 
 	ga := &testGithubActivities{}
 	env.RegisterActivity(ga)
@@ -154,72 +152,6 @@ func TestMinRevisionSetter_NoOpenPR(t *testing.T) {
 	}).Return(activities.ListPRsResponse{
 		PullRequests: []github.PullRequest{},
 	}, nil)
-
-	env.ExecuteWorkflow(testSetMiminumValidRevisionForRootWorkflow, req, 10)
-	env.AssertExpectations(t)
-
-	err := env.GetWorkflowResult(nil)
-	assert.Nil(t, err)
-}
-
-func TestMinRevisionSetter_OpenPR_SetMinRevision_Default(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-	env.OnGetVersion(version.MultiQueue, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
-
-	ga := &testGithubActivities{}
-	ra := &testRevisionSetterActivities{}
-	env.RegisterActivity(ra)
-	env.RegisterActivity(ga)
-
-	req := Request{
-		Repo: github.Repo{
-			Owner: "owner",
-			Name:  "test",
-		},
-		Root: terraform.Root{
-			Path:         "test/dir2",
-			TrackedFiles: raw.DefaultAutoPlanWhenModified,
-		},
-	}
-
-	pullRequests := []github.PullRequest{
-		{
-			Number: 1,
-		},
-		{
-			Number: 2,
-		},
-	}
-
-	filesModifiedPr1 := []string{"test/dir2/rebase.tf"}
-	filesModifiedPr2 := []string{"test/dir1/no-rebase.tf"}
-
-	env.OnActivity(ga.GithubListPRs, mock.Anything, activities.ListPRsRequest{
-		Repo:  req.Repo,
-		State: github.OpenPullRequest,
-	}).Return(activities.ListPRsResponse{
-		PullRequests: pullRequests,
-	}, nil)
-
-	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
-		Repo:        req.Repo,
-		PullRequest: pullRequests[0],
-	}).Return(activities.ListModifiedFilesResponse{
-		FilePaths: filesModifiedPr1,
-	}, nil)
-
-	env.OnActivity(ga.GithubListModifiedFiles, mock.Anything, activities.ListModifiedFilesRequest{
-		Repo:        req.Repo,
-		PullRequest: pullRequests[1],
-	}).Return(activities.ListModifiedFilesResponse{
-		FilePaths: filesModifiedPr2,
-	}, nil)
-
-	env.OnActivity(ra.SetPRRevision, mock.Anything, activities.SetPRRevisionRequest{
-		Repository:  req.Repo,
-		PullRequest: pullRequests[0],
-	}).Return(nil)
 
 	env.ExecuteWorkflow(testSetMiminumValidRevisionForRootWorkflow, req, 10)
 	env.AssertExpectations(t)
@@ -308,7 +240,6 @@ func TestMinRevisionSetter_OpenPR_SetMinRevision_v1(t *testing.T) {
 func TestMinRevisionSetter_ListModifiedFilesErr(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
-	env.OnGetVersion(version.MultiQueue, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 
 	ga := &testGithubActivities{}
 	ra := &testRevisionSetterActivities{}
@@ -359,7 +290,6 @@ func TestMinRevisionSetter_ListModifiedFilesErr(t *testing.T) {
 func TestMinRevisionSetter_OpenPR_PatternMatchErr(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
-	env.OnGetVersion(version.MultiQueue, workflow.DefaultVersion, 1).Return(workflow.DefaultVersion)
 
 	ga := &testGithubActivities{}
 	ra := &testRevisionSetterActivities{}

--- a/server/neptune/workflows/activities/github/client.go
+++ b/server/neptune/workflows/activities/github/client.go
@@ -73,46 +73,6 @@ func (c *Client) CompareCommits(ctx Context, owner, repo string, base, head stri
 	return client.Repositories.CompareCommits(ctx, owner, repo, base, head, opts)
 }
 
-func (c *Client) ListModifiedFiles(ctx Context, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
-	if err != nil {
-		return nil, errors.Wrap(err, "creating client from installation")
-	}
-
-	run := func(ctx context.Context, nextPage int) ([]*github.CommitFile, *github.Response, error) {
-		listOptions := github.ListOptions{
-			PerPage: 100,
-		}
-		listOptions.Page = nextPage
-		return client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, &listOptions)
-	}
-
-	return gh_helper.Iterate(ctx, run)
-}
-
-func (c *Client) ListPullRequests(ctx Context, owner, repo, base, state, sortBy, order string) ([]*github.PullRequest, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
-	if err != nil {
-		return nil, errors.Wrap(err, "creating client from installation")
-	}
-
-	run := func(ctx context.Context, nextPage int) ([]*github.PullRequest, *github.Response, error) {
-		prListOptions := github.PullRequestListOptions{
-			State: state,
-			Base:  base,
-			ListOptions: github.ListOptions{
-				PerPage: 100,
-			},
-			Sort:      sortBy,
-			Direction: order,
-		}
-		prListOptions.ListOptions.Page = nextPage
-		return client.PullRequests.List(ctx, owner, repo, &prListOptions)
-	}
-
-	return gh_helper.Iterate(ctx, run)
-}
-
 func (c *Client) ListReviews(ctx Context, owner string, repo string, number int) ([]*github.PullRequestReview, error) {
 	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
 	if err != nil {

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -247,32 +247,6 @@ func mkSubDir(parentDir string, subDir string) (string, error) {
 	return fullDir, nil
 }
 
-type RevsionSetter struct {
-	*prRevisionSetterActivities
-}
-
-func NewRevisionSetter(cfg valid.RevisionSetter) (*RevsionSetter, error) {
-	// Use a NoopClient if revision setter is not configured
-	var client revisionSetterClient
-	if cfg.URL == "" {
-		client = &NoopClient{}
-	} else {
-		client = &http.Client{}
-	}
-
-	return NewRevisionSetterWithClient(client, cfg)
-}
-
-func NewRevisionSetterWithClient(client revisionSetterClient, cfg valid.RevisionSetter) (*RevsionSetter, error) {
-	return &RevsionSetter{
-		prRevisionSetterActivities: &prRevisionSetterActivities{
-			client:    client,
-			url:       cfg.URL,
-			basicAuth: cfg.BasicAuth,
-		},
-	}, nil
-}
-
 func convertPolicies(policies []valid.PolicySet) []PolicySet {
 	var convertedPolicies []PolicySet
 	for _, policy := range policies {

--- a/server/neptune/workflows/deploy.go
+++ b/server/neptune/workflows/deploy.go
@@ -67,8 +67,7 @@ func GetDeployWithPlugins(InitPlugins InitDeployPlugins) DeployFunc {
 			ctx,
 			req,
 			deploy.ChildWorkflows{
-				Terraform:     Terraform,
-				SetPRRevision: PRRevision,
+				Terraform: Terraform,
 			},
 			plugins,
 		)

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -86,7 +86,7 @@ func TestDeployWorkflow(t *testing.T) {
 		Repo:     repo,
 	}
 
-	s := initAndRegisterActivities(t, env, revRequest)
+	s := initAndRegisterActivities(t, env)
 
 	env.RegisterDelayedCallback(func() {
 		signalWorkflow(env, revRequest)
@@ -160,7 +160,7 @@ func buildConfig(t *testing.T) config.Config {
 	}
 }
 
-func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironment, revReq workflows.DeployNewRevisionSignalRequest) *testSingletons {
+func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironment) *testSingletons {
 	cfg := buildConfig(t)
 
 	deployActivities, err := activities.NewDeploy(cfg.DeploymentConfig)

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +31,6 @@ type a struct {
 	*activities.Github
 	*activities.Terraform
 	*activities.Deploy
-	*activities.RevsionSetter
 }
 
 // we don't want to mess up all our gitconfig for testing purposes
@@ -51,7 +48,6 @@ func TestDeployWorkflow(t *testing.T) {
 
 	env.RegisterWorkflow(deployWorkflow)
 	env.RegisterWorkflow(workflows.Terraform)
-	env.RegisterWorkflow(workflows.PRRevision)
 
 	repo := workflows.Repo{
 		FullName: "nish/repo",
@@ -121,10 +117,9 @@ func signalWorkflow(env *testsuite.TestWorkflowEnvironment, revRequest workflows
 }
 
 type testSingletons struct {
-	a                    *a
-	githubClient         *testGithubClient
-	revisionSetterClient *testRevSetterClient
-	streamCloser         *testStreamCloser
+	a            *a
+	githubClient *testGithubClient
+	streamCloser *testStreamCloser
 }
 
 func buildConfig(t *testing.T) config.Config {
@@ -202,38 +197,17 @@ func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironm
 	)
 	assert.NoError(t, err)
 
-	revSetterClient := &testRevSetterClient{
-		ExpectedCalls: []SetRevisionCall{
-			{
-				RepoName: revReq.Repo.Name,
-				PullNum:  1,
-				Revision: revReq.Revision,
-			},
-		},
-	}
-	revisionSetterActivities, err := activities.NewRevisionSetterWithClient(
-		revSetterClient,
-		valid.RevisionSetter{},
-	)
-	assert.NoError(t, err)
-
-	assert.NoError(t, err)
-
 	env.RegisterActivity(terraformActivities)
 	env.RegisterActivity(deployActivities)
 	env.RegisterActivity(githubActivities)
-	env.RegisterActivity(revisionSetterActivities)
-
 	return &testSingletons{
 		a: &a{
-			Github:        githubActivities,
-			Terraform:     terraformActivities,
-			Deploy:        deployActivities,
-			RevsionSetter: revisionSetterActivities,
+			Github:    githubActivities,
+			Terraform: terraformActivities,
+			Deploy:    deployActivities,
 		},
-		githubClient:         githubClient,
-		streamCloser:         streamCloser,
-		revisionSetterClient: revSetterClient,
+		githubClient: githubClient,
+		streamCloser: streamCloser,
 	}
 }
 
@@ -338,50 +312,6 @@ func (c *testGithubClient) CompareCommits(ctx internalGithub.Context, owner, rep
 	return &github.CommitsComparison{
 		Status: github.String("ahead"),
 	}, &github.Response{}, nil
-}
-
-func (c *testGithubClient) ListModifiedFiles(ctx internalGithub.Context, owner, repo string, pullNumber int) ([]*github.CommitFile, error) {
-	return []*github.CommitFile{
-		{
-			Filename: github.String("terraform/mytestroot/a.tf"),
-		},
-	}, nil
-}
-
-func (c *testGithubClient) ListPullRequests(ctx internalGithub.Context, owner, repo, base, state, sortBy, order string) ([]*github.PullRequest, error) {
-	return []*github.PullRequest{
-		{
-			Number: github.Int(1),
-		},
-	}, nil
-}
-
-type SetRevisionCall struct {
-	RepoName string
-	PullNum  int
-	Revision string
-}
-
-type testRevSetterClient struct {
-	t             *testing.T
-	ExpectedCalls []SetRevisionCall
-}
-
-func (t *testRevSetterClient) Do(req *http.Request) (*http.Response, error) {
-	parts := strings.Split(req.URL.Path, "/")
-	num, err := strconv.Atoi(parts[2])
-	assert.NoError(t.t, err)
-
-	assert.Equal(t.t, t.ExpectedCalls[0], SetRevisionCall{
-		RepoName: parts[1],
-		PullNum:  num,
-		Revision: parts[3],
-	})
-
-	return &http.Response{
-		Body:       http.NoBody,
-		StatusCode: http.StatusOK,
-	}, nil
 }
 
 type testAllocator struct {

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer.go
@@ -92,7 +92,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraform.De
 	}
 
 	// log error and continue deploys if any of the post deploy task fails
-	if err := p.runPostDeployTasks(ctx, requestedDeployment, scope); err != nil {
+	if err := p.runPostDeployTasks(ctx, requestedDeployment); err != nil {
 		workflow.GetLogger(ctx).Error("error running post deploy tasks", key.ErrKey, err)
 	}
 
@@ -102,7 +102,7 @@ func (p *Deployer) Deploy(ctx workflow.Context, requestedDeployment terraform.De
 	return requestedDeployment.BuildPersistableInfo(), err
 }
 
-func (p *Deployer) runPostDeployTasks(ctx workflow.Context, deployment terraform.DeploymentInfo, scope metrics.Scope) error {
+func (p *Deployer) runPostDeployTasks(ctx workflow.Context, deployment terraform.DeploymentInfo) error {
 	if err := p.persistLatestDeployment(ctx, deployment.BuildPersistableInfo()); err != nil {
 		return errors.Wrap(err, "persisting deployment")
 	}

--- a/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/deployer_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
@@ -17,7 +19,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/temporal"
@@ -32,7 +33,12 @@ const (
 	TerraformClientError ErrorType = "TerraformClientError"
 )
 
-func testPRRevWorkflow(ctx workflow.Context, request prrevision.Request) error {
+type testExecutor struct {
+	called bool
+}
+
+func (e *testExecutor) Execute(ctx workflow.Context, info plugins.TerraformDeploymentInfo) error {
+	e.called = true
 	return nil
 }
 
@@ -76,13 +82,20 @@ type deployerRequest struct {
 	ExpectedT         *testing.T
 }
 
-func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.Info, error) {
+type deployResponse struct {
+	*deployment.Info
+	ExecutorCalled bool
+}
+
+func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployResponse, error) {
 	options := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
 	}
 
 	ctx = workflow.WithActivityOptions(ctx, options)
 	var a *testDeployActivity
+
+	e := &testExecutor{}
 
 	deployer := &queue.Deployer{
 		Activities: a,
@@ -95,10 +108,15 @@ func testDeployerWorkflow(ctx workflow.Context, r deployerRequest) (*deployment.
 			expectedT:            r.ExpectedT,
 			expectedDeploymentID: r.Info.ID.String(),
 		},
-		PRRevisionWorkflow: testPRRevWorkflow,
+		Executors: []plugins.PostDeployExecutor{e},
 	}
 
-	return deployer.Deploy(ctx, r.Info, r.LatestDeploy, metrics.NewNullableScope())
+	info, err := deployer.Deploy(ctx, r.Info, r.LatestDeploy, metrics.NewNullableScope())
+	if err != nil {
+		return nil, err
+	}
+
+	return &deployResponse{Info: info, ExecutorCalled: e.called}, nil
 }
 
 func TestDeployer_FirstDeploy(t *testing.T) {
@@ -167,11 +185,11 @@ func TestDeployer_FirstDeploy(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
-	assert.Equal(t, latestDeployedRevision, resp)
+	assert.Equal(t, latestDeployedRevision, resp.Info)
 }
 
 func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
@@ -252,7 +270,7 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
@@ -268,7 +286,7 @@ func TestDeployer_CompareCommit_DeployAhead(t *testing.T) {
 			Owner: deploymentInfo.Repo.Owner,
 			Name:  deploymentInfo.Repo.Name,
 		},
-	}, resp)
+	}, resp.Info)
 }
 
 func TestDeployer_CompareCommit_Identical(t *testing.T) {
@@ -329,7 +347,7 @@ func TestDeployer_CompareCommit_Identical(t *testing.T) {
 		LatestDeploy: latestDeployedRevision,
 	})
 	env.AssertExpectations(t)
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 	assert.Equal(t, &deployment.Info{
@@ -346,7 +364,7 @@ func TestDeployer_CompareCommit_Identical(t *testing.T) {
 			Owner: deploymentInfo.Repo.Owner,
 			Name:  deploymentInfo.Repo.Name,
 		},
-	}, resp)
+	}, resp.Info)
 }
 
 func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
@@ -417,10 +435,8 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 			ExpectedT: t,
 		})
 		env.AssertExpectations(t)
-		var resp *deployment.Info
-		err := env.GetWorkflowResult(&resp)
+		err := env.GetWorkflowError()
 		assert.Error(t, err)
-		assert.Nil(t, resp)
 	})
 
 	cases := []activities.DiffDirection{activities.DirectionAhead, activities.DirectionDiverged}
@@ -456,10 +472,8 @@ func TestDeployer_CompareCommit_SkipDeploy(t *testing.T) {
 				ExpectedT: t,
 			})
 			env.AssertExpectations(t)
-			var resp *deployment.Info
-			err := env.GetWorkflowResult(&resp)
+			err := env.GetWorkflowError()
 			assert.Error(t, err)
-			assert.Nil(t, resp)
 		})
 	}
 }
@@ -542,7 +556,7 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
@@ -558,7 +572,7 @@ func TestDeployer_CompareCommit_DeployDiverged(t *testing.T) {
 			Owner: deploymentInfo.Repo.Owner,
 			Name:  deploymentInfo.Repo.Name,
 		},
-	}, resp)
+	}, resp.Info)
 }
 
 func TestDeployer_WorkflowFailure_PlanRejection_SkipUpdateLatestDeployment(t *testing.T) {
@@ -622,8 +636,7 @@ func TestDeployer_WorkflowFailure_PlanRejection_SkipUpdateLatestDeployment(t *te
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
+	err := env.GetWorkflowError()
 
 	wfErr, ok := err.(*temporal.WorkflowExecutionError)
 	assert.True(t, ok)
@@ -715,8 +728,7 @@ func TestDeployer_TerraformClientError_UpdateLatestDeployment(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
-	err := env.GetWorkflowResult(&resp)
+	err := env.GetWorkflowError()
 
 	wfErr, ok := err.(*temporal.WorkflowExecutionError)
 	assert.True(t, ok)
@@ -727,7 +739,7 @@ func TestDeployer_TerraformClientError_UpdateLatestDeployment(t *testing.T) {
 	assert.Equal(t, "TerraformClientError", appErr.Type())
 }
 
-func TestDeployer_SetPRRevision(t *testing.T) {
+func TestDeployer_Executor(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	env.OnGetVersion(version.SetPRRevision, workflow.DefaultVersion, 2).Return(workflow.Version(1))
@@ -754,13 +766,6 @@ func TestDeployer_SetPRRevision(t *testing.T) {
 		Root:       root,
 		Repo:       repo,
 	}
-
-	env.RegisterWorkflow(testPRRevWorkflow)
-	env.OnWorkflow(testPRRevWorkflow, mock.Anything, prrevision.Request{
-		Repo:     repo,
-		Root:     root,
-		Revision: deploymentInfo.Commit.Revision,
-	}).Return(nil)
 
 	latestDeployedRevision := &deployment.Info{
 		ID:       deploymentInfo.ID.String(),
@@ -812,7 +817,7 @@ func TestDeployer_SetPRRevision(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
@@ -828,7 +833,8 @@ func TestDeployer_SetPRRevision(t *testing.T) {
 			Owner: deploymentInfo.Repo.Owner,
 			Name:  deploymentInfo.Repo.Name,
 		},
-	}, resp)
+	}, resp.Info)
+	assert.True(t, resp.ExecutorCalled)
 }
 
 func TestDeployer_SetPRRevision_NonDefaultBranchOld_v1(t *testing.T) {
@@ -1023,7 +1029,7 @@ func TestDeployer_SetPRRevision_NonDefaultBranchNew_v2(t *testing.T) {
 
 	env.AssertExpectations(t)
 
-	var resp *deployment.Info
+	var resp *deployResponse
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
 
@@ -1040,5 +1046,5 @@ func TestDeployer_SetPRRevision_NonDefaultBranchNew_v2(t *testing.T) {
 			Owner: deploymentInfo.Repo.Owner,
 			Name:  deploymentInfo.Repo.Name,
 		},
-	}, resp)
+	}, resp.Info)
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -83,7 +83,7 @@ func NewWorker(
 	q queue,
 	a workerActivities,
 	tfWorkflow terraform.Workflow,
-	prRevWorkflow Workflow,
+	postDeployExecutors []plugins.PostDeployExecutor,
 	repoName, rootName string,
 	githubCheckRunCache CheckRunClient,
 	additionalNotifiers ...plugins.TerraformWorkflowNotifier,
@@ -100,7 +100,7 @@ func NewWorker(
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,
 		GithubCheckRunCache:     githubCheckRunCache,
-		PRRevisionWorkflow:      prRevWorkflow,
+		Executors:               postDeployExecutors,
 	}
 
 	latestDeployment, err := deployer.FetchLatestDeployment(ctx, repoName, rootName)

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/prrevision"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
@@ -387,10 +387,6 @@ func TestNewWorker(t *testing.T) {
 		return terraformWorkflow.Response{}, nil
 	}
 
-	emptyPRRevWorkflow := func(ctx workflow.Context, request prrevision.Request) error {
-		return nil
-	}
-
 	type res struct {
 		Lock queue.LockState
 	}
@@ -400,7 +396,7 @@ func TestNewWorker(t *testing.T) {
 			ScheduleToCloseTimeout: 5 * time.Second,
 		})
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
-		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, emptyPRRevWorkflow, "nish/repo", "root", &testCheckRunClient{})
+		_, err := queue.NewWorker(ctx, q, &testDeployActivity{}, emptyWorkflow, []plugins.PostDeployExecutor{}, "nish/repo", "root", &testCheckRunClient{})
 		return res{
 			Lock: q.GetLockState(),
 		}, err

--- a/server/neptune/workflows/internal/deploy/workflow.go
+++ b/server/neptune/workflows/internal/deploy/workflow.go
@@ -65,8 +65,7 @@ type QueueWorker interface {
 }
 
 type ChildWorkflows struct {
-	Terraform     terraform.Workflow
-	SetPRRevision queue.Workflow
+	Terraform terraform.Workflow
 }
 
 func Workflow(ctx workflow.Context, request Request, children ChildWorkflows, plugins plugins.Deploy) error {
@@ -116,7 +115,13 @@ func newRunner(ctx workflow.Context, request Request, children ChildWorkflows, p
 		lockStateUpdater.UpdateQueuedRevisions(ctx, d, request.Repo.FullName)
 	}, scope)
 
-	worker, err := queue.NewWorker(ctx, revisionQueue, a, children.Terraform, children.SetPRRevision, request.Repo.FullName, request.Root.Name, checkRunCache, plugins.Notifiers...)
+	worker, err := queue.NewWorker(
+		ctx,
+		revisionQueue,
+		a, children.Terraform, plugins.PostDeployExecutors,
+		request.Repo.FullName,
+		request.Root.Name,
+		checkRunCache, plugins.Notifiers...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/neptune/workflows/internal/prrevision/version/multi_queue.go
+++ b/server/neptune/workflows/internal/prrevision/version/multi_queue.go
@@ -1,3 +1,0 @@
-package version
-
-const MultiQueue = "multi-queue"

--- a/server/neptune/workflows/plugins/deploy.go
+++ b/server/neptune/workflows/plugins/deploy.go
@@ -8,9 +8,17 @@ type TerraformWorkflowNotifier interface {
 	Notify(workflow.Context, TerraformDeploymentInfo, *TerraformWorkflowState) error
 }
 
+// PostDeployExecutor can be used to enable specific actions to occur after a single deploy has been executed
+type PostDeployExecutor interface {
+	Execute(workflow.Context, TerraformDeploymentInfo) error
+}
+
 // Customizable plugins for the deploy workflow
 type Deploy struct {
 
 	// A set of notifiers that are called for TerraformWorkflowState changes
 	Notifiers []TerraformWorkflowNotifier
+
+	// A set of post deploy executors that are called after a deployment has transpired
+	PostDeployExecutors []PostDeployExecutor
 }


### PR DESCRIPTION
This is lyft specific code so extracting this to our `lyft` package and passing it in as a plugin.  The goal of the `lyft` package is to eventually be moved to our private repo and passed in while initializing the server in code.