### PR TITLE
Remove unneeded gateway status checks

### DIFF
--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -216,9 +216,6 @@ func (p *CommentEventWorkerProxy) handle(ctx context.Context, request *http.Buff
 	}, event.InstallationToken)
 
 	if err != nil {
-		if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx, event.HeadRepo, event.Pull, models.FailedVCSStatus, cmd.Name, "", err.Error()); statusErr != nil {
-			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %v", statusErr))
-		}
 		return errors.Wrap(err, "getting project commands")
 	}
 
@@ -246,18 +243,9 @@ func (p *CommentEventWorkerProxy) handle(ctx context.Context, request *http.Buff
 	return combinedErrors.ErrorOrNil()
 }
 
-// TODO: remove Apply after we roll out pr workflow, and PolicyCheck after all legacy code is removed
 func (p *CommentEventWorkerProxy) markSuccessStatuses(ctx context.Context, event Comment, cmd *command.Comment) {
 	if cmd.Name == command.Plan {
-		for _, name := range []command.Name{command.Plan, command.PolicyCheck, command.Apply} {
-			if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx, event.HeadRepo, event.Pull, models.SuccessVCSStatus, name, "", "no modified roots"); statusErr != nil {
-				p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %v", statusErr))
-			}
-		}
-	}
-
-	if cmd.Name == command.Apply {
-		if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx, event.HeadRepo, event.Pull, models.SuccessVCSStatus, cmd.Name, "", "no modified roots"); statusErr != nil {
+		if _, statusErr := p.vcsStatusUpdater.UpdateCombined(ctx, event.HeadRepo, event.Pull, models.SuccessVCSStatus, command.Plan, "", "no modified roots"); statusErr != nil {
 			p.logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %v", statusErr))
 		}
 	}

--- a/server/neptune/gateway/event/comment_handler_test.go
+++ b/server/neptune/gateway/event/comment_handler_test.go
@@ -402,7 +402,7 @@ func TestCommentEventWorkerProxy_HandlePlanComment_NoCmds(t *testing.T) {
 	}
 	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
-	assert.True(t, statusUpdater.AllCalled())
+	assert.False(t, statusUpdater.AllCalled())
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
 	assert.False(t, writer.isCalled)
@@ -461,7 +461,7 @@ func TestCommentEventWorkerProxy_HandleApplyComment_NoCmds(t *testing.T) {
 	}
 	err := commentEventWorkerProxy.Handle(context.Background(), bufReq, commentEvent, cmd)
 	assert.NoError(t, err)
-	assert.True(t, statusUpdater.AllCalled())
+	assert.False(t, statusUpdater.AllCalled())
 	assert.False(t, commentCreator.isCalled)
 	assert.False(t, testSignaler.called)
 	assert.False(t, writer.isCalled)

--- a/server/neptune/gateway/event/legacy_pull_handler.go
+++ b/server/neptune/gateway/event/legacy_pull_handler.go
@@ -33,17 +33,10 @@ func (l *LegacyPullHandler) Handle(ctx context.Context, request *http.BufferedRe
 	// mark legacy statuses as successful if there are no roots in general
 	// this is processed here to make it easy to clean up when we deprecate legacy mode
 	if len(allRoots) == 0 {
-		for _, cmd := range []command.Name{command.Plan, command.Apply, command.PolicyCheck} {
-			if _, statusErr := l.VCSStatusUpdater.UpdateCombinedCount(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, cmd, 0, 0, ""); statusErr != nil {
-				l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
-			}
+		if _, statusErr := l.VCSStatusUpdater.UpdateCombinedCount(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, command.Plan, 0, 0, ""); statusErr != nil {
+			l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
 		}
 		return nil
-	}
-
-	// mark apply status as successful until we're able to remove this as a required check from our github org.
-	if _, statusErr := l.VCSStatusUpdater.UpdateCombined(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, command.Apply, "", PlatformModeApplyStatusMessage); statusErr != nil {
-		l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
 	}
 
 	// forward to sns

--- a/server/neptune/gateway/event/legacy_pull_handler_test.go
+++ b/server/neptune/gateway/event/legacy_pull_handler_test.go
@@ -25,7 +25,7 @@ func TestLegacyHandler_Handle_NoRoots(t *testing.T) {
 	err := legacyHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{}, []*valid.MergedProjectCfg{})
 	assert.NoError(t, err)
 	assert.False(t, workerProxy.called)
-	assert.Equal(t, statusUpdater.combinedCountCalls, 3)
+	assert.Equal(t, statusUpdater.combinedCountCalls, 1)
 	assert.Equal(t, statusUpdater.combinedCalls, 0)
 }
 
@@ -43,7 +43,7 @@ func TestLegacyHandler_Handle_WorkerProxyFailure(t *testing.T) {
 	err := legacyHandler.Handle(context.Background(), &http.BufferedRequest{}, event.PullRequest{}, []*valid.MergedProjectCfg{legacyRoot})
 	assert.ErrorIs(t, err, assert.AnError)
 	assert.Equal(t, 0, statusUpdater.combinedCountCalls)
-	assert.Equal(t, 1, statusUpdater.combinedCalls)
+	assert.Equal(t, 0, statusUpdater.combinedCalls)
 }
 
 func TestLegacyHandler_Handle_WorkerProxySuccess(t *testing.T) {
@@ -62,7 +62,7 @@ func TestLegacyHandler_Handle_WorkerProxySuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, workerProxy.called)
 	assert.Equal(t, 0, statusUpdater.combinedCountCalls)
-	assert.Equal(t, 1, statusUpdater.combinedCalls)
+	assert.Equal(t, 0, statusUpdater.combinedCalls)
 }
 
 type mockVCSStatusUpdater struct {


### PR DESCRIPTION
Now that we've deprecated atlantis/apply, let's skip marking it as successful in gateway in the case we receive a comment/pull event that has no Terraform roots in the underlying revision. 