### PR TITLE
Comment on PR if inactivity timeout is reached

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -43,6 +43,7 @@ type githubClient interface { //nolint:interfacebloat
 	ListCommits(ctx internal.Context, owner string, repo string, number int) ([]*github.RepositoryCommit, error)
 	DismissReview(ctx internal.Context, owner, repo string, number int, reviewID int64, review *github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, *github.Response, error)
 	ListTeamMembers(ctx internal.Context, org string, teamSlug string) ([]*github.User, error)
+	CreateComment(ctx internal.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 }
 
 type DiffDirection string
@@ -464,4 +465,29 @@ func (a *githubActivities) GithubListTeamMembers(ctx context.Context, request Li
 	return ListTeamMembersResponse{
 		Members: members,
 	}, nil
+}
+
+type CreateCommentRequest struct {
+	Repo        internal.Repo
+	PRNumber    int
+	CommentBody string
+}
+
+type CreateCommentResponse struct{}
+
+func (a *githubActivities) GithubCreateComment(ctx context.Context, request CreateCommentRequest) (CreateCommentResponse, error) {
+	comment := &github.IssueComment{
+		Body: github.String(request.CommentBody),
+	}
+	_, resp, err := a.Client.CreateComment(
+		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
+		request.Repo.Owner,
+		request.Repo.Name,
+		request.PRNumber,
+		comment,
+	)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return CreateCommentResponse{}, errors.Wrap(err, "creating comment on PR")
+	}
+	return CreateCommentResponse{}, nil
 }

--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -479,14 +479,14 @@ func (a *githubActivities) GithubCreateComment(ctx context.Context, request Crea
 	comment := &github.IssueComment{
 		Body: github.String(request.CommentBody),
 	}
-	_, resp, err := a.Client.CreateComment(
+	_, _, err := a.Client.CreateComment(
 		internal.ContextWithInstallationToken(ctx, request.Repo.Credentials.InstallationToken),
 		request.Repo.Owner,
 		request.Repo.Name,
 		request.PRNumber,
 		comment,
 	)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		return CreateCommentResponse{}, errors.Wrap(err, "creating comment on PR")
 	}
 	return CreateCommentResponse{}, nil

--- a/server/neptune/workflows/activities/github/client.go
+++ b/server/neptune/workflows/activities/github/client.go
@@ -138,3 +138,11 @@ func (c *Client) ListTeamMembers(ctx Context, org string, teamSlug string) ([]*g
 	}
 	return gh_helper.Iterate(ctx, run)
 }
+
+func (c *Client) CreateComment(ctx Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+	if err != nil {
+		return nil, nil, err
+	}
+	return client.Issues.CreateComment(ctx, owner, repo, number, comment)
+}

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -262,6 +262,10 @@ type testGithubClient struct {
 	DeploymentID string
 }
 
+func (c *testGithubClient) CreateComment(ctx internalGithub.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	return &github.IssueComment{}, &github.Response{}, nil
+}
+
 func (c *testGithubClient) ListTeamMembers(ctx internalGithub.Context, org string, teamSlug string) ([]*github.User, error) {
 	return []*github.User{}, nil
 }

--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -111,7 +111,7 @@ func (f *FailedPolicyHandler) Handle(ctx workflow.Context, revision revision.Rev
 		case onPollTick:
 			// TODO: evaluate a better polling rate for approvals, or remove all together
 			cancelTimer()
-			cancelTimer, _ = s.AddTimeout(ctx, 10*time.Minute, onTimeout)
+			cancelTimer, _ = s.AddTimeout(ctx, time.Hour, onTimeout)
 		}
 
 		// onPollTick and onReviewSignal actions, filter out failing policies that have been approved and identify if

--- a/server/neptune/workflows/internal/pr/revision/processor.go
+++ b/server/neptune/workflows/internal/pr/revision/processor.go
@@ -174,7 +174,6 @@ func (p *Processor) markCombinedCheckRun(ctx workflow.Context, revision Revision
 		Summary: summary,
 	}
 	// ID is empty because we want to create a new check run
-	// TODO: do we want to create a new check run, are we persisting the original mark plan CR as queued in gateway?
 	_, err := p.GithubCheckRunCache.CreateOrUpdate(ctx, "", request)
 	if err != nil {
 		workflow.GetLogger(ctx).Error("unable to update check run with validation error", internalContext.ErrKey, err)

--- a/server/neptune/workflows/internal/pr/runner.go
+++ b/server/neptune/workflows/internal/pr/runner.go
@@ -242,6 +242,9 @@ func (r *Runner) shouldProcessRevision(prRevision revision.Revision) bool {
 }
 
 func (r *Runner) notifyOnTimeout(ctx workflow.Context, prRevision revision.Revision) {
+	ctx = workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
+		MaximumAttempts: 3,
+	})
 	createCommentRequest := activities.CreateCommentRequest{
 		Repo:        prRevision.Repo,
 		PRNumber:    r.PRNumber,


### PR DESCRIPTION
To prevent holding state on Github PRs that may have been abandoned or no longer in active iteration, we shutdown any existing workflow after a week of inactivity. This change also notifies the user of this by creating a comment in the PR explaining this prior to shutdown.

<img width="917" alt="image" src="https://github.com/lyft/atlantis/assets/22844626/40fbd1eb-0520-4016-b756-c6e2e635d4ba">


Also: decided to increase the poll rate against policy check logic to 1 hour increments before initial rollout to see its effects to the GH rate limit before tightening that value.
