### PR TITLE
Bypass validation step GH reason

### DIFF
--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -48,6 +48,7 @@ type checkrunTemplateData struct {
 	PRMode                  bool
 	Skipped                 bool
 	ValidationError         bool
+	BypassedError           bool
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -64,6 +65,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	hearbeatTimeout := workflowState.Result.Reason == state.HeartbeatTimeoutError
 	skipped := workflowState.Result.Reason == state.SkippedCompletionReason
 	validation := workflowState.Result.Reason == state.ValidationFailedReason
+	bypassed := workflowState.Result.Reason == state.BypassedFailedValidationReason
 	var prMode bool
 	if workflowState.Mode != nil {
 		prMode = *workflowState.Mode == terraform.PR
@@ -84,6 +86,7 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 		PRMode:                  prMode,
 		InternalError:           internalError,
 		ValidationError:         validation,
+		BypassedError:           bypassed,
 		TimedOut:                timedOut,
 		ActivityDurationTimeout: activityDurationTimeout,
 		SchedulingTimeout:       schedulingTimeout,

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -39,6 +39,11 @@ Policy checks for this revision have failed. Please review logs to determine whi
 For most cases, these policy checks are designed to prevent accidental deployments of invalid infrastructure changes.
 If your change needs to bypass these checks, please reach out to the owners of the failing policy check/s and request PR approvals from them.
 {{end}}
+{{if .BypassedError }}
+## Validation Checks Bypassed :white_check_mark:
+Policy checks for this revision originally failed, but have been bypassed by a user with policy admin privileges.
+If you need to reference back to which policies originally failed, the original logs are linked above.
+{{end}}
 {{if .TimedOut }}
 ## Timeout :clock1:
 :point_right: We've hit an unknown timeout.  Please retry the deployment. If this persists this is most likely a bug, please contact the owners of atlantis so they can diagnose it.

--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -194,7 +194,7 @@ func determineCheckRunState(workflowState *state.Workflow) github.CheckRunState 
 		return github.CheckRunPending
 	}
 
-	if workflowState.Result.Reason == state.SuccessfulCompletionReason {
+	if workflowState.Result.Reason == state.SuccessfulCompletionReason || workflowState.Result.Reason == state.BypassedFailedValidationReason {
 		return github.CheckRunSuccess
 	}
 

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -39,6 +39,7 @@ const (
 	ActivityDurationTimeoutError
 	SkippedCompletionReason
 	ValidationFailedReason
+	BypassedFailedValidationReason
 )
 
 type JobOutput struct {


### PR DESCRIPTION
  Supporting the conversion GH approvals to atlantis/plan check run updates is going to be more of an invasive change so I'm breaking up the components. This first change just supports the new check run description, detailing what a `BypassedFailedValidationReason` means.