### PR TITLE
Don't mark atlantis/plan as queued in gateway

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -73,10 +73,9 @@ func NewCommentEventWorkerProxy(logger logging.Logger, snsWriter Writer, schedul
 		logger:    logger,
 		scheduler: scheduler,
 		legacyHandler: &LegacyCommentHandler{
-			logger:           logger,
-			snsWriter:        snsWriter,
-			vcsStatusUpdater: vcsStatusUpdater,
-			globalCfg:        globalCfg,
+			logger:    logger,
+			snsWriter: snsWriter,
+			globalCfg: globalCfg,
 		},
 		neptuneWorkerProxy: &NeptuneWorkerProxy{
 			logger:             logger,
@@ -242,7 +241,7 @@ func (p *CommentEventWorkerProxy) handle(ctx context.Context, request *http.Buff
 	return combinedErrors.ErrorOrNil()
 }
 
-// TODO: do we need to keep marking plan as successful after legacy deprecation?
+// TODO: remove Apply after we roll out pr workflow, and PolicyCheck after all legacy code is removed
 func (p *CommentEventWorkerProxy) markSuccessStatuses(ctx context.Context, event Comment, cmd *command.Comment) {
 	if cmd.Name == command.Plan {
 		for _, name := range []command.Name{command.Plan, command.PolicyCheck, command.Apply} {

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -497,14 +497,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment(t *testing.T) {
 	writer := &mockSnsWriter{}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Plan.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
+	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
 	allocator := &testAllocator{
 		t:                 t,
@@ -520,7 +513,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment(t *testing.T) {
 	}
 	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
-	assert.True(t, statusUpdater.isCalled)
+	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
 	assert.True(t, writer.isCalled)
@@ -574,14 +567,7 @@ func TestCommentEventWorkerProxy_HandlePlanCommentAllocatorEnabled(t *testing.T)
 	writer := &mockSnsWriter{}
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Plan.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
+	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
 	allocator := &testAllocator{
 		t:                  t,
@@ -600,7 +586,7 @@ func TestCommentEventWorkerProxy_HandlePlanCommentAllocatorEnabled(t *testing.T)
 	}
 	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
-	assert.True(t, statusUpdater.isCalled)
+	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
 	assert.True(t, writer.isCalled)
@@ -631,14 +617,7 @@ func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 	scheduler := &sync.SynchronousScheduler{Logger: logger}
 	rootDeployer := &mockRootDeployer{}
 	commentCreator := &mockCommentCreator{}
-	statusUpdater := &mockStatusUpdater{
-		expectedRepo:      testRepo,
-		expectedPull:      testPull,
-		expectedVCSStatus: models.QueuedVCSStatus,
-		expectedCmd:       command.Plan.String(),
-		expectedBody:      "Request received. Adding to the queue...",
-		expectedT:         t,
-	}
+	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
 	allocator := &testAllocator{
 		t:                 t,
@@ -664,7 +643,7 @@ func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 	}
 	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.Error(t, err)
-	assert.True(t, statusUpdater.isCalled)
+	assert.False(t, statusUpdater.isCalled)
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, rootDeployer.isCalled)
 	assert.True(t, writer.isCalled)

--- a/server/neptune/gateway/event/legacy_comment_handler.go
+++ b/server/neptune/gateway/event/legacy_comment_handler.go
@@ -3,8 +3,6 @@ package event
 import (
 	"bytes"
 	"context"
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/config/valid"
 	"github.com/runatlantis/atlantis/server/legacy/events/command"
@@ -14,10 +12,9 @@ import (
 )
 
 type LegacyCommentHandler struct {
-	logger           logging.Logger
-	vcsStatusUpdater statusUpdater
-	snsWriter        Writer
-	globalCfg        valid.GlobalCfg
+	logger    logging.Logger
+	snsWriter Writer
+	globalCfg valid.GlobalCfg
 }
 
 func (p *LegacyCommentHandler) Handle(ctx context.Context, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg, request *http.BufferedRequest) error {
@@ -25,20 +22,11 @@ func (p *LegacyCommentHandler) Handle(ctx context.Context, event Comment, cmd *c
 	if cmd.Name == command.Apply {
 		return nil
 	}
-	p.SetQueuedStatus(ctx, event, cmd)
 	// forward everything to sns for now since platform mode doesn't do anything w.r.t to comments atm.
 	if err := p.ForwardToSns(ctx, request); err != nil {
 		return errors.Wrap(err, "forwarding request through sns")
 	}
 	return nil
-}
-
-func (p *LegacyCommentHandler) SetQueuedStatus(ctx context.Context, event Comment, cmd *command.Comment) {
-	if p.shouldMarkEventQueued(event, cmd) {
-		if _, err := p.vcsStatusUpdater.UpdateCombined(ctx, event.BaseRepo, event.Pull, models.QueuedVCSStatus, cmd.Name, "", "Request received. Adding to the queue..."); err != nil {
-			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
-		}
-	}
 }
 
 func (p *LegacyCommentHandler) shouldMarkEventQueued(event Comment, cmd *command.Comment) bool {

--- a/server/neptune/gateway/event/legacy_comment_handler.go
+++ b/server/neptune/gateway/event/legacy_comment_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/runatlantis/atlantis/server/legacy/events/command"
 	"github.com/runatlantis/atlantis/server/legacy/http"
 	"github.com/runatlantis/atlantis/server/logging"
-	"github.com/runatlantis/atlantis/server/models"
 )
 
 type LegacyCommentHandler struct {
@@ -27,24 +26,6 @@ func (p *LegacyCommentHandler) Handle(ctx context.Context, event Comment, cmd *c
 		return errors.Wrap(err, "forwarding request through sns")
 	}
 	return nil
-}
-
-func (p *LegacyCommentHandler) shouldMarkEventQueued(event Comment, cmd *command.Comment) bool {
-	// pending status should only be for plan step
-	if cmd.Name != command.Plan {
-		return false
-	}
-	// pull event should not be from a fork
-	if event.Pull.HeadRepo.Owner != event.Pull.BaseRepo.Owner {
-		return false
-	}
-	// pull event should not be from closed PR
-	if event.Pull.State == models.ClosedPullState {
-		return false
-	}
-	// pull event should not use an invalid base branch
-	repo := p.globalCfg.MatchingRepo(event.Pull.BaseRepo.ID())
-	return repo.BranchMatches(event.Pull.BaseBranch)
 }
 
 func (p *LegacyCommentHandler) ForwardToSns(ctx context.Context, request *http.BufferedRequest) error {

--- a/server/neptune/gateway/event/legacy_pull_handler.go
+++ b/server/neptune/gateway/event/legacy_pull_handler.go
@@ -46,11 +46,6 @@ func (l *LegacyPullHandler) Handle(ctx context.Context, request *http.BufferedRe
 		l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
 	}
 
-	// mark plan status as queued. since this is the pull handler, we know that we're only executing plans
-	if _, err := l.VCSStatusUpdater.UpdateCombined(ctx, event.Pull.HeadRepo, event.Pull, models.QueuedVCSStatus, command.Plan, "", "Request received. Adding to the queue..."); err != nil {
-		l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", err))
-	}
-
 	// forward to sns
 	err := l.WorkerProxy.Handle(ctx, request, event)
 	if err != nil {

--- a/server/neptune/gateway/event/legacy_pull_handler_test.go
+++ b/server/neptune/gateway/event/legacy_pull_handler_test.go
@@ -43,7 +43,7 @@ func TestLegacyHandler_Handle_WorkerProxyFailure(t *testing.T) {
 	err := legacyHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{}, []*valid.MergedProjectCfg{legacyRoot})
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Equal(t, 0, statusUpdater.combinedCountCalls)
-	assert.Equal(t, 2, statusUpdater.combinedCalls)
+	assert.Equal(t, 1, statusUpdater.combinedCalls)
 }
 
 func TestLegacyHandler_Handle_WorkerProxySuccess(t *testing.T) {
@@ -62,7 +62,7 @@ func TestLegacyHandler_Handle_WorkerProxySuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, workerProxy.called)
 	assert.Equal(t, 0, statusUpdater.combinedCountCalls)
-	assert.Equal(t, 2, statusUpdater.combinedCalls)
+	assert.Equal(t, 1, statusUpdater.combinedCalls)
 }
 
 type mockVCSStatusUpdater struct {


### PR DESCRIPTION
We only wanted to support this here temporarily, let's remove this and only mark the general `atlantis/plan` with a success/failure conclusion in the temporalworker itself