### PR TITLE
Fix loop var closure reference.

### DIFF
--- a/server/neptune/gateway/event/pull_request_review_handler.go
+++ b/server/neptune/gateway/event/pull_request_review_handler.go
@@ -59,7 +59,8 @@ func (p *PullRequestReviewWorkerProxy) Handle(ctx context.Context, event PullReq
 		p.handlePlatformMode,
 	}
 	var combinedErrors *multierror.Error
-	for _, f := range fxns {
+	for _, fxn := range fxns {
+		f := fxn
 		err := p.Scheduler.Schedule(ctx, func(ctx context.Context) error {
 			return f(ctx, request, event)
 		})


### PR DESCRIPTION
Without this only the last function will ever be executed and it'll be executed twice.