### PR TITLE
Check if key is in roots map of Processor

### DIFF
--- a/server/neptune/workflows/internal/pr/revision/state.go
+++ b/server/neptune/workflows/internal/pr/revision/state.go
@@ -38,6 +38,9 @@ func (s *StateReceiver) Notify(ctx workflow.Context, workflowState *state.Workfl
 	rootInfo, ok := roots[workflowState.ID]
 
 	// TODO remove versioning
+	// there can be an edge case where we've canceled a previous check run to handle a new revision
+	// but the canceled child terraform workflow has sent over one last update prior to shutdown
+	// we should avoid notifying on this case
 	v := workflow.GetVersion(ctx, CheckBeforeNotify, workflow.DefaultVersion, workflow.Version(1))
 	if v != workflow.DefaultVersion && !ok {
 		workflow.GetLogger(ctx).Warn(fmt.Sprintf("skipping notifying root %s", workflowState.ID))

--- a/server/neptune/workflows/internal/pr/revision/state_test.go
+++ b/server/neptune/workflows/internal/pr/revision/state_test.go
@@ -88,7 +88,7 @@ func TestStateReceive(t *testing.T) {
 		},
 	}
 
-	t.Run("calls notifiers with state", func(t *testing.T) {
+	t.Run("calls notifiers with missing root info", func(t *testing.T) {
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 
@@ -98,6 +98,30 @@ func TestStateReceive(t *testing.T) {
 					Output: jobOutput,
 					Status: state.WaitingJobStatus,
 				},
+				ID: internalRootInfo.ID.String(),
+			},
+			T: t,
+		})
+
+		env.AssertExpectations(t)
+
+		var result stateReceiveResponse
+		err = env.GetWorkflowResult(&result)
+		assert.False(t, result.NotifierCalled)
+		assert.NoError(t, err)
+	})
+
+	t.Run("calls notifiers with valid state", func(t *testing.T) {
+		ts := testsuite.WorkflowTestSuite{}
+		env := ts.NewTestWorkflowEnvironment()
+
+		env.ExecuteWorkflow(testStateReceiveWorkflow, stateReceiveRequest{
+			State: &state.Workflow{
+				Plan: &state.Job{
+					Output: jobOutput,
+					Status: state.WaitingJobStatus,
+				},
+				ID: internalRootInfo.ID.String(),
 			},
 			RootInfo: internalRootInfo,
 			T:        t,


### PR DESCRIPTION
Before notifying, we should ensure the key is in the roots map to prevent attempts to notify check run on invalid, empty repo metadata. There is a chance the root map can miss a key if multiple revisions come in quickly and a new Processor for the latest revision is receiving a signal on an old revision. We shouldn't care about this signal since we already perform a clean defer to cancel those check runs on shutdown of the old revision Processor.