### PR TITLE
Avoid failing child TF workflow on validation failure

### DIFF
--- a/server/neptune/workflows/internal/terraform/request.go
+++ b/server/neptune/workflows/internal/terraform/request.go
@@ -64,19 +64,3 @@ func newUpdateJobError(err error, msg string) UpdateJobError {
 		ExternalError: ExternalError{ErrType: UpdateJobErrorType},
 	}
 }
-
-type ValidationError struct {
-	Err error
-	ExternalError
-}
-
-func (e ValidationError) Error() string {
-	return e.Err.Error()
-}
-
-func newValidationError() ValidationError {
-	return ValidationError{
-		Err:           fmt.Errorf("plan failed validation checks"),
-		ExternalError: ExternalError{ErrType: ValidationErrorType},
-	}
-}

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -424,15 +424,6 @@ func (r *Runner) toExternalError(err error, msg string) error {
 		return e.ToTemporalApplicationError()
 	}
 
-	var validationErr ValidationError
-	if errors.As(err, &validationErr) {
-		e := ApplicationError{
-			ErrType: validationErr.GetExternalType(),
-			Msg:     errors.Wrap(err, msg).Error(),
-		}
-		return e.ToTemporalApplicationError()
-	}
-
 	var timeoutErr *temporal.TimeoutError
 	if errors.As(err, &timeoutErr) {
 		switch timeoutErr.TimeoutType() {

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -197,7 +197,8 @@ func (r *Runner) Validate(ctx workflow.Context, root *terraform.LocalRoot, serve
 		}); e != nil {
 			return nil, newUpdateJobError(e, "unable to update job with failed status")
 		}
-		return validateResults, newValidationError()
+		// even if we fail, we still want to return the results for processing the failed policies
+		return validateResults, nil
 	}
 
 	if err := r.Store.UpdateValidateJobWithStatus(state.SuccessJobStatus, state.UpdateOptions{
@@ -285,9 +286,6 @@ func (r *Runner) Run(ctx workflow.Context) (Response, error) {
 			if appErr.Type() == PlanRejectedErrorType {
 				reason = state.SkippedCompletionReason
 			}
-			if appErr.Type() == ValidationErrorType {
-				reason = state.ValidationFailedReason
-			}
 		}
 
 		// check for any timeouts that percolated up
@@ -303,6 +301,10 @@ func (r *Runner) Run(ctx workflow.Context) (Response, error) {
 			default:
 				reason = state.TimeoutError
 			}
+		}
+
+		if containsFailure(resp.ValidationResults) {
+			reason = state.ValidationFailedReason
 		}
 
 		updateErr := r.Store.UpdateCompletion(state.WorkflowResult{

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -633,7 +633,7 @@ func TestSuccess_PRMode_FailedPolicy(t *testing.T) {
 	var resp response
 	err = env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
-	assert.True(t, resp.ValidateErr)
+	assert.False(t, resp.ValidateErr)
 
 	// assert results are expected
 	env.AssertExpectations(t)


### PR DESCRIPTION
Initially we failed the TF workflow if the validation step returned failed Conftest policies for the corresponding root (this allowed us the easily parse out that error to perform the correct update logic for our GH check run). Bug testing seems to hint that if we do fail the workflow (i.e. return an error), we don't return any workflow result either. Solution here is to simply mark the workflow as successful even if the Terraform plan doesn't pass all validation requirements. We can process the results itself to set the failure reason to `ValidationFailedReason`.

This better lines up with my interpretation of a successful TF workflow since failing validation checks shouldn't mean the TF workflow didn't do its job correctly (we do the same behavior on the Conftest activity itself). Plus, it avoids having to create a more complex error type to contain all of the metadata we want returned to the parent PR workflow.