### PR TITLE
Temporarily remove ratelimit poller in temporal worker

### DIFF
--- a/server/neptune/temporalworker/server.go
+++ b/server/neptune/temporalworker/server.go
@@ -225,10 +225,11 @@ func NewServer(config *config.Config) (*Server, error) {
 				Executor:  crons.NewRuntimeStats(scope).Run,
 				Frequency: 1 * time.Minute,
 			},
-			{
-				Executor:  crons.NewRateLimitStats(scope, clientCreator, config.GithubCfg.TemporalAppInstallationID).Run,
-				Frequency: 1 * time.Minute,
-			},
+			// TODO: use when we rollout new app for temporalworker all together
+			//{
+			//	Executor:  crons.NewRateLimitStats(scope, clientCreator, config.GithubCfg.TemporalAppInstallationID).Run,
+			//	Frequency: 1 * time.Minute,
+			//},
 		},
 		HTTPServerProxy:            httpServerProxy,
 		Port:                       config.ServerCfg.Port,


### PR DESCRIPTION
This is just temporary for a cleaner rollout. Originally merged this change to test in staging, but ideally, all instances of using the new `TemporalAppInstallationID` config should be rolled out together in https://github.com/lyft/atlantis/pull/711