### PR TITLE
Remove unused platform mode feature allocator and support atlantis plan -p flag

### DIFF
--- a/server/legacy/lyft/gateway/events_controller.go
+++ b/server/legacy/lyft/gateway/events_controller.go
@@ -135,7 +135,6 @@ func NewVCSEventsController(
 	)
 
 	pushHandler := &gateway_handlers.PushHandler{
-		Allocator:    featureAllocator,
 		Scheduler:    asyncScheduler,
 		Logger:       logger,
 		RootDeployer: rootDeployer,

--- a/server/neptune/gateway/event/comment_handler.go
+++ b/server/neptune/gateway/event/comment_handler.go
@@ -103,6 +103,10 @@ type NeptuneWorkerProxy struct {
 }
 
 func (p *NeptuneWorkerProxy) Handle(ctx context.Context, event Comment, cmd *command.Comment, roots []*valid.MergedProjectCfg, request *http.BufferedRequest) error {
+	if cmd.IsForSpecificProject() {
+		roots = partitionRootsByProject(cmd.ProjectName, roots)
+	}
+
 	if cmd.Name == command.Apply {
 		return p.handleApplies(ctx, event, cmd, roots)
 	}
@@ -141,10 +145,6 @@ func (p *NeptuneWorkerProxy) handleApplies(ctx context.Context, event Comment, c
 	triggerInfo := workflows.DeployTriggerInfo{
 		Type:  workflows.ManualTrigger,
 		Force: cmd.ForceApply,
-	}
-
-	if cmd.IsForSpecificProject() {
-		roots = partitionRootsByProject(cmd.ProjectName, roots)
 	}
 
 	if len(roots) == 0 {

--- a/server/neptune/gateway/event/push_event_handler.go
+++ b/server/neptune/gateway/event/push_event_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/runatlantis/atlantis/server/logging"
 	"github.com/runatlantis/atlantis/server/models"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
-	"github.com/runatlantis/atlantis/server/neptune/lyft/feature"
 	"github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/runatlantis/atlantis/server/vcs"
@@ -40,27 +39,12 @@ type rootDeployer interface {
 }
 
 type PushHandler struct {
-	Allocator    feature.Allocator
 	Scheduler    scheduler
 	Logger       logging.Logger
 	RootDeployer rootDeployer
 }
 
 func (p *PushHandler) Handle(ctx context.Context, event Push) error {
-	shouldAllocate, err := p.Allocator.ShouldAllocate(feature.PlatformMode, feature.FeatureContext{
-		RepoName: event.Repo.FullName,
-	})
-
-	if err != nil {
-		p.Logger.ErrorContext(ctx, "unable to allocate platformmode")
-		return nil
-	}
-
-	if !shouldAllocate {
-		p.Logger.InfoContext(ctx, "handler not configured for allocation")
-		return nil
-	}
-
 	if event.Ref.Type != vcs.BranchRef || event.Ref.Name != event.Repo.DefaultBranch {
 		p.Logger.WarnContext(ctx, "dropping event for unexpected ref")
 		return nil

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -53,17 +53,7 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 				Name: "blah",
 			},
 		}
-		allocator := &testAllocator{
-			expectedAllocation: true,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -89,17 +79,7 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 			},
 		}
 
-		allocator := &testAllocator{
-			expectedAllocation: true,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -125,17 +105,7 @@ func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 				Name: "main",
 			},
 		}
-		allocator := &testAllocator{
-			expectedAllocation: true,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -172,17 +142,7 @@ func TestHandlePushEvent(t *testing.T) {
 	}
 
 	t.Run("allocation result false", func(t *testing.T) {
-		allocator := &testAllocator{
-			expectedAllocation: false,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -193,17 +153,7 @@ func TestHandlePushEvent(t *testing.T) {
 	})
 
 	t.Run("allocation error", func(t *testing.T) {
-		allocator := &testAllocator{
-			expectedError:     assert.AnError,
-			expectedFeatureID: feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -214,17 +164,8 @@ func TestHandlePushEvent(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		allocator := &testAllocator{
-			expectedAllocation: true,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
 		ctx := context.Background()
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{},
@@ -235,18 +176,8 @@ func TestHandlePushEvent(t *testing.T) {
 	})
 
 	t.Run("root deployer error", func(t *testing.T) {
-		allocator := &testAllocator{
-			expectedAllocation: true,
-			expectedFeatureID:  feature.PlatformMode,
-			expectedFeatureCtx: feature.FeatureContext{
-				RepoName: repoFullName,
-			},
-			t: t,
-		}
-
 		ctx := context.Background()
 		handler := event.PushHandler{
-			Allocator:    allocator,
 			Scheduler:    &sync.SynchronousScheduler{Logger: logger},
 			Logger:       logger,
 			RootDeployer: &mockRootDeployer{error: assert.AnError},


### PR DESCRIPTION
Two more gateway fixes:

- We've completely rolled out platform mode, so let's remove the feature allocator for it in Gateway's PushHandler
- Comment events support per project/root flags, let's make sure we support them for both the atlantis plan and atlantis apply comment instead of just the latter