### PR TITLE
ensure only one error handler is called

### DIFF
--- a/server/legacy/lyft/gateway/events_controller.go
+++ b/server/legacy/lyft/gateway/events_controller.go
@@ -87,10 +87,18 @@ func NewVCSEventsController(
 		closedPullHandler,
 	)
 
-	errorHandler := gateway_handlers.NewPREventErrorHandler(
+	legacyErrorHandler := gateway_handlers.NewLegacyErrorHandler(
 		commentCreator,
 		globalCfg,
 		logger,
+		featureAllocator,
+	)
+
+	neptuneErrorHandler := gateway_handlers.NewNeptuneErrorHandler(
+		commentCreator,
+		globalCfg,
+		logger,
+		featureAllocator,
 	)
 
 	teamMemberFetcher := &github.TeamMemberFetcher{
@@ -120,7 +128,8 @@ func NewVCSEventsController(
 			vcsStatusUpdater,
 			globalCfg,
 			rootConfigBuilder,
-			errorHandler,
+			legacyErrorHandler,
+			neptuneErrorHandler,
 			requirementChecker),
 		logger,
 	)

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -3,9 +3,10 @@ package event_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/runatlantis/atlantis/server/neptune/gateway/pr"
 	"github.com/runatlantis/atlantis/server/neptune/lyft/feature"
-	"testing"
 
 	"github.com/runatlantis/atlantis/server/config/valid"
 	"github.com/runatlantis/atlantis/server/legacy/events/command"
@@ -178,7 +179,7 @@ func TestCommentEventWorkerProxy_HandleForceApply(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name:       command.Apply,
@@ -236,7 +237,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_RequirementsFailed(t *testin
 	commentCreator := &mockCommentCreator{}
 	statusUpdater := &mockStatusUpdater{}
 	cfg := valid.NewGlobalCfg("somedir")
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{
 		err: assert.AnError,
 	})
 	bufReq := buildRequest(t)
@@ -319,7 +320,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
@@ -394,7 +395,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
@@ -453,7 +454,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Apply,
@@ -513,7 +514,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
@@ -593,7 +594,7 @@ func TestCommentEventWorkerProxy_HandlePlanCommentAllocatorEnabled(t *testing.T)
 		expectedRoots:     roots,
 		expectedPRRequest: prRequest,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	cmd := &command.Comment{
 		Name: command.Plan,
@@ -647,7 +648,7 @@ func TestCommentEventWorkerProxy_WriteError(t *testing.T) {
 	prSignaler := &mockPRSignaler{
 		expectedT: t,
 	}
-	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, &requirementsChecker{})
+	commentEventWorkerProxy := event.NewCommentEventWorkerProxy(logger, writer, scheduler, allocator, prSignaler, testSignaler, commentCreator, statusUpdater, cfg, rootConfigBuilder, noopErrorHandler{}, noopErrorHandler{}, &requirementsChecker{})
 	bufReq := buildRequest(t)
 	commentEvent := event.Comment{
 		Pull:     testPull,

--- a/server/neptune/gateway/event/pr_error_handler.go
+++ b/server/neptune/gateway/event/pr_error_handler.go
@@ -47,16 +47,6 @@ func NewLegacyErrorHandler(commentCreator *github.CommentCreator, cfg valid.Glob
 	}
 }
 
-func NewPREventErrorHandler(commentCreator *github.CommentCreator, cfg valid.GlobalCfg, logger logging.Logger) *PREventErrorHandler {
-	return &PREventErrorHandler{
-		commentCreator: commentCreator,
-		templateLoader: &template.Loader[template.PRCommentData]{
-			GlobalCfg: cfg,
-		},
-		logger: logger,
-	}
-}
-
 type LegacyPREventErrorHandler struct {
 	allocator feature.Allocator
 	delegate  *PREventErrorHandler


### PR DESCRIPTION
Was setting up a demo for my team and noticed this can happen so i thought i'd fix it 🙂 

<img width="1018" alt="image" src="https://github.com/lyft/atlantis/assets/7416619/a6c8f8de-b7c7-4a71-bd94-3b39018a9094">

Basically since you're only surfacing either legacy or neptune, we shouldn't have two comments appear.