### PR TITLE
Use scheduler for modified pr event's legacy and platform logic

### DIFF
--- a/server/neptune/gateway/event/modified_pull_request_handler_test.go
+++ b/server/neptune/gateway/event/modified_pull_request_handler_test.go
@@ -84,7 +84,7 @@ func TestModifiedPullHandler_Handle_SignalerFailure(t *testing.T) {
 		Allocator: &testFeatureAllocator{Enabled: true},
 	}
 	err := pullHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{})
-	assert.ErrorIs(t, err, assert.AnError)
+	assert.ErrorContains(t, err, assert.AnError.Error())
 }
 
 func TestModifiedPullHandler_Handle_BranchStrategy(t *testing.T) {


### PR DESCRIPTION
Wraps both the legacy and platform mode handlers in scheduler calls to run asynchronously.