### PR TITLE
Fix team list fetch to use Name identifier

### DIFF
--- a/server/neptune/workflows/internal/pr/revision/policy/filter.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/filter.go
@@ -9,13 +9,13 @@ type Filter struct{}
 
 func (p *Filter) Filter(teams map[string][]string, currentReviews []*github.PullRequestReview, failedPolicies []activities.PolicySet) []activities.PolicySet {
 	approvers := findRecentApprovers(currentReviews)
-	var filteredFailedPolicies []activities.PolicySet
+	var remainingFailedPolicies []activities.PolicySet
 	for _, failedPolicy := range failedPolicies {
-		if approved := p.policyApprovedByOwner(approvers, teams[failedPolicy.Owner]); !approved {
-			filteredFailedPolicies = append(filteredFailedPolicies, failedPolicy)
+		if approved := p.policyApprovedByOwner(approvers, teams[failedPolicy.Name]); !approved {
+			remainingFailedPolicies = append(remainingFailedPolicies, failedPolicy)
 		}
 	}
-	return filteredFailedPolicies
+	return remainingFailedPolicies
 }
 
 // only return an approval from a user if it is their most recent review

--- a/server/neptune/workflows/internal/pr/revision/policy/filter_test.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/filter_test.go
@@ -12,7 +12,8 @@ func TestFilter_FilterOutTeamA(t *testing.T) {
 	filter := policy.Filter{}
 	expectedFilteredPolicies := []activities.PolicySet{
 		{
-			Owner: "team-c",
+			Owner: "owners-c",
+			Name:  "team-c",
 		},
 	}
 	teams := map[string][]string{
@@ -22,10 +23,12 @@ func TestFilter_FilterOutTeamA(t *testing.T) {
 	}
 	failedPolicies := []activities.PolicySet{
 		{
-			Owner: "team-a",
+			Owner: "owners-a",
+			Name:  "team-a",
 		},
 		{
-			Owner: "team-c",
+			Owner: "owners-c",
+			Name:  "team-c",
 		},
 	}
 	currentReviews := []*github.PullRequestReview{
@@ -55,10 +58,12 @@ func TestFilter_IgnoreOldApprovalWhenChangesRequested(t *testing.T) {
 	}
 	failedPolicies := []activities.PolicySet{
 		{
-			Owner: "team-a",
+			Owner: "owners-a",
+			Name:  "team-a",
 		},
 		{
-			Owner: "team-c",
+			Owner: "owners-c",
+			Name:  "team-c",
 		},
 	}
 	currentReviews := []*github.PullRequestReview{

--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -143,7 +143,6 @@ func (f *FailedPolicyHandler) filterOutBypassedPolicies(ctx workflow.Context, re
 	}
 
 	// Dismiss stale approvals
-	// TODO gate dismissal with flag
 	currentReviews := listPRReviewsResponse.Reviews
 	currentReviews, err = f.Dismisser.Dismiss(ctx, revision, teams, currentReviews)
 	if err != nil {

--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -152,8 +152,8 @@ func (f *FailedPolicyHandler) filterOutBypassedPolicies(ctx workflow.Context, re
 	}
 
 	// Filter out failed policies from policy approvals
-	filteredPolicies := f.PolicyFilter.Filter(teams, currentReviews, failedPolicies)
-	return filteredPolicies
+	remainingFailedPolicies := f.PolicyFilter.Filter(teams, currentReviews, failedPolicies)
+	return remainingFailedPolicies
 }
 
 func (f *FailedPolicyHandler) fetchTeamMembers(ctx workflow.Context, repo gh.Repo, slug string) ([]string, error) {


### PR DESCRIPTION
Bug fix in approval logic: Make sure we fetch the set of owners on a team using the team name (i.e. `teams[failedPolicy.Name]`) instead of owners because that is the key we build the list off of. PR also goes through and consistently names the remaining failed policies to the variable: `remainingFailedPolicies`.