### PR TITLE
Use global cfg installation id for temporal worker github activities

### DIFF
--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -226,11 +226,10 @@ func NewServer(config *config.Config) (*Server, error) {
 				Executor:  crons.NewRuntimeStats(scope).Run,
 				Frequency: 1 * time.Minute,
 			},
-			// TODO: use when we rollout new app for temporalworker all together
-			//{
-			//	Executor:  crons.NewRateLimitStats(scope, clientCreator, config.GithubCfg.TemporalAppInstallationID).Run,
-			//	Frequency: 1 * time.Minute,
-			//},
+			{
+				Executor:  crons.NewRateLimitStats(scope, clientCreator, config.GithubCfg.TemporalAppInstallationID).Run,
+				Frequency: 1 * time.Minute,
+			},
 		},
 		HTTPServerProxy:            httpServerProxy,
 		Port:                       config.ServerCfg.Port,

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -198,6 +198,7 @@ func NewServer(config *config.Config) (*Server, error) {
 
 	githubActivities, err := activities.NewGithub(
 		config.App,
+		0, // TODO, pass config here
 		scope.SubScope("app"),
 		config.DataDir,
 		featureAllocator,

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -161,6 +161,7 @@ func NewServer(config *config.Config) (*Server, error) {
 		config.DataDir,
 		config.ServerCfg.URL,
 		config.TemporalCfg.TerraformTaskQueue,
+		config.GithubCfg.TemporalAppInstallationID,
 		jobStreamHandler,
 	)
 	if err != nil {

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -197,9 +197,8 @@ func NewServer(config *config.Config) (*Server, error) {
 	}
 
 	githubActivities, err := activities.NewGithub(
-		config.App,
-		0, // TODO, pass config here
-		scope.SubScope("app"),
+		clientCreator,
+		config.GithubCfg.TemporalAppInstallationID,
 		config.DataDir,
 		featureAllocator,
 	)

--- a/server/neptune/workflows/activities/github/client.go
+++ b/server/neptune/workflows/activities/github/client.go
@@ -11,32 +11,12 @@ import (
 )
 
 type Client struct {
-	ClientCreator githubapp.ClientCreator
+	ClientCreator  githubapp.ClientCreator
+	InstallationID int64
 }
 
-type Context interface {
-	GetInstallationToken() int64
-	context.Context
-}
-
-type contextWithToken struct {
-	InstallationToken int64
-	context.Context
-}
-
-func (c *contextWithToken) GetInstallationToken() int64 {
-	return c.InstallationToken
-}
-
-func ContextWithInstallationToken(ctx context.Context, installationToken int64) Context {
-	return &contextWithToken{
-		InstallationToken: installationToken,
-		Context:           ctx,
-	}
-}
-
-func (c *Client) CreateCheckRun(ctx Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) CreateCheckRun(ctx context.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
@@ -44,8 +24,8 @@ func (c *Client) CreateCheckRun(ctx Context, owner, repo string, opts github.Cre
 
 	return client.Checks.CreateCheckRun(ctx, owner, repo, opts)
 }
-func (c *Client) UpdateCheckRun(ctx Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
@@ -53,8 +33,8 @@ func (c *Client) UpdateCheckRun(ctx Context, owner, repo string, checkRunID int6
 
 	return client.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, opts)
 }
-func (c *Client) GetArchiveLink(ctx Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
@@ -63,8 +43,8 @@ func (c *Client) GetArchiveLink(ctx Context, owner, repo string, archiveformat g
 	return client.Repositories.GetArchiveLink(ctx, owner, repo, archiveformat, opts, followRedirects)
 }
 
-func (c *Client) CompareCommits(ctx Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) CompareCommits(ctx context.Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
@@ -73,8 +53,8 @@ func (c *Client) CompareCommits(ctx Context, owner, repo string, base, head stri
 	return client.Repositories.CompareCommits(ctx, owner, repo, base, head, opts)
 }
 
-func (c *Client) ListReviews(ctx Context, owner string, repo string, number int) ([]*github.PullRequestReview, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) ListReviews(ctx context.Context, owner string, repo string, number int) ([]*github.PullRequestReview, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client from installation")
 	}
@@ -89,16 +69,16 @@ func (c *Client) ListReviews(ctx Context, owner string, repo string, number int)
 	return gh_helper.Iterate(ctx, run)
 }
 
-func (c *Client) GetPullRequest(ctx Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
 	}
 	return client.PullRequests.Get(ctx, owner, repo, number)
 }
 
-func (c *Client) ListCommits(ctx Context, owner string, repo string, number int) ([]*github.RepositoryCommit, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) ListCommits(ctx context.Context, owner string, repo string, number int) ([]*github.RepositoryCommit, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client from installation")
 	}
@@ -113,16 +93,16 @@ func (c *Client) ListCommits(ctx Context, owner string, repo string, number int)
 	return gh_helper.Iterate(ctx, run)
 }
 
-func (c *Client) DismissReview(ctx Context, owner string, repo string, number int, reviewID int64, review *github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) DismissReview(ctx context.Context, owner string, repo string, number int, reviewID int64, review *github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating client from installation")
 	}
 	return client.PullRequests.DismissReview(ctx, owner, repo, number, reviewID, review)
 }
 
-func (c *Client) ListTeamMembers(ctx Context, org string, teamSlug string) ([]*github.User, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) ListTeamMembers(ctx context.Context, org string, teamSlug string) ([]*github.User, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client from installation")
 	}
@@ -139,8 +119,8 @@ func (c *Client) ListTeamMembers(ctx Context, org string, teamSlug string) ([]*g
 	return gh_helper.Iterate(ctx, run)
 }
 
-func (c *Client) CreateComment(ctx Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
-	client, err := c.ClientCreator.NewInstallationClient(ctx.GetInstallationToken())
+func (c *Client) CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	client, err := c.ClientCreator.NewInstallationClient(c.InstallationID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -18,13 +18,11 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/file"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	internal "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/cli"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github/link"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/slack-go/slack"
-	"github.com/uber-go/tally/v4"
 )
 
 const (
@@ -221,17 +219,7 @@ func NewGithubWithClient(client githubClient, dataDir string, getter gogetter, a
 	}, nil
 }
 
-func NewGithub(appConfig githubapp.Config, installationID int64, scope tally.Scope, dataDir string, allocator feature.Allocator) (*Github, error) {
-	clientCreator, err := githubapp.NewDefaultCachingClientCreator(
-		appConfig,
-		githubapp.WithClientMiddleware(
-			github.ClientMetrics(scope.SubScope("app")),
-		))
-
-	if err != nil {
-		return nil, errors.Wrap(err, "initializing client creator")
-	}
-
+func NewGithub(clientCreator githubapp.ClientCreator, installationID int64, dataDir string, allocator feature.Allocator) (*Github, error) {
 	client := &internal.Client{
 		ClientCreator:  clientCreator,
 		InstallationID: installationID,

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -93,7 +93,7 @@ type PolicySet struct {
 	Paths []string
 }
 
-func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.ValidationConfig, ghAppConfig githubapp.Config, dataDir string, serverURL *url.URL, taskQueue string, streamHandler StreamCloser, opts ...TerraformOptions) (*Terraform, error) {
+func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.ValidationConfig, ghAppConfig githubapp.Config, dataDir string, serverURL *url.URL, taskQueue string, installationID int64, streamHandler StreamCloser, opts ...TerraformOptions) (*Terraform, error) {
 	binDir, err := mkSubDir(dataDir, BinDirName)
 	if err != nil {
 		return nil, err
@@ -185,6 +185,7 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 			GitCredentialsFileLock: gitCredentialsFileLock,
 			FileWriter:             &file.Writer{},
 			CacheDir:               cacheDir,
+			InstallationID:         installationID,
 		},
 		conftestActivity: &conftestActivity{
 			DefaultConftestVersion: defaultConftestVersion,

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -221,7 +221,7 @@ func NewGithubWithClient(client githubClient, dataDir string, getter gogetter, a
 	}, nil
 }
 
-func NewGithub(appConfig githubapp.Config, scope tally.Scope, dataDir string, allocator feature.Allocator) (*Github, error) {
+func NewGithub(appConfig githubapp.Config, installationID int64, scope tally.Scope, dataDir string, allocator feature.Allocator) (*Github, error) {
 	clientCreator, err := githubapp.NewDefaultCachingClientCreator(
 		appConfig,
 		githubapp.WithClientMiddleware(
@@ -233,7 +233,8 @@ func NewGithub(appConfig githubapp.Config, scope tally.Scope, dataDir string, al
 	}
 
 	client := &internal.Client{
-		ClientCreator: clientCreator,
+		ClientCreator:  clientCreator,
+		InstallationID: installationID,
 	}
 
 	return NewGithubWithClient(client, dataDir, HashiGetter, allocator)

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -97,6 +97,7 @@ type terraformActivities struct {
 	GitCredentialsFileLock *file.RWLock
 	FileWriter             writer
 	CacheDir               string
+	InstallationID         int64
 }
 
 func NewTerraformActivities(
@@ -107,6 +108,7 @@ func NewTerraformActivities(
 	gitCredentialsFileLock *file.RWLock,
 	fileWriter writer,
 	cacheDir string,
+	installationID int64,
 ) *terraformActivities { //nolint:revive // avoiding refactor while adding linter action
 	return &terraformActivities{
 		TerraformClient:        client,
@@ -114,6 +116,7 @@ func NewTerraformActivities(
 		StreamHandler:          streamHandler,
 		GitCLICredentials:      gitCredentialsRefresher,
 		GitCredentialsFileLock: gitCredentialsFileLock,
+		InstallationID:         installationID,
 		FileWriter:             fileWriter,
 		CacheDir:               cacheDir,
 	}
@@ -176,7 +179,7 @@ func (t *terraformActivities) TerraformInit(ctx context.Context, request Terrafo
 		Version:           tfVersion,
 	}
 
-	err = t.GitCLICredentials.Refresh(ctx, request.GithubInstallationID)
+	err = t.GitCLICredentials.Refresh(ctx, t.InstallationID)
 	if err != nil {
 		activity.GetLogger(ctx).Error("Error refreshing git cli credentials. This is bug and will likely cause fetching of private modules to fail", key.ErrKey, err)
 	}

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -203,12 +203,11 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 			}
 
 			req := TerraformInitRequest{
-				DynamicEnvs:          c.DynamicEnvs,
-				JobID:                jobID,
-				Path:                 path,
-				TfVersion:            c.RequestVersion,
-				Args:                 c.RequestArgs,
-				GithubInstallationID: 1235,
+				DynamicEnvs: c.DynamicEnvs,
+				JobID:       jobID,
+				Path:        path,
+				TfVersion:   c.RequestVersion,
+				Args:        c.RequestArgs,
 			}
 
 			credsRefresher := &testCredsRefresher{
@@ -225,7 +224,8 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 				credsRefresher,
 				&file.RWLock{},
 				&mockWriter{},
-				"some/dir")
+				"some/dir",
+				1235)
 			env.RegisterActivity(tfActivity)
 
 			_, err = env.ExecuteActivity(tfActivity.TerraformInit, req)
@@ -273,9 +273,8 @@ func TestTerraformInit_StreamsOutput(t *testing.T) {
 	}
 
 	req := TerraformInitRequest{
-		JobID:                jobID,
-		Path:                 path,
-		GithubInstallationID: 1235,
+		JobID: jobID,
+		Path:  path,
 	}
 
 	streamHandler := &testStreamHandler{
@@ -289,7 +288,7 @@ func TestTerraformInit_StreamsOutput(t *testing.T) {
 		t:                      t,
 	}
 
-	tfActivity := NewTerraformActivities(testTfClient, expectedVersion, streamHandler, credsRefresher, &file.RWLock{}, &mockWriter{}, "some/dir")
+	tfActivity := NewTerraformActivities(testTfClient, expectedVersion, streamHandler, credsRefresher, &file.RWLock{}, &mockWriter{}, "some/dir", 1235)
 	env.RegisterActivity(tfActivity)
 
 	_, err = env.ExecuteActivity(tfActivity.TerraformInit, req)
@@ -465,7 +464,7 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 
 			tfActivity := NewTerraformActivities(&testTfClient, expectedVersion, &testStreamHandler{
 				t: t,
-			}, credsRefresher, &file.RWLock{}, fileWriter, "some/dir")
+			}, credsRefresher, &file.RWLock{}, fileWriter, "some/dir", 0)
 			env.RegisterActivity(tfActivity)
 
 			_, err = env.ExecuteActivity(tfActivity.TerraformPlan, req)
@@ -547,7 +546,7 @@ func TestTerraformPlan_ReturnsResponse(t *testing.T) {
 
 	credsRefresher := &testCredsRefresher{}
 
-	tfActivity := NewTerraformActivities(&testTfClient, expectedVersion, streamHandler, credsRefresher, &file.RWLock{}, &mockWriter{}, "some/dir")
+	tfActivity := NewTerraformActivities(&testTfClient, expectedVersion, streamHandler, credsRefresher, &file.RWLock{}, &mockWriter{}, "some/dir", 0)
 
 	env.RegisterActivity(tfActivity)
 
@@ -681,7 +680,7 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 
 			tfActivity := NewTerraformActivities(testClient, expectedVersion, &testStreamHandler{
 				t: t,
-			}, &testCredsRefresher{}, &file.RWLock{}, &mockWriter{}, "some/dir")
+			}, &testCredsRefresher{}, &file.RWLock{}, &mockWriter{}, "some/dir", 0)
 			env.RegisterActivity(tfActivity)
 
 			_, err = env.ExecuteActivity(tfActivity.TerraformApply, req)
@@ -738,7 +737,7 @@ func TestTerraformApply_StreamsOutput(t *testing.T) {
 		expectedJobID: jobID,
 	}
 
-	tfActivity := NewTerraformActivities(testTfClient, expectedVersion, streamHandler, &testCredsRefresher{}, &file.RWLock{}, &mockWriter{}, "some/dir")
+	tfActivity := NewTerraformActivities(testTfClient, expectedVersion, streamHandler, &testCredsRefresher{}, &file.RWLock{}, &mockWriter{}, "some/dir", 0)
 	env.RegisterActivity(tfActivity)
 
 	_, err = env.ExecuteActivity(tfActivity.TerraformApply, req)

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
-	internalGithub "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -262,23 +261,23 @@ type testGithubClient struct {
 	DeploymentID string
 }
 
-func (c *testGithubClient) CreateComment(ctx internalGithub.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+func (c *testGithubClient) CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
 	return &github.IssueComment{}, &github.Response{}, nil
 }
 
-func (c *testGithubClient) ListTeamMembers(ctx internalGithub.Context, org string, teamSlug string) ([]*github.User, error) {
+func (c *testGithubClient) ListTeamMembers(ctx context.Context, org string, teamSlug string) ([]*github.User, error) {
 	return []*github.User{}, nil
 }
 
-func (c *testGithubClient) ListCommits(ctx internalGithub.Context, owner string, repo string, number int) ([]*github.RepositoryCommit, error) {
+func (c *testGithubClient) ListCommits(ctx context.Context, owner string, repo string, number int) ([]*github.RepositoryCommit, error) {
 	return []*github.RepositoryCommit{}, nil
 }
 
-func (c *testGithubClient) DismissReview(ctx internalGithub.Context, owner, repo string, number int, reviewID int64, review *github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, *github.Response, error) {
+func (c *testGithubClient) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, review *github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, *github.Response, error) {
 	return &github.PullRequestReview{}, &github.Response{}, nil
 }
 
-func (c *testGithubClient) ListReviews(ctx internalGithub.Context, owner string, repo string, number int) ([]*github.PullRequestReview, error) {
+func (c *testGithubClient) ListReviews(ctx context.Context, owner string, repo string, number int) ([]*github.PullRequestReview, error) {
 	return []*github.PullRequestReview{
 		{
 			State: github.String("APPROVED"),
@@ -286,17 +285,17 @@ func (c *testGithubClient) ListReviews(ctx internalGithub.Context, owner string,
 	}, nil
 }
 
-func (c *testGithubClient) GetPullRequest(ctx internalGithub.Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
+func (c *testGithubClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, *github.Response, error) {
 	return &github.PullRequest{}, &github.Response{}, nil
 }
 
-func (c *testGithubClient) CreateCheckRun(ctx internalGithub.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+func (c *testGithubClient) CreateCheckRun(ctx context.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
 	c.DeploymentID = opts.GetExternalID()
 	return &github.CheckRun{
 		ID: github.Int64(123),
 	}, &github.Response{}, nil
 }
-func (c *testGithubClient) UpdateCheckRun(ctx internalGithub.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
+func (c *testGithubClient) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, *github.Response, error) {
 	c.DeploymentID = opts.GetExternalID()
 	update := CheckRunUpdate{
 		Summary:    opts.GetOutput().GetSummary(),
@@ -308,12 +307,12 @@ func (c *testGithubClient) UpdateCheckRun(ctx internalGithub.Context, owner, rep
 
 	return &github.CheckRun{}, &github.Response{}, nil
 }
-func (c *testGithubClient) GetArchiveLink(ctx internalGithub.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
+func (c *testGithubClient) GetArchiveLink(ctx context.Context, owner, repo string, archiveformat github.ArchiveFormat, opts *github.RepositoryContentGetOptions, followRedirects bool) (*url.URL, *github.Response, error) {
 	url, _ := url.Parse("www.testurl.com")
 
 	return url, &github.Response{Response: &http.Response{StatusCode: http.StatusFound}}, nil
 }
-func (c *testGithubClient) CompareCommits(ctx internalGithub.Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
+func (c *testGithubClient) CompareCommits(ctx context.Context, owner, repo string, base, head string, opts *github.ListOptions) (*github.CommitsComparison, *github.Response, error) {
 	return &github.CommitsComparison{
 		Status: github.String("ahead"),
 	}, &github.Response{}, nil

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -178,6 +178,7 @@ func initAndRegisterActivities(t *testing.T, env *testsuite.TestWorkflowEnvironm
 		cfg.DataDir,
 		cfg.ServerCfg.URL,
 		cfg.TemporalCfg.TerraformTaskQueue,
+		0,
 		streamCloser,
 		activities.TerraformOptions{
 			TFVersionCache:          cache.NewLocalBinaryCache("terraform"),


### PR DESCRIPTION
Let's pass the new installation id configuration throughout all use cases of the GH id in the temporal worker.