### PR TITLE
Set initial poll tick to occur after Handle() is called

### DIFF
--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -95,7 +95,8 @@ func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Rev
 			Counter(metricNames.PollTick).
 			Inc(1)
 	}
-	cancelTimer, _ := s.AddTimeout(ctx, 10*time.Minute, onTimeout)
+	// perform initial check immediately (subsequent polls can occur at larger intervals)
+	cancelTimer, _ := s.AddTimeout(ctx, time.Millisecond, onTimeout)
 
 	for {
 		if len(failingTerraformWorkflows) == 0 {


### PR DESCRIPTION
We should run through the policy handler logic (dismissals, initial state checks, etc.) immediately after the revision processor first spins up the Handle(), mainly to handle pr review dismissals on stale revisions immediately after a new plan has been generated. 

Subsequent polls will [continue](https://github.com/lyft/atlantis/blob/4ee94b44da15408df79b50d0cc3a6d5535fe6ac7/server/neptune/workflows/internal/pr/revision/policy/handler.go#L114) to occur at 10 min. intervals for now. Alternatively, we can maintain existing poll logic and add following [code chunk](https://github.com/lyft/atlantis/blob/4ee94b44da15408df79b50d0cc3a6d5535fe6ac7/server/neptune/workflows/internal/pr/revision/policy/handler.go#L119-L123) before spinning up the for-select if that is preferred for clarity.