### PR TITLE
Create admin mode on Terraform Workflows

### DIFF
--- a/server/neptune/workflows/activities/terraform/job.go
+++ b/server/neptune/workflows/activities/terraform/job.go
@@ -53,4 +53,5 @@ type WorkflowMode int
 const (
 	Deploy WorkflowMode = iota
 	PR
+	Admin
 )

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -27,6 +27,10 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func(wo
 		return nil, func(_ workflow.Context) error { return nil }, err
 	}
 
+	if r.Request.WorkflowMode == terraform.Admin {
+		return fetchRootResponse.LocalRoot, func(c workflow.Context) error { return nil }, nil
+	}
+
 	return fetchRootResponse.LocalRoot, func(c workflow.Context) error {
 		var cleanupResponse activities.CleanupResponse
 		err = workflow.ExecuteActivity(c, r.Ta.Cleanup, activities.CleanupRequest{ //nolint:gosimple // unnecessary to add a method to convert reponses

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -350,6 +350,10 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 		return Response{}, r.toExternalError(err, "running plan job")
 	}
 
+	if r.Request.WorkflowMode == terraform.Admin {
+		return Response{}, nil
+	}
+
 	if r.Request.WorkflowMode == terraform.PR {
 		validationResults, err := r.Validate(ctx, root, response.ServerURL, planResponse.PlanJSONFile)
 		if err != nil {


### PR DESCRIPTION
Modifications within admin mode help for exploring more details around generated plans. More specifically:
1. Supports clone, init, plan steps as normal
2. Skips validate/apply steps
3. Skips automated cleanup
