### PR TITLE
Support plan and validation summaries

### DIFF
--- a/server/neptune/workflows/activities/conftest/summary.go
+++ b/server/neptune/workflows/activities/conftest/summary.go
@@ -1,0 +1,58 @@
+package conftest
+
+import (
+	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"strings"
+)
+
+type ValidateSummary struct {
+	Failures  []string
+	Successes []string
+}
+
+func NewValidateSummaryFromResults(results []activities.ValidationResult) ValidateSummary {
+	if len(results) == 0 {
+		return ValidateSummary{}
+	}
+
+	var failures []string
+	var successes []string
+	for _, result := range results {
+		summary := result.PolicySet.Name
+		switch result.Status {
+		case activities.Fail:
+			failures = append(failures, summary)
+		case activities.Success:
+			successes = append(successes, summary)
+		}
+	}
+
+	return ValidateSummary{
+		Failures:  failures,
+		Successes: successes,
+	}
+}
+
+func (s ValidateSummary) IsEmpty() bool {
+	return len(s.Successes) == 0 && len(s.Failures) == 0
+}
+
+func (s ValidateSummary) String() string {
+	if s.IsEmpty() {
+		return "No policies exist in this run."
+	}
+	successes := strings.Join(s.Successes, ", ")
+	if successes == "" {
+		successes = "None"
+	}
+	failures := strings.Join(s.Failures, ", ")
+	if failures == "" {
+		failures = "None"
+	}
+
+	return fmt.Sprintf(
+		"Successful policies: %s\n\n"+
+			"Failing policies: %s\n",
+		successes, failures)
+}

--- a/server/neptune/workflows/activities/conftest/summary.go
+++ b/server/neptune/workflows/activities/conftest/summary.go
@@ -52,5 +52,5 @@ func (s ValidateSummary) String() string {
 	}
 
 	return fmt.Sprintf(
-		"Successful policies: %s`\n\n`"+"Failing policies: %s", successes, failures)
+		"Successful policies: %s`\n\n`Failing policies: %s", successes, failures)
 }

--- a/server/neptune/workflows/activities/conftest/summary.go
+++ b/server/neptune/workflows/activities/conftest/summary.go
@@ -40,7 +40,7 @@ func (s ValidateSummary) IsEmpty() bool {
 
 func (s ValidateSummary) String() string {
 	if s.IsEmpty() {
-		return "No policies exist in this run."
+		return "No policies exist in this run. Most likely, no policies were ever configured or there was an internal error. Please check the logs."
 	}
 	successes := strings.Join(s.Successes, ", ")
 	if successes == "" {

--- a/server/neptune/workflows/activities/conftest/summary.go
+++ b/server/neptune/workflows/activities/conftest/summary.go
@@ -52,7 +52,5 @@ func (s ValidateSummary) String() string {
 	}
 
 	return fmt.Sprintf(
-		"Successful policies: %s\n\n"+
-			"Failing policies: %s\n",
-		successes, failures)
+		"Successful policies: %s`\n\n`"+"Failing policies: %s", successes, failures)
 }

--- a/server/neptune/workflows/activities/conftest/summary.go
+++ b/server/neptune/workflows/activities/conftest/summary.go
@@ -20,11 +20,10 @@ func NewValidateSummaryFromResults(results []activities.ValidationResult) Valida
 	var successes []string
 	for _, result := range results {
 		summary := result.PolicySet.Name
-		switch result.Status {
-		case activities.Fail:
-			failures = append(failures, summary)
-		case activities.Success:
+		if result.Status == activities.Success {
 			successes = append(successes, summary)
+		} else {
+			failures = append(failures, summary)
 		}
 	}
 

--- a/server/neptune/workflows/activities/conftest/summary_test.go
+++ b/server/neptune/workflows/activities/conftest/summary_test.go
@@ -1,0 +1,52 @@
+package conftest
+
+import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
+	"gopkg.in/go-playground/assert.v1"
+	"testing"
+)
+
+func TestNewValidateSummaryFromResults(t *testing.T) {
+	testResults := []activities.ValidationResult{
+		{
+			PolicySet: activities.PolicySet{
+				Name: "policy1",
+			},
+			Status: activities.Fail,
+		},
+		{
+			PolicySet: activities.PolicySet{
+				Name: "policy2",
+			},
+			Status: activities.Success,
+		},
+	}
+	summary := NewValidateSummaryFromResults(testResults)
+	assert.Equal(t, summary.Failures, []string{"policy1"})
+	assert.Equal(t, summary.Successes, []string{"policy2"})
+}
+
+func TestValidateSummary_IsEmpty(t *testing.T) {
+	summary := ValidateSummary{}
+	assert.Equal(t, summary.IsEmpty(), true)
+	summary = ValidateSummary{
+		Failures:  []string{"policy1"},
+		Successes: []string{"policy2"},
+	}
+	assert.Equal(t, summary.IsEmpty(), false)
+}
+
+func TestValidateSummary_String(t *testing.T) {
+	summary := ValidateSummary{}
+	assert.Equal(t, summary.String(), "No policies exist in this run.")
+	summary = ValidateSummary{
+		Failures:  []string{},
+		Successes: []string{"policy2"},
+	}
+	assert.Equal(t, summary.String(), "Successful policies: policy2\n\nFailing policies: None\n")
+	summary = ValidateSummary{
+		Failures:  []string{"policy1"},
+		Successes: []string{"policy2"},
+	}
+	assert.Equal(t, summary.String(), "Successful policies: policy2\n\nFailing policies: policy1\n")
+}

--- a/server/neptune/workflows/activities/conftest/summary_test.go
+++ b/server/neptune/workflows/activities/conftest/summary_test.go
@@ -43,10 +43,10 @@ func TestValidateSummary_String(t *testing.T) {
 		Failures:  []string{},
 		Successes: []string{"policy2"},
 	}
-	assert.Equal(t, summary.String(), "Successful policies: policy2\n\nFailing policies: None\n")
+	assert.Equal(t, summary.String(), "Successful policies: policy2`\n\n`Failing policies: None")
 	summary = ValidateSummary{
 		Failures:  []string{"policy1"},
 		Successes: []string{"policy2"},
 	}
-	assert.Equal(t, summary.String(), "Successful policies: policy2\n\nFailing policies: policy1\n")
+	assert.Equal(t, summary.String(), "Successful policies: policy2`\n\n`Failing policies: policy1")
 }

--- a/server/neptune/workflows/activities/conftest/summary_test.go
+++ b/server/neptune/workflows/activities/conftest/summary_test.go
@@ -38,7 +38,7 @@ func TestValidateSummary_IsEmpty(t *testing.T) {
 
 func TestValidateSummary_String(t *testing.T) {
 	summary := ValidateSummary{}
-	assert.Equal(t, summary.String(), "No policies exist in this run.")
+	assert.Equal(t, summary.String(), "No policies exist in this run. Most likely, no policies were ever configured or there was an internal error. Please check the logs.")
 	summary = ValidateSummary{
 		Failures:  []string{},
 		Successes: []string{"policy2"},

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	_ "embed" //embedding files
 	"fmt"
-	"html/template"
-
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"html/template"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 )
@@ -81,11 +80,11 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	var planSummary string
 	var validateSummary string
 	if prMode {
-		if workflowState.Plan != nil && workflowState.Plan.Output != nil {
+		if workflowState.Plan != nil && workflowState.Plan.IsComplete() && workflowState.Plan.Output != nil {
 			planSummary = workflowState.Plan.Output.PlanSummary.String()
 		}
 
-		if workflowState.Validate != nil && workflowState.Validate.Output != nil {
+		if workflowState.Validate != nil && workflowState.Validate.IsComplete() && workflowState.Validate.Output != nil {
 			validateSummary = workflowState.Validate.Output.ValidateSummary.String()
 		}
 	}

--- a/server/neptune/workflows/activities/github/markdown/renderer.go
+++ b/server/neptune/workflows/activities/github/markdown/renderer.go
@@ -49,6 +49,8 @@ type checkrunTemplateData struct {
 	Skipped                 bool
 	ValidationError         bool
 	BypassedError           bool
+	PlanSummary             string
+	ValidateSummary         string
 }
 
 func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
@@ -72,15 +74,29 @@ func RenderWorkflowStateTmpl(workflowState *state.Workflow) string {
 	}
 
 	var applyActionsSummary string
-
 	if workflowState.Apply != nil {
 		applyActionsSummary = workflowState.Apply.GetActions().Summary
 	}
+
+	var planSummary string
+	var validateSummary string
+	if prMode {
+		if workflowState.Plan != nil && workflowState.Plan.Output != nil {
+			planSummary = workflowState.Plan.Output.PlanSummary.String()
+		}
+
+		if workflowState.Validate != nil && workflowState.Validate.Output != nil {
+			validateSummary = workflowState.Validate.Output.ValidateSummary.String()
+		}
+	}
+
 	return renderTemplate(checkrunTemplate, checkrunTemplateData{
 		PlanStatus:              planStatus,
 		PlanLogURL:              planLogURL,
+		PlanSummary:             planSummary,
 		ValidateStatus:          validateStatus,
 		ValidateLogURL:          validateLogURL,
+		ValidateSummary:         validateSummary,
 		ApplyStatus:             applyStatus,
 		ApplyLogURL:             applyLogURL,
 		PRMode:                  prMode,

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -38,14 +38,14 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 ## Plan Summary
 `{{.PlanSummary}}`
 
-:warning: **Please review plan logs linked above carefully for details on what resources were added, modified, or deleted (if any).**
+:warning: **Please carefully review plan logs linked above for details on what resources were added, modified, or deleted (if any).**
 {{end}}
 
 {{if .ValidateSummary }}
 ## Validation Summary
 `{{.ValidateSummary}}`
 
-:warning: **Please review validation logs linked above carefully for details on what specific validation rules failed (if any).**
+:warning: **Please carefully review validation logs linked above for details on what specific validation rules failed (if any).**
 {{end}}
 
 {{if .ValidationError }}

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -33,17 +33,34 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 
 **Note: If the terraform operations do not indicate any failure, there is a likely a platform issue. Contact service owners for additional debugging.**
 {{end}}
+
+{{if .PlanSummary }}
+## Plan Summary
+`{{.PlanSummary}}`
+
+:warning: **Please review plan logs linked above carefully for details on what resources were added, modified, or deleted (if any).**
+{{end}}
+
+{{if .ValidateSummary }}
+## Validation Summary
+`{{.ValidateSummary}}`
+
+:warning: **Please review validation logs linked above carefully for details on what specific validation rules failed (if any).**
+{{end}}
+
 {{if .ValidationError }}
 ## Validation Failure :no_entry_sign:
 Policy checks for this revision have failed. Please review logs to determine which policies have failed and why.
 For most cases, these policy checks are designed to prevent accidental deployments of invalid infrastructure changes.
 If your change needs to bypass these checks, please reach out to the owners of the failing policy check/s and request PR approvals from them.
 {{end}}
+
 {{if .BypassedError }}
 ## Validation Checks Bypassed :white_check_mark:
 Policy checks for this revision originally failed, but have been bypassed by a user with policy admin privileges.
 If you need to reference back to which policies originally failed, the original logs are linked above.
 {{end}}
+
 {{if .TimedOut }}
 ## Timeout :clock1:
 :point_right: We've hit an unknown timeout.  Please retry the deployment. If this persists this is most likely a bug, please contact the owners of atlantis so they can diagnose it.

--- a/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
+++ b/server/neptune/workflows/activities/github/markdown/templates/checkrun.tmpl
@@ -49,14 +49,14 @@ If a specific terraform operation has failed, check the logs (linked above) to d
 {{end}}
 
 {{if .ValidationError }}
-## Validation Failure :no_entry_sign:
+### Validation Failure :no_entry_sign:
 Policy checks for this revision have failed. Please review logs to determine which policies have failed and why.
 For most cases, these policy checks are designed to prevent accidental deployments of invalid infrastructure changes.
 If your change needs to bypass these checks, please reach out to the owners of the failing policy check/s and request PR approvals from them.
 {{end}}
 
 {{if .BypassedError }}
-## Validation Checks Bypassed :white_check_mark:
+### Validation Checks Bypassed :white_check_mark:
 Policy checks for this revision originally failed, but have been bypassed by a user with policy admin privileges.
 If you need to reference back to which policies originally failed, the original logs are linked above.
 {{end}}

--- a/server/neptune/workflows/activities/terraform/summary.go
+++ b/server/neptune/workflows/activities/terraform/summary.go
@@ -66,7 +66,7 @@ func NewPlanSummaryFromJSON(b []byte) (PlanSummary, error) {
 
 func (s PlanSummary) String() string {
 	if s.IsEmpty() {
-		return ""
+		return "No plan summary created."
 	}
 	return fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", len(s.Creations), len(s.Updates), len(s.Deletions))
 }

--- a/server/neptune/workflows/activities/terraform/summary.go
+++ b/server/neptune/workflows/activities/terraform/summary.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-json"
 	"github.com/pkg/errors"
@@ -61,4 +62,11 @@ func NewPlanSummaryFromJSON(b []byte) (PlanSummary, error) {
 		Deletions: deletions,
 		Updates:   updates,
 	}, nil
+}
+
+func (s PlanSummary) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+	return fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", len(s.Creations), len(s.Updates), len(s.Deletions))
 }

--- a/server/neptune/workflows/activities/terraform/summary.go
+++ b/server/neptune/workflows/activities/terraform/summary.go
@@ -66,7 +66,7 @@ func NewPlanSummaryFromJSON(b []byte) (PlanSummary, error) {
 
 func (s PlanSummary) String() string {
 	if s.IsEmpty() {
-		return "No plan summary created."
+		return "No plan summary created. Most likely due to an error. Please check the logs."
 	}
 	return fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", len(s.Creations), len(s.Updates), len(s.Deletions))
 }

--- a/server/neptune/workflows/activities/terraform/summary_test.go
+++ b/server/neptune/workflows/activities/terraform/summary_test.go
@@ -67,3 +67,12 @@ func TestSummary_empty(t *testing.T) {
 	assert.Equal(t, terraform.PlanSummary{}, summary)
 	assert.True(t, summary.IsEmpty())
 }
+
+func TestSummary_string(t *testing.T) {
+	plan := "{\"format_version\": \"1.0\",\"resource_changes\":[{\"change\":{\"actions\":[\"update\"]},\"address\":\"type.resource_update\"},{\"change\":{\"actions\":[\"create\"]},\"address\":\"type.resource_create\"}, {\"change\":{\"actions\":[\"delete\"]},\"address\":\"type.resource_delete\"}]}"
+
+	summary, err := terraform.NewPlanSummaryFromJSON([]byte(plan))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Plan: 1 to add, 1 to change, 1 to destroy.", summary.String())
+}

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -125,10 +125,9 @@ func (s *WorkflowStore) UpdateValidateJobWithStatus(status JobStatus, options ..
 
 	case FailedJobStatus, SuccessJobStatus:
 		s.state.Validate.EndTime = getEndTimeFromOpts(options...)
-	}
-
-	for _, o := range options {
-		s.state.Validate.Output.ValidateSummary = o.ValidateSummary
+		for _, o := range options {
+			s.state.Validate.Output.ValidateSummary = o.ValidateSummary
+		}
 	}
 
 	s.state.Validate.Status = status

--- a/server/neptune/workflows/internal/terraform/state/store.go
+++ b/server/neptune/workflows/internal/terraform/state/store.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 	"net/url"
 	"time"
 
@@ -28,10 +29,11 @@ type WorkflowStore struct {
 }
 
 type UpdateOptions struct {
-	PlanSummary  terraform.PlanSummary
-	PlanApproval terraform.PlanApproval
-	StartTime    time.Time
-	EndTime      time.Time
+	PlanSummary     terraform.PlanSummary
+	PlanApproval    terraform.PlanApproval
+	ValidateSummary conftest.ValidateSummary
+	StartTime       time.Time
+	EndTime         time.Time
 }
 
 func NewWorkflowStoreWithGenerator(notifier UpdateNotifier, g urlGenerator, mode terraform.WorkflowMode, id string) *WorkflowStore {
@@ -125,6 +127,10 @@ func (s *WorkflowStore) UpdateValidateJobWithStatus(status JobStatus, options ..
 		s.state.Validate.EndTime = getEndTimeFromOpts(options...)
 	}
 
+	for _, o := range options {
+		s.state.Validate.Output.ValidateSummary = o.ValidateSummary
+	}
+
 	s.state.Validate.Status = status
 	return s.notifier(s.state)
 }
@@ -150,7 +156,7 @@ func (s *WorkflowStore) UpdatePlanJobWithStatus(status JobStatus, options ...Upd
 	s.state.Plan.Status = status
 
 	for _, o := range options {
-		s.state.Plan.Output.Summary = o.PlanSummary
+		s.state.Plan.Output.PlanSummary = o.PlanSummary
 	}
 	return s.notifier(s.state)
 }

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -102,6 +102,10 @@ func (j Job) GetActions() JobActions {
 	return JobActions{}
 }
 
+func (j Job) IsComplete() bool {
+	return j.Status == SuccessJobStatus || j.Status == FailedJobStatus
+}
+
 type WorkflowResult struct {
 	Status WorkflowStatus
 	Reason WorkflowCompletionReason

--- a/server/neptune/workflows/internal/terraform/state/workflow.go
+++ b/server/neptune/workflows/internal/terraform/state/workflow.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 	"net/url"
 	"time"
 
@@ -46,7 +47,10 @@ type JobOutput struct {
 	URL *url.URL
 
 	// populated for plan jobs
-	Summary terraform.PlanSummary
+	PlanSummary terraform.PlanSummary
+
+	// populated for validate jobs
+	ValidateSummary conftest.ValidateSummary
 }
 
 type JobAction struct {


### PR DESCRIPTION
PR adds plan and validation checks summaries to the check runs of a PR workflow upon completion of the plan and validation jobs, respectively. Open to feedback on how this looks, where we should position it (i.e. before or after the explanation on if the validation step failed/bypassed, etc.)


Here's an example of what it could look like (in my test, there are no conftest policies enabled):

<h2 class="f3" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; font-size: 1.5em; font-weight: var(--base-text-weight-semibold, 600); line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted)); color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">atlantis/plan: root1</h2><div class="ml-0" style="box-sizing: border-box; margin-left: 0px !important; margin-bottom: 0px !important; color: rgb(31, 35, 40); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Operation | Status | Logs
-- | -- | --
Plan | success | Click Here
Validate | success | Click Here

<h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: var(--base-text-weight-semibold, 600); line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));">Plan Summary</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted)); border-radius: 6px;">Plan: 1 to add, 0 to change, 0 to destroy.</code></p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><g-emoji class="g-emoji" alias="warning" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png" style="box-sizing: border-box; display: inline-block; min-width: 1ch; font-family: &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-size: 1.25em; font-weight: var(--base-text-weight-normal, 400); line-height: 1; vertical-align: -0.075em; font-style: normal !important;">⚠️</g-emoji><span> </span><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold, 600);">Please review plan logs linked above carefully for details on what resources were added, modified, or deleted (if any).</strong></p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: var(--base-text-weight-semibold, 600); line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--borderColor-muted, var(--color-border-muted));">Validation Summary</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted)); border-radius: 6px;">Successful policies: policy2

Failing policies: policy1</code></p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><g-emoji class="g-emoji" alias="warning" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png" style="box-sizing: border-box; display: inline-block; min-width: 1ch; font-family: &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-size: 1.25em; font-weight: var(--base-text-weight-normal, 400); line-height: 1; vertical-align: -0.075em; font-style: normal !important;">⚠️</g-emoji><span> </span><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold, 600);">Please review validation logs linked above carefully for details on what specific validation rules failed (if any).</strong></p></div>
