### PR TITLE
Update check run after all failing policies are approved

### DIFF
--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	temporalInternal "github.com/runatlantis/atlantis/server/neptune/workflows/internal/temporal"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -28,6 +29,10 @@ type policyFilter interface {
 	Filter(teams map[string][]string, currentApprovals []*github.PullRequestReview, failedPolicies []activities.PolicySet) []activities.PolicySet
 }
 
+type notifier interface {
+	Notify(ctx workflow.Context, workflowState *state.Workflow, roots map[string]revision.RootInfo)
+}
+
 type NewReviewRequest struct {
 	Revision string
 }
@@ -40,6 +45,7 @@ type FailedPolicyHandler struct {
 	PRNumber            int
 	Org                 string
 	Scope               metrics.Scope
+	Notifier            notifier
 }
 
 type Action int64
@@ -50,12 +56,16 @@ const (
 	onSkip
 )
 
-func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Revision, workflowResponses []terraform.Response) {
+// Handle processes the roots corresponding to each Terraform workflow response and determines if any policies are failing
+// and need manual approvals from policy owners.
+func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Revision, roots map[string]revision.RootInfo, terraformWorkflowResponses []terraform.Response) {
 	scope := f.Scope.SubScopeWithTags(map[string]string{metricNames.RevisionTag: revision.Revision})
-	failedPolicies := dedup(workflowResponses, scope)
-	if len(failedPolicies) == 0 {
+	remainingFailedPolicies := fetchAllFailingPolicies(terraformWorkflowResponses, scope)
+	if len(remainingFailedPolicies) == 0 {
 		return
 	}
+	// we don't want to notify any workflows that were successful before we started polling for approvals
+	_, failingTerraformWorkflowResponses := partitionWorkflowsByFailure(terraformWorkflowResponses, remainingFailedPolicies)
 
 	var action Action
 	s := temporalInternal.SelectorWithTimeout{
@@ -66,10 +76,10 @@ func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Rev
 		if !more {
 			return
 		}
-		var reviewRequest NewReviewRequest
-		c.Receive(ctx, &reviewRequest)
+		var approvalRequest NewReviewRequest
+		c.Receive(ctx, &approvalRequest)
 		// skip signal if it's not for the current revision
-		if reviewRequest.Revision != revision.Revision {
+		if approvalRequest.Revision != revision.Revision {
 			action = onSkip
 		}
 		scope.SubScopeWithTags(map[string]string{metricNames.SignalNameTag: "pr-approval"}).
@@ -86,25 +96,32 @@ func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Rev
 	cancelTimer, _ := s.AddTimeout(ctx, 5*time.Minute, onTimeout)
 
 	for {
-		if len(failedPolicies) == 0 {
+		if len(remainingFailedPolicies) == 0 {
 			break
 		}
 		s.Select(ctx)
 		switch action {
 		case onSkip:
 			continue
-		case onApprovalSignal:
-			failedPolicies = f.handle(ctx, revision, failedPolicies)
 		case onPollTick:
 			// TODO: evaluate a better polling rate for approvals, or remove all together
 			cancelTimer()
 			cancelTimer, _ = s.AddTimeout(ctx, 10*time.Minute, onTimeout)
-			failedPolicies = f.handle(ctx, revision, failedPolicies)
+		}
+		// onPollTick and onApprovalSignal actions, filter out any newly approved policies
+		failingPolicies := f.filterOutApprovedPolicies(ctx, revision, remainingFailedPolicies)
+		// check if we've filtered out any newly approved policies
+		if len(failingPolicies) < len(remainingFailedPolicies) {
+			// notify any workflows that are now newly successful
+			successfulWorkflows, failingWorkflows := partitionWorkflowsByFailure(failingTerraformWorkflowResponses, failingPolicies)
+			f.updateCheckStatuses(ctx, roots, successfulWorkflows)
+			failingTerraformWorkflowResponses = failingWorkflows
+			remainingFailedPolicies = failingPolicies
 		}
 	}
 }
 
-func (f *FailedPolicyHandler) handle(ctx workflow.Context, revision revision.Revision, failedPolicies []activities.PolicySet) []activities.PolicySet {
+func (f *FailedPolicyHandler) filterOutApprovedPolicies(ctx workflow.Context, revision revision.Revision, failedPolicies []activities.PolicySet) []activities.PolicySet {
 	// Fetch current approvals in activity
 	var listPRReviewsResponse activities.ListPRReviewsResponse
 	err := workflow.ExecuteActivity(ctx, f.GithubActivities.GithubListPRReviews, activities.ListPRReviewsRequest{
@@ -150,7 +167,56 @@ func (f *FailedPolicyHandler) fetchTeamMembers(ctx workflow.Context, repo gh.Rep
 	return listTeamMembersResponse.Members, err
 }
 
-func dedup(workflowResponses []terraform.Response, scope metrics.Scope) []activities.PolicySet {
+// partitionWorkflowsByFailure separates workflows into successful and failing workflows
+// based on the provided failing policies
+func partitionWorkflowsByFailure(workflows []terraform.Response, failingPolicies []activities.PolicySet) ([]terraform.Response, []terraform.Response) {
+	var failingWorkflows []terraform.Response
+	var successfulWorkflows []terraform.Response
+	for _, workflow := range workflows {
+		if containsAnyPolicy(workflow, failingPolicies) {
+			failingWorkflows = append(failingWorkflows, workflow)
+		} else {
+			successfulWorkflows = append(successfulWorkflows, workflow)
+		}
+	}
+	return successfulWorkflows, failingWorkflows
+}
+
+// updateCheckStatuses checks to see if each root's workflow has any remaining failing policies.
+// If it doesn't then the workflow's check status reason is updated to be bypassed (i.e. passing)
+func (f *FailedPolicyHandler) updateCheckStatuses(ctx workflow.Context, roots map[string]revision.RootInfo, successfulWorkflows []terraform.Response) {
+	numUpdates := 0
+	for _, successfulWorkflow := range successfulWorkflows {
+		sw := successfulWorkflow
+		workflow.Go(ctx, func(c workflow.Context) {
+			workflowState := sw.WorkflowState
+			workflowState.Result.Status = state.CompleteWorkflowStatus
+			workflowState.Result.Reason = state.BypassedFailedValidationReason
+			f.Notifier.Notify(c, &workflowState, roots)
+			numUpdates++
+		})
+	}
+	err := workflow.Await(ctx, func() bool {
+		return numUpdates == len(successfulWorkflows)
+	})
+	if err != nil {
+		workflow.GetLogger(ctx).Error(err.Error())
+	}
+}
+
+// containsAnyPolicy checks if any of the provided failing policies are present in the provided workflow
+func containsAnyPolicy(workflowResponse terraform.Response, failingPolicies []activities.PolicySet) bool {
+	for _, response := range workflowResponse.ValidationResults {
+		for _, policy := range failingPolicies {
+			if response.PolicySet.Name == policy.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fetchAllFailingPolicies(workflowResponses []terraform.Response, scope metrics.Scope) []activities.PolicySet {
 	var failedPolicies []activities.PolicySet
 	for _, response := range workflowResponses {
 		for _, validationResult := range response.ValidationResults {

--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -189,11 +189,13 @@ func (f *FailedPolicyHandler) updateCheckStatuses(ctx workflow.Context, roots ma
 	for _, successfulWorkflow := range successfulWorkflows {
 		sw := successfulWorkflow
 		workflow.Go(ctx, func(c workflow.Context) {
+			defer func() {
+				numUpdates++
+			}()
 			workflowState := sw.WorkflowState
 			workflowState.Result.Status = state.CompleteWorkflowStatus
 			workflowState.Result.Reason = state.BypassedFailedValidationReason
 			f.Notifier.Notify(c, &workflowState, roots)
-			numUpdates++
 		})
 	}
 	err := workflow.Await(ctx, func() bool {

--- a/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision/policy"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
@@ -27,6 +28,8 @@ type request struct {
 	FilterResponse      []activities.PolicySet
 	FilterErr           error
 	GithubActivities    *mockGithubActivities
+	Roots               map[string]revision.RootInfo
+	State               *state.Workflow
 }
 
 type response struct {
@@ -35,10 +38,11 @@ type response struct {
 	DismisserErr     error
 	FilterCalls      int
 	FilterPolicies   []activities.PolicySet
+	NotifierCalls    int
 }
 
 const (
-	approveID = "approve"
+	reviewID = "review"
 )
 
 func testWorkflow(ctx workflow.Context, r request) (response, error) {
@@ -54,21 +58,29 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 		filteredPolicies:  r.FilterResponse,
 		t:                 r.T,
 	}
+	notifier := &mockNotifier{
+		t:                     r.T,
+		expectedRoots:         r.Roots,
+		expectedWorkflowState: r.State,
+	}
 	handler := &policy.FailedPolicyHandler{
-		ReviewSignalChannel: workflow.GetSignalChannel(ctx, approveID),
+		ReviewSignalChannel: workflow.GetSignalChannel(ctx, reviewID),
 		Dismisser:           dismisser,
 		PolicyFilter:        filter,
 		GithubActivities:    r.GithubActivities,
 		PRNumber:            1,
 		Scope:               metrics.NewNullableScope(),
+		Notifier:            notifier,
 	}
-	handler.Handle(ctx, r.Revision, r.WorkflowResponses)
+	handler.Handle(ctx, r.Revision, r.Roots, r.WorkflowResponses)
+	_ = workflow.Sleep(ctx, 5*time.Second) //sleep to test notifier called
 	return response{
 		DismisserCalls:   dismisser.calls,
 		DismisserReviews: dismisser.expectedReviews,
 		DismisserErr:     dismisser.err,
 		FilterCalls:      filter.calls,
 		FilterPolicies:   filter.filteredPolicies,
+		NotifierCalls:    notifier.calls,
 	}, nil
 }
 
@@ -90,7 +102,7 @@ func TestFailedPolicyHandlerRunner_NoRoots(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(approveID, policy.NewReviewRequest{})
+		env.SignalWorkflow(reviewID, policy.NewReviewRequest{})
 	}, 2*time.Second)
 	env.ExecuteWorkflow(testWorkflow, req)
 	var resp response
@@ -108,6 +120,9 @@ func TestFailedPolicyHandlerRunner_Handle(t *testing.T) {
 	ga := &mockGithubActivities{
 		reviews: activities.ListPRReviewsResponse{Reviews: []*github.PullRequestReview{testApproval}},
 	}
+	roots := map[string]revision.RootInfo{
+		"testRoot": {},
+	}
 	req := request{
 		T:        t,
 		Revision: revision.Revision{Repo: gh.Repo{Name: "repo"}, Revision: "sha"},
@@ -123,25 +138,31 @@ func TestFailedPolicyHandlerRunner_Handle(t *testing.T) {
 		},
 		GithubActivities: ga,
 		DismissResponse:  []*github.PullRequestReview{testApproval},
+		Roots:            roots,
+		State: &state.Workflow{Result: state.WorkflowResult{
+			Status: state.CompleteWorkflowStatus,
+			Reason: state.ValidationFailedReason,
+		}},
 	}
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	env.RegisterActivity(ga)
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(approveID, policy.NewReviewRequest{Revision: "stale"})
+		env.SignalWorkflow(reviewID, policy.NewReviewRequest{Revision: "stale"})
 	}, 2*time.Second)
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(approveID, policy.NewReviewRequest{Revision: "sha"})
+		env.SignalWorkflow(reviewID, policy.NewReviewRequest{Revision: "sha"})
 	}, 2*time.Second)
 	env.ExecuteWorkflow(testWorkflow, req)
 	var resp response
 	err := env.GetWorkflowResult(&resp)
 	assert.NoError(t, err)
-	assert.Equal(t, resp.DismisserCalls, 1)
-	assert.Equal(t, resp.FilterCalls, 1)
+	assert.Equal(t, 1, resp.DismisserCalls)
+	assert.Equal(t, 1, resp.FilterCalls)
 	assert.NoError(t, resp.DismisserErr)
 	assert.Empty(t, resp.FilterPolicies)
-	assert.Equal(t, resp.DismisserReviews[0], testApproval)
+	assert.Equal(t, testApproval, resp.DismisserReviews[0])
+	assert.Equal(t, 1, resp.NotifierCalls)
 }
 
 type mockDismisser struct {
@@ -181,4 +202,17 @@ func (g *mockGithubActivities) GithubListTeamMembers(ctx context.Context, reques
 func (g *mockGithubActivities) GithubListPRReviews(ctx context.Context, request activities.ListPRReviewsRequest) (activities.ListPRReviewsResponse, error) {
 	g.called = true
 	return g.reviews, g.err
+}
+
+type mockNotifier struct {
+	calls                 int
+	t                     *testing.T
+	expectedWorkflowState *state.Workflow
+	expectedRoots         map[string]revision.RootInfo
+}
+
+func (m *mockNotifier) Notify(ctx workflow.Context, workflowState *state.Workflow, roots map[string]revision.RootInfo) {
+	m.calls++
+	assert.Equal(m.t, m.expectedWorkflowState, workflowState)
+	assert.Equal(m.t, m.expectedRoots, roots)
 }

--- a/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
@@ -86,18 +86,9 @@ func testWorkflow(ctx workflow.Context, r request) (response, error) {
 
 func TestFailedPolicyHandlerRunner_NoRoots(t *testing.T) {
 	req := request{
-		T:        t,
-		Revision: revision.Revision{Repo: gh.Repo{Name: "repo"}},
-		WorkflowResponses: []terraform.Response{
-			{
-				ValidationResults: []activities.ValidationResult{
-					{
-						Status:    activities.Success,
-						PolicySet: activities.PolicySet{Name: "policy1"},
-					},
-				},
-			},
-		},
+		T:                 t,
+		Revision:          revision.Revision{Repo: gh.Repo{Name: "repo"}},
+		WorkflowResponses: []terraform.Response{},
 	}
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()

--- a/server/neptune/workflows/internal/pr/revision/processor.go
+++ b/server/neptune/workflows/internal/pr/revision/processor.go
@@ -24,7 +24,7 @@ type TFStateReceiver interface {
 }
 
 type PolicyHandler interface {
-	Handle(ctx workflow.Context, prRevision Revision, failedPolicies []terraform.Response)
+	Handle(ctx workflow.Context, prRevision Revision, roots map[string]RootInfo, workflowResponses []terraform.Response)
 }
 
 type CheckRunClient interface {
@@ -61,7 +61,7 @@ func (p *Processor) Process(ctx workflow.Context, prRevision Revision) {
 		futures = append(futures, future)
 	}
 	workflowResponses := p.awaitWorkflows(ctx, futures, roots)
-	p.PolicyHandler.Handle(ctx, prRevision, workflowResponses)
+	p.PolicyHandler.Handle(ctx, prRevision, roots, workflowResponses)
 	// At this point, all workflows should be successful, and we can mark combined plan check run as success
 	p.markCombinedCheckRunSuccessful(ctx, prRevision)
 }

--- a/server/neptune/workflows/internal/pr/revision/processor.go
+++ b/server/neptune/workflows/internal/pr/revision/processor.go
@@ -2,9 +2,12 @@ package revision
 
 import (
 	"github.com/google/uuid"
+	metricNames "github.com/runatlantis/atlantis/server/metrics"
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/sideeffect"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
@@ -36,6 +39,7 @@ type Processor struct {
 	TFWorkflow          TFWorkflow
 	PolicyHandler       PolicyHandler
 	GithubCheckRunCache CheckRunClient
+	Scope               metrics.Scope
 }
 
 // Process handles spinning off child Terraform workflows per root and
@@ -43,6 +47,9 @@ type Processor struct {
 func (p *Processor) Process(ctx workflow.Context, prRevision Revision) {
 	roots := make(map[string]RootInfo)
 	var futures []workflow.ChildWorkflowFuture
+	scope := p.Scope.SubScope("policies").SubScopeWithTags(map[string]string{
+		metricNames.RevisionTag: prRevision.Revision,
+	})
 	for _, root := range prRevision.Roots {
 		id, err := sideeffect.GenerateUUID(ctx)
 		if err != nil {
@@ -60,8 +67,22 @@ func (p *Processor) Process(ctx workflow.Context, prRevision Revision) {
 		future := p.processRoot(ctx, root, prRevision, id)
 		futures = append(futures, future)
 	}
-	workflowResponses := p.awaitWorkflows(ctx, futures, roots)
-	p.PolicyHandler.Handle(ctx, prRevision, roots, workflowResponses)
+
+	terraformWorkflowResponses := p.awaitChildTerraformWorkflows(ctx, futures, roots)
+	// Count all policy successes/failures + handle any failures by listening for approvals in PolicyHandler
+	var failingTerraformWorkflowResponses []terraform.Response
+	for _, resp := range terraformWorkflowResponses {
+		for _, validationResult := range resp.ValidationResults {
+			switch validationResult.Status {
+			case activities.Fail:
+				scope.SubScope(validationResult.PolicySet.Name).Counter(metricNames.ExecutionFailureMetric).Inc(1)
+				failingTerraformWorkflowResponses = append(failingTerraformWorkflowResponses, resp)
+			case activities.Success:
+				scope.SubScope(validationResult.PolicySet.Name).Counter(metricNames.ExecutionSuccessMetric).Inc(1)
+			}
+		}
+	}
+	p.PolicyHandler.Handle(ctx, prRevision, roots, failingTerraformWorkflowResponses)
 	// At this point, all workflows should be successful, and we can mark combined plan check run as success
 	p.markCombinedCheckRunSuccessful(ctx, prRevision)
 }
@@ -93,9 +114,9 @@ func (p *Processor) processRoot(ctx workflow.Context, root terraformActivities.R
 	return future
 }
 
-// awaitWorkflows creates a selector to listen to the completion of each root's child workflow future and any state
+// awaitChildTerraformWorkflows creates a selector to listen to the completion of each root's child workflow future and any state
 // change signals they send over the shared WorkflowStateChangeSignal channel; we only return when all workflows complete
-func (p *Processor) awaitWorkflows(ctx workflow.Context, futures []workflow.ChildWorkflowFuture, roots map[string]RootInfo) []terraform.Response {
+func (p *Processor) awaitChildTerraformWorkflows(ctx workflow.Context, futures []workflow.ChildWorkflowFuture, roots map[string]RootInfo) []terraform.Response {
 	selector := workflow.NewNamedSelector(ctx, "TerraformChildWorkflow")
 	ch := workflow.GetSignalChannel(ctx, state.WorkflowStateChangeSignal)
 	selector.AddReceive(ch, func(c workflow.ReceiveChannel, _ bool) {

--- a/server/neptune/workflows/internal/pr/revision/processor_test.go
+++ b/server/neptune/workflows/internal/pr/revision/processor_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/pr/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
@@ -119,6 +120,7 @@ func testProcessRevisionWorkflow(ctx workflow.Context, r processRevisionRequest)
 				Mode:  terraformActivities.PR,
 			},
 		},
+		Scope: metrics.NewNullableScope(),
 	}
 	processor.Process(ctx, r.Revision)
 

--- a/server/neptune/workflows/internal/pr/revision/processor_test.go
+++ b/server/neptune/workflows/internal/pr/revision/processor_test.go
@@ -17,13 +17,14 @@ import (
 const (
 	badPolicy  = "bad-policy"
 	badPolicy2 = "bad-policy-2"
+	goodPolicy = "good-policy"
 )
 
 type processRevisionRequest struct {
-	T                      *testing.T
-	Revision               revision.Revision
-	TFWorkflowFail         bool
-	ExpectedFailedPolicies []activities.PolicySet
+	T              *testing.T
+	Revision       revision.Revision
+	TFWorkflowFail bool
+	Responses      []terraform.Response
 }
 
 type processRevisionResponse struct{}
@@ -31,19 +32,31 @@ type processRevisionResponse struct{}
 // test 3 roots, two successful, one failure
 // have first two roots contain different failing policies
 // confirm policies returned are what we expect
-
 func TestProcess(t *testing.T) {
 	t.Run("returns expected policy failures", func(t *testing.T) {
-		expectedPolicies := []activities.PolicySet{
-			{Name: badPolicy},
-			{Name: badPolicy2},
+		result1 := activities.ValidationResult{
+			PolicySet: activities.PolicySet{Name: goodPolicy},
+			Status:    activities.Success,
+		}
+		result2 := activities.ValidationResult{
+			PolicySet: activities.PolicySet{Name: badPolicy2},
+			Status:    activities.Fail,
+		}
+		result3 := activities.ValidationResult{
+			PolicySet: activities.PolicySet{Name: badPolicy},
+			Status:    activities.Fail,
+		}
+		responses := []terraform.Response{
+			{
+				ValidationResults: []activities.ValidationResult{result1, result2, result3},
+			},
 		}
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 		env.RegisterWorkflow(testTFWorkflow)
 		env.ExecuteWorkflow(testProcessRevisionWorkflow, processRevisionRequest{
-			T:                      t,
-			ExpectedFailedPolicies: expectedPolicies,
+			T:         t,
+			Responses: responses,
 			Revision: revision.Revision{
 				Repo: github.Repo{},
 				Roots: []terraformActivities.Root{
@@ -91,10 +104,10 @@ func testProcessRevisionWorkflow(ctx workflow.Context, r processRevisionRequest)
 	processor := revision.Processor{
 		TFStateReceiver: &revision.StateReceiver{},
 		TFWorkflow:      tfWorkflow,
-		PolicyHandler: testPolicyHandler{
-			expectedFailedPolicies: r.ExpectedFailedPolicies,
-			expectedRevision:       r.Revision,
-			t:                      r.T,
+		PolicyHandler: &testPolicyHandler{
+			expectedRevision:  r.Revision,
+			expectedResponses: r.Responses,
+			t:                 r.T,
 		},
 		GithubCheckRunCache: &testCheckRunCache{
 			t: r.T,
@@ -117,7 +130,7 @@ func testTFWorkflow(_ workflow.Context, _ terraform.Request) (terraform.Response
 		ValidationResults: []activities.ValidationResult{
 			{
 				Status:    activities.Success,
-				PolicySet: activities.PolicySet{Name: "good-policy"},
+				PolicySet: activities.PolicySet{Name: goodPolicy},
 			},
 			{
 				Status:    activities.Fail,
@@ -136,14 +149,14 @@ func testTFWorkflowFailure(_ workflow.Context, _ terraform.Request) (terraform.R
 }
 
 type testPolicyHandler struct {
-	t                      *testing.T
-	expectedFailedPolicies []activities.PolicySet
-	expectedRevision       revision.Revision
+	t                 *testing.T
+	expectedResponses []terraform.Response
+	expectedRevision  revision.Revision
 }
 
-func (p testPolicyHandler) Handle(_ workflow.Context, revision revision.Revision, failedPolicies []terraform.Response) {
+func (p *testPolicyHandler) Handle(ctx workflow.Context, revision revision.Revision, roots map[string]revision.RootInfo, responses []terraform.Response) {
 	assert.Equal(p.t, p.expectedRevision, revision)
-	assert.Equal(p.t, p.expectedFailedPolicies, failedPolicies)
+	assert.Equal(p.t, p.expectedResponses, responses)
 }
 
 type testCheckRunCache struct {

--- a/server/neptune/workflows/internal/pr/revision/state.go
+++ b/server/neptune/workflows/internal/pr/revision/state.go
@@ -26,6 +26,10 @@ func (s *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 		metrics.SignalNameTag: state.WorkflowStateChangeSignal,
 	}).Counter(metrics.SignalReceive).Inc(1)
 
+	s.Notify(ctx, workflowState, roots)
+}
+
+func (s *StateReceiver) Notify(ctx workflow.Context, workflowState *state.Workflow, roots map[string]RootInfo) {
 	rootInfo := roots[workflowState.ID]
 	for _, notifier := range s.InternalNotifiers {
 		if err := notifier.Notify(ctx, rootInfo.ToInternalInfo(), workflowState); err != nil {

--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -91,10 +91,11 @@ func newRunner(ctx workflow.Context, scope workflowMetrics.Scope, org string, tf
 			Dismisser:           &dismisser,
 			PolicyFilter:        &policy.Filter{},
 			Org:                 org,
-			Scope:               scope.SubScope("policies"),
+			Scope:               scope,
 			Notifier:            &stateReceiver,
 		},
 		GithubCheckRunCache: checkRunCache,
+		Scope:               scope,
 	}
 	shutdownChecker := ShutdownStateChecker{
 		GithubActivities: ga,

--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -92,6 +92,7 @@ func newRunner(ctx workflow.Context, scope workflowMetrics.Scope, org string, tf
 			PolicyFilter:        &policy.Filter{},
 			Org:                 org,
 			Scope:               scope.SubScope("policies"),
+			Notifier:            &stateReceiver,
 		},
 		GithubCheckRunCache: checkRunCache,
 	}

--- a/server/neptune/workflows/internal/terraform/response.go
+++ b/server/neptune/workflows/internal/terraform/response.go
@@ -2,8 +2,10 @@ package terraform
 
 import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 )
 
 type Response struct {
 	ValidationResults []activities.ValidationResult
+	WorkflowState     state.Workflow
 }

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -173,6 +173,10 @@ func (s *WorkflowStore) UpdateCompletion(result WorkflowResult) error {
 	return s.notifier(s.state)
 }
 
+func (s *WorkflowStore) GetStateCopy() Workflow {
+	return *s.state
+}
+
 func getStartTimeFromOpts(options ...UpdateOptions) time.Time {
 	for _, o := range options {
 		if !o.StartTime.IsZero() {

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -346,10 +346,14 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 
 	if r.Request.WorkflowMode == terraform.PR {
 		validationResults, err := r.Validate(ctx, root, response.ServerURL, planResponse.PlanJSONFile)
-		if err != nil {
-			return Response{ValidationResults: validationResults}, r.toExternalError(err, "running validate job")
+		resp := Response{
+			ValidationResults: validationResults,
+			WorkflowState:     r.Store.GetStateCopy(),
 		}
-		return Response{ValidationResults: validationResults}, nil
+		if err != nil {
+			return resp, r.toExternalError(err, "running validate job")
+		}
+		return resp, nil
 	}
 
 	if err = r.Apply(ctx, root, response.ServerURL, planResponse); err != nil {

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -348,12 +348,12 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 
 	if r.Request.WorkflowMode == terraform.PR {
 		validationResults, err := r.Validate(ctx, root, response.ServerURL, planResponse.PlanJSONFile)
+		if err != nil {
+			return Response{}, r.toExternalError(err, "running validate job")
+		}
 		resp := Response{
 			ValidationResults: validationResults,
 			WorkflowState:     r.Store.GetStateCopy(),
-		}
-		if err != nil {
-			return resp, r.toExternalError(err, "running validate job")
 		}
 		return resp, nil
 	}


### PR DESCRIPTION
We support using GH approvals as a way to bypass failing policies. If all failing policies on a root are approved, we need to mark the checkrun status as successful to allow for merges. Note this is triggered by approval events (we will rerun full plan and policy check steps if a review = requested changes to revert back to no approvals).