### PR TITLE
Rely on original pull event's action field to process PR event type

### DIFF
--- a/server/vcs/provider/github/converter/pull_event.go
+++ b/server/vcs/provider/github/converter/pull_event.go
@@ -43,24 +43,26 @@ func (e PullEventConverter) Convert(ctx context.Context, pullEvent *github.PullR
 		return event.PullRequest{}, err
 	}
 
-	action := latestPRState.GetState()
+	// Rely on action from original pull event to filter out irrelevant PR events
+	action := pullEvent.GetAction()
 	// If it's a draft PR we ignore it for auto-planning if configured to do so
 	// however it's still possible for users to run plan on it manually via a
 	// comment so if any draft PR is closed we still need to check if we need
 	// to delete its locks.
-	if latestPRState.GetDraft() && action != "closed" && !e.AllowDraftPRs {
-		action = "other"
-	}
-
-	// if original event was not: synchronize, open, ready_for_review, or closed, we don't want to process revision
-	if !eventActionModifiesPull(pullEvent) {
+	if pullEvent.GetPullRequest().GetDraft() && pullEvent.GetAction() != "closed" && !e.AllowDraftPRs {
 		action = "other"
 	}
 
 	var pullEventType models.PullRequestEventType
 	switch action {
-	case "open":
+	case "opened":
 		pullEventType = models.OpenedPullEvent
+	case "ready_for_review":
+		// when an author takes a PR out of 'draft' state a 'ready_for_review'
+		// event is triggered. We want atlantis to treat this as a freshly opened PR
+		pullEventType = models.OpenedPullEvent
+	case "synchronize":
+		pullEventType = models.UpdatedPullEvent
 	case "closed":
 		pullEventType = models.ClosedPullEvent
 	default:
@@ -78,13 +80,4 @@ func (e PullEventConverter) Convert(ctx context.Context, pullEvent *github.PullR
 		Timestamp:         eventTimestamp,
 		InstallationToken: installationToken,
 	}, nil
-}
-
-func eventActionModifiesPull(pullEvent *github.PullRequestEvent) bool {
-	originalAction := pullEvent.GetAction()
-	switch originalAction {
-	case "opened", "ready_for_review", "synchronized", "closed":
-		return true
-	}
-	return false
 }

--- a/server/vcs/provider/github/converter/pull_event.go
+++ b/server/vcs/provider/github/converter/pull_event.go
@@ -52,6 +52,11 @@ func (e PullEventConverter) Convert(ctx context.Context, pullEvent *github.PullR
 		action = "other"
 	}
 
+	// if original event was not: synchronize, open, ready_for_review, or closed, we don't want to process revision
+	if !eventActionModifiesPull(pullEvent) {
+		action = "other"
+	}
+
 	var pullEventType models.PullRequestEventType
 	switch action {
 	case "open":
@@ -73,4 +78,13 @@ func (e PullEventConverter) Convert(ctx context.Context, pullEvent *github.PullR
 		Timestamp:         eventTimestamp,
 		InstallationToken: installationToken,
 	}, nil
+}
+
+func eventActionModifiesPull(pullEvent *github.PullRequestEvent) bool {
+	originalAction := pullEvent.GetAction()
+	switch originalAction {
+	case "opened", "ready_for_review", "synchronized", "closed":
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Though we want to fetch the latest state changes from the pull request, we still want to avoid always running a Terraform plan on every open PR regardless of if the event was a code update vs. a simple edit. Confirming the original event was relevant (i.e. open, ready_for_review, synchronize, closed) will block this.