### PR TITLE
Listen for context cancellation in policy handler selector

### DIFF
--- a/server/metrics/common.go
+++ b/server/metrics/common.go
@@ -31,6 +31,7 @@ const (
 	// Signal receive is when we receive it off the channel
 	SignalReceive = "signal_receive"
 	PollTick      = "poll_tick"
+	ContextCancel = "context_canceled"
 
 	// Forced shutdown timeout when a workflow is suspected to be abandoned
 	ShutdownTimeout = "shutdown_timeout"


### PR DESCRIPTION
Parent context can be canceled within the code if the PR is closed/new revision comes in. We should be able to gracefully exit this for-select if we listen for those cancellations and return.