### PR TITLE
Mark combined plan checkrun as success in PR workflow

### DIFF
--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	KeyDelim       = "_"
-	CompleteStatus = "completed"
+	KeyDelim                  = "_"
+	CompleteStatus            = "completed"
+	CombinedPlanCheckRunTitle = "atlantis/plan"
 )
 
 type checksActivities interface {

--- a/server/neptune/workflows/internal/pr/revision/processor.go
+++ b/server/neptune/workflows/internal/pr/revision/processor.go
@@ -5,6 +5,7 @@ import (
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
@@ -26,10 +27,15 @@ type PolicyHandler interface {
 	Handle(ctx workflow.Context, prRevision Revision, failedPolicies []terraform.Response)
 }
 
+type CheckRunClient interface {
+	CreateOrUpdate(ctx workflow.Context, id string, request notifier.GithubCheckRunRequest) (int64, error)
+}
+
 type Processor struct {
-	TFStateReceiver TFStateReceiver
-	TFWorkflow      TFWorkflow
-	PolicyHandler   PolicyHandler
+	TFStateReceiver     TFStateReceiver
+	TFWorkflow          TFWorkflow
+	PolicyHandler       PolicyHandler
+	GithubCheckRunCache CheckRunClient
 }
 
 // Process handles spinning off child Terraform workflows per root and
@@ -56,6 +62,8 @@ func (p *Processor) Process(ctx workflow.Context, prRevision Revision) {
 	}
 	workflowResponses := p.awaitWorkflows(ctx, futures, roots)
 	p.PolicyHandler.Handle(ctx, prRevision, workflowResponses)
+	// At this point, all workflows should be successful, and we can mark combined plan check run as success
+	p.markCombinedCheckRunSuccessful(ctx, prRevision)
 }
 
 func (p *Processor) processRoot(ctx workflow.Context, root terraformActivities.Root, prRevision Revision, id uuid.UUID) workflow.ChildWorkflowFuture {
@@ -118,4 +126,22 @@ func (p *Processor) awaitWorkflows(ctx workflow.Context, futures []workflow.Chil
 		}
 	}
 	return results
+}
+
+func (p *Processor) markCombinedCheckRunSuccessful(ctx workflow.Context, revision Revision) {
+	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
+		MaximumAttempts: 3,
+	})
+
+	request := notifier.GithubCheckRunRequest{
+		Title: notifier.CombinedPlanCheckRunTitle,
+		Sha:   revision.Revision,
+		Repo:  revision.Repo,
+		State: github.CheckRunSuccess,
+		Mode:  terraformActivities.PR,
+	}
+	_, err := p.GithubCheckRunCache.CreateOrUpdate(ctx, "", request)
+	if err != nil {
+		workflow.GetLogger(ctx).Error("unable to update check run with validation error", internalContext.ErrKey, err)
+	}
 }

--- a/server/neptune/workflows/internal/pr/revision/processor.go
+++ b/server/neptune/workflows/internal/pr/revision/processor.go
@@ -140,6 +140,8 @@ func (p *Processor) markCombinedCheckRunSuccessful(ctx workflow.Context, revisio
 		State: github.CheckRunSuccess,
 		Mode:  terraformActivities.PR,
 	}
+	// ID is empty because we want to create a new check run
+	// TODO: do we want to create a new check run, are we persisting the original mark plan CR as queued in gateway?
 	_, err := p.GithubCheckRunCache.CreateOrUpdate(ctx, "", request)
 	if err != nil {
 		workflow.GetLogger(ctx).Error("unable to update check run with validation error", internalContext.ErrKey, err)

--- a/server/neptune/workflows/internal/pr/workflow.go
+++ b/server/neptune/workflows/internal/pr/workflow.go
@@ -2,9 +2,7 @@ package pr
 
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	workflowMetrics "github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"go.temporal.io/sdk/workflow"
 	"strconv"
@@ -18,7 +16,6 @@ type prActivities struct {
 }
 
 func Workflow(ctx workflow.Context, request Request, tfWorkflow revision.TFWorkflow) error {
-	var a *prActivities
 	options := workflow.ActivityOptions{
 		TaskQueue:           TaskQueue,
 		StartToCloseTimeout: 5 * time.Second,
@@ -28,13 +25,6 @@ func Workflow(ctx workflow.Context, request Request, tfWorkflow revision.TFWorkf
 		"repo":   request.RepoFullName,
 		"pr-num": strconv.Itoa(request.PRNum),
 	})
-	checkRunCache := notifier.NewGithubCheckRunCache(a)
-	notifiers := []revision.WorkflowNotifier{
-		&notifier.CheckRunNotifier{
-			CheckRunSessionCache: checkRunCache,
-			Mode:                 tfModel.PR,
-		},
-	}
-	runner := newRunner(ctx, scope, request.Organization, tfWorkflow, request.PRNum, notifiers)
+	runner := newRunner(ctx, scope, request.Organization, tfWorkflow, request.PRNum)
 	return runner.Run(ctx)
 }


### PR DESCRIPTION
We want to persist the combined plan check run. This should mark it as a success once we've passed all root workflows.