### PR TITLE
Avoid adding invalid check runs to the check run cache

### DIFF
--- a/server/neptune/workflows/internal/notifier/github.go
+++ b/server/neptune/workflows/internal/notifier/github.go
@@ -61,8 +61,12 @@ func (c *GithubCheckRunCache) CreateOrUpdate(ctx workflow.Context, deploymentID 
 		if err != nil {
 			return 0, err
 		}
-		c.deploymentCheckRunCache[key] = resp.ID
-		c.deleteIfCompleted(resp.Status, key)
+		// skip adding to cache if ID is invalid
+		// this case can occur in PR workflows if the allocator is not enabled
+		if resp.ID != 0 {
+			c.deploymentCheckRunCache[key] = resp.ID
+			c.deleteIfCompleted(resp.Status, key)
+		}
 
 		return resp.ID, nil
 	}


### PR DESCRIPTION
The problem with enabling a feature allocator at the check run mutation level is the temporal worker relies on a built in cache to store in progress check run IDs. This can cause issues down the line because if we are now tasked with updating this check run after enabling the feature flag, the original logic will store an empty check run id in the cache, causing us to attempt to Update the check run with a "0" id. 

With this change, I want test out skipping storing those 0 id check runs and see what the UX behavior is if we just create a new check run to replace any existing ones.