### PR TITLE
Set up new gh ratelimit publisher for gateway/temporalworker

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -69,6 +69,7 @@ func (t *TemporalWorker) NewServer(userConfig legacy.UserConfig, config legacy.C
 		DeploymentConfig:         globalCfg.PersistenceConfig.Deployments,
 		DataDir:                  userConfig.DataDir,
 		TemporalCfg:              globalCfg.Temporal,
+		GithubCfg:                globalCfg.Github,
 		App:                      appConfig,
 		CtxLogger:                ctxLogger,
 		StatsNamespace:           userConfig.StatsNamespace,

--- a/server/config/raw/github.go
+++ b/server/config/raw/github.go
@@ -1,0 +1,24 @@
+package raw
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/runatlantis/atlantis/server/config/valid"
+)
+
+type Github struct {
+	GatewayAppInstallationID  int64 `yaml:"gateway_app_installation_id" json:"gateway_app_installation_id"`
+	TemporalAppInstallationID int64 `yaml:"temporal_app_installation_id" json:"temporal_app_installation_id"`
+}
+
+func (g *Github) Validate() error {
+	return validation.ValidateStruct(g,
+		validation.Field(&g.GatewayAppInstallationID, validation.Required),
+		validation.Field(&g.TemporalAppInstallationID, validation.Required))
+}
+
+func (g *Github) ToValid() valid.Github {
+	return valid.Github{
+		GatewayAppInstallationID:  g.GatewayAppInstallationID,
+		TemporalAppInstallationID: g.TemporalAppInstallationID,
+	}
+}

--- a/server/config/raw/github_test.go
+++ b/server/config/raw/github_test.go
@@ -1,0 +1,85 @@
+package raw_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/runatlantis/atlantis/server/config/raw"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestGithub_Unmarshal(t *testing.T) {
+	t.Run("yaml", func(t *testing.T) {
+		rawYaml := `
+gateway_app_installation_id: 567
+temporal_app_installation_id: 1234
+`
+
+		var result raw.Github
+
+		err := yaml.UnmarshalStrict([]byte(rawYaml), &result)
+		assert.NoError(t, err)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		rawJSON := `
+{
+	"temporal_app_installation_id": 1234,
+	"gateway_app_installation_id": 567
+}		
+`
+
+		var result raw.Github
+
+		err := json.Unmarshal([]byte(rawJSON), &result)
+		assert.NoError(t, err)
+	})
+}
+
+func TestGithub_Validate_Success(t *testing.T) {
+	cases := []struct {
+		description string
+		subject     *raw.Github
+	}{
+		{
+			description: "success",
+			subject: &raw.Github{
+				GatewayAppInstallationID:  int64(123),
+				TemporalAppInstallationID: int64(567),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.NoError(t, c.subject.Validate())
+		})
+	}
+}
+
+func TestGithub_Validate_Error(t *testing.T) {
+	cases := []struct {
+		description string
+		subject     raw.Github
+	}{
+		{
+			description: "missing gateway id",
+			subject: raw.Github{
+				GatewayAppInstallationID: int64(123),
+			},
+		},
+		{
+			description: "missing temporal id",
+			subject: raw.Github{
+				TemporalAppInstallationID: int64(456),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.Error(t, c.subject.Validate())
+		})
+	}
+}

--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -22,6 +22,7 @@ type GlobalCfg struct {
 	Metrics              Metrics              `yaml:"metrics" json:"metrics"`
 	TerraformLogFilters  TerraformLogFilters  `yaml:"terraform_log_filters" json:"terraform_log_filters"`
 	Temporal             Temporal             `yaml:"temporal" json:"temporal"`
+	Github               Github               `yaml:"github" json:"github"`
 	Persistence          Persistence          `yaml:"persistence" json:"persistence"`
 	RevisionSetter       RevisionSetter       `yaml:"revision_setter" json:"revision_setter"`
 	Admin                Admin                `yaml:"admin" json:"admin"`
@@ -110,6 +111,7 @@ func (g GlobalCfg) Validate() error {
 		validation.Field(&g.PullRequestWorkflows),
 		validation.Field(&g.DeploymentWorkflows),
 		validation.Field(&g.Metrics),
+		validation.Field(&g.Github),
 		validation.Field(&g.TerraformLogFilters),
 		validation.Field(&g.Persistence),
 	)
@@ -191,6 +193,7 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 		PersistenceConfig:    g.Persistence.ToValid(defaultCfg),
 		TerraformLogFilter:   g.TerraformLogFilters.ToValid(),
 		Temporal:             g.Temporal.ToValid(),
+		Github:               g.Github.ToValid(),
 		Admin:                g.Admin.ToValid(),
 		RevisionSetter:       g.RevisionSetter.ToValid(),
 	}

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -61,6 +61,7 @@ type GlobalCfg struct {
 	PersistenceConfig    PersistenceConfig
 	TerraformLogFilter   TerraformLogFilters
 	Temporal             Temporal
+	Github               Github
 	RevisionSetter       RevisionSetter
 	Admin                Admin
 }
@@ -142,6 +143,11 @@ type Temporal struct {
 	UseSystemCACert    bool
 	Namespace          string
 	TerraformTaskQueue string
+}
+
+type Github struct {
+	GatewayAppInstallationID  int64
+	TemporalAppInstallationID int64
 }
 
 type TerraformLogFilters struct {

--- a/server/neptune/gateway/event/push_event_handler_test.go
+++ b/server/neptune/gateway/event/push_event_handler_test.go
@@ -8,28 +8,12 @@ import (
 	"github.com/runatlantis/atlantis/server/models"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/deploy"
 	"github.com/runatlantis/atlantis/server/neptune/gateway/event"
-	"github.com/runatlantis/atlantis/server/neptune/lyft/feature"
 	"github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/vcs"
 	"github.com/stretchr/testify/assert"
 )
 
 const testRoot = "testroot"
-
-type testAllocator struct {
-	t                  *testing.T
-	expectedFeatureID  feature.Name
-	expectedFeatureCtx feature.FeatureContext
-	expectedAllocation bool
-	expectedError      error
-}
-
-func (a *testAllocator) ShouldAllocate(featureID feature.Name, featureCtx feature.FeatureContext) (bool, error) {
-	assert.Equal(a.t, a.expectedFeatureID, featureID)
-	assert.Equal(a.t, a.expectedFeatureCtx, featureCtx)
-
-	return a.expectedAllocation, a.expectedError
-}
 
 func TestHandlePushEvent_FiltersEvents(t *testing.T) {
 	logger := logging.NewNoopCtxLogger(t)

--- a/server/neptune/gateway/server.go
+++ b/server/neptune/gateway/server.go
@@ -337,6 +337,10 @@ func NewServer(config Config) (*Server, error) {
 				Executor:  crons.NewRuntimeStats(statsScope).Run,
 				Frequency: 1 * time.Minute,
 			},
+			{
+				Executor:  crons.NewRateLimitStats(statsScope, clientCreator, globalCfg.Github.GatewayAppInstallationID).Run,
+				Frequency: 1 * time.Minute,
+			},
 		},
 		StatsCloser:    closer,
 		Scheduler:      asyncScheduler,

--- a/server/neptune/sync/crons/ratelimit_stats.go
+++ b/server/neptune/sync/crons/ratelimit_stats.go
@@ -1,0 +1,45 @@
+package crons
+
+import (
+	"context"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/runatlantis/atlantis/server/metrics"
+	"github.com/uber-go/tally/v4"
+	"net/http"
+)
+
+const (
+	subScope  = "github.ratelimit"
+	remaining = "remaining"
+)
+
+type RateLimitStatCollector struct {
+	Scope          tally.Scope
+	ClientCreator  githubapp.ClientCreator
+	InstallationID int64
+}
+
+func NewRateLimitStats(scope tally.Scope, clientCreator githubapp.ClientCreator, installationID int64) *RateLimitStatCollector {
+	return &RateLimitStatCollector{
+		Scope:          scope.SubScope(subScope),
+		ClientCreator:  clientCreator,
+		InstallationID: installationID,
+	}
+}
+
+func (r *RateLimitStatCollector) Run(ctx context.Context) error {
+	installationClient, err := r.ClientCreator.NewInstallationClient(r.InstallationID)
+	if err != nil {
+		return errors.Wrap(err, "creating installation client")
+	}
+
+	rateLimits, resp, err := installationClient.RateLimits(ctx)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		r.Scope.Counter(metrics.ExecutionErrorMetric).Inc(1)
+		return errors.Wrap(err, "fetching github ratelimit")
+	}
+
+	r.Scope.Gauge(remaining).Update(float64(rateLimits.GetCore().Remaining))
+	return nil
+}

--- a/server/neptune/temporalworker/config/config.go
+++ b/server/neptune/temporalworker/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ServerCfg        ServerConfig
 	FeatureConfig    FeatureConfig
 	TemporalCfg      valid.Temporal
+	GithubCfg        valid.Github
 	TerraformCfg     TerraformConfig
 	ValidationConfig ValidationConfig
 	DeploymentConfig valid.StoreConfig

--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -225,6 +225,10 @@ func NewServer(config *config.Config) (*Server, error) {
 				Executor:  crons.NewRuntimeStats(scope).Run,
 				Frequency: 1 * time.Minute,
 			},
+			{
+				Executor:  crons.NewRateLimitStats(scope, clientCreator, config.GithubCfg.TemporalAppInstallationID).Run,
+				Frequency: 1 * time.Minute,
+			},
 		},
 		HTTPServerProxy:            httpServerProxy,
 		Port:                       config.ServerCfg.Port,


### PR DESCRIPTION
Two changes here:
1. Inject installation ID defining a separate GH app for gateway and temporal servers (we will [eventually](https://github.com/lyft/atlantis/pull/711) reconfigure code to use these installation ids over the ones passed in from the webhook event)
2. Set up new github ratelimit stats publisher in gateway and temporal servers that use these app installations. This already needed to be migrated over to the new workers anyways, but also can serve as an initial test of the new ids without having to impact existing code.