### PR TITLE
Check policy is failing in workflow success criteria

### DIFF
--- a/server/neptune/workflows/internal/pr/revision/policy/handler.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler.go
@@ -210,9 +210,9 @@ func (f *FailedPolicyHandler) updateCheckStatuses(ctx workflow.Context, roots ma
 
 // containsAnyFailingPolicy checks if any of the provided failing policies are present in the provided workflow
 func containsAnyFailingPolicy(workflowResponse terraform.Response, failingPolicies []activities.PolicySet) bool {
-	for _, response := range workflowResponse.ValidationResults {
+	for _, validationResult := range workflowResponse.ValidationResults {
 		for _, policy := range failingPolicies {
-			if response.PolicySet.Name == policy.Name {
+			if validationResult.Status == activities.Fail && validationResult.PolicySet.Name == policy.Name {
 				return true
 			}
 		}

--- a/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
+++ b/server/neptune/workflows/internal/pr/revision/policy/handler_test.go
@@ -124,6 +124,10 @@ func TestFailedPolicyHandlerRunner_Handle(t *testing.T) {
 						Status:    activities.Fail,
 						PolicySet: activities.PolicySet{Name: "policy1"},
 					},
+					{
+						Status:    activities.Success,
+						PolicySet: activities.PolicySet{Name: "policy2"},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
When processing if a workflow still contains any failing policies after we filter out approved ones, we should make sure that policy was failing for that specific workflow in the first place.