### PR TITLE
add flags that will be used for terraformadmin mode

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -84,9 +84,9 @@ const (
 	LyftModeFlag                 = "lyft-mode"
 	LyftWorkerQueueURLFlag       = "lyft-worker-queue-url"
 
-	RepoNameForTerraformAdminFlag = "repo-name-for-terraform-admin"
-	RootNameForTerraformAdminFlag = "root-name-for-terraform-admin"
-	RevisionForTerraformAdminFlag = "revision-for-terraform-admin"
+	RepoNameForTerraformAdminFlag = "repo-name-for-terraform-admin-flag"
+	RootNameForTerraformAdminFlag = "root-name-for-terraform-admin-flag"
+	RevisionForTerraformAdminFlag = "revision-for-terraform-admin-flag"
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser            = ""
 	DefaultADBasicPassword        = ""

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -84,6 +84,9 @@ const (
 	LyftModeFlag                 = "lyft-mode"
 	LyftWorkerQueueURLFlag       = "lyft-worker-queue-url"
 
+	RepoNameForTerraformAdminFlag = "repo-name-for-terraform-admin"
+	RootNameForTerraformAdminFlag = "root-name-for-terraform-admin"
+	RevisionForTerraformAdminFlag = "revision-for-terraform-admin"
 	// NOTE: Must manually set these as defaults in the setDefaults function.
 	DefaultADBasicUser            = ""
 	DefaultADBasicPassword        = ""
@@ -236,6 +239,18 @@ var stringFlags = map[string]stringFlag{
 	},
 	LyftWorkerQueueURLFlag: {
 		description:  "Provide queue of AWS SQS queue for atlantis work to pull GH events from and process.",
+		defaultValue: "",
+	},
+	RepoNameForTerraformAdminFlag: {
+		description:  "The repo name is necessary when running in terraform admin mode so that we know which repo to clone",
+		defaultValue: "",
+	},
+	RootNameForTerraformAdminFlag: {
+		description:  "The root name is necessary when running in terraform admin mode so that we know which root to run ops on",
+		defaultValue: "",
+	},
+	RevisionForTerraformAdminFlag: {
+		description:  "The revision is necessary when running in terraform admin mode so that we know which revision to run ops on",
 		defaultValue: "",
 	},
 }

--- a/server/legacy/user_config.go
+++ b/server/legacy/user_config.go
@@ -11,6 +11,7 @@ const (
 	Gateway
 	Worker
 	TemporalWorker
+	TerraformAdmin
 )
 
 // UserConfig holds config values passed in by the user.
@@ -75,6 +76,10 @@ type UserConfig struct {
 
 	// Supports adding a default URL to the checkrun UI when details URL is not set
 	DefaultCheckrunDetailsURL string `mapstructure:"default-checkrun-details-url"`
+
+	RepoNameForTerraformAdminFlag string `mapstructure:"repo-name-for-terraform-admin-flag"`
+	RootNameForTerraformAdminFlag string `mapstructure:"root-name-for-terraform-admin-flag"`
+	RevisionForTerraformAdminFlag string `mapstructure:"revision-for-terraform-admin-flag"`
 }
 
 // ToLogLevel returns the LogLevel object corresponding to the user-passed
@@ -104,6 +109,8 @@ func (u UserConfig) ToLyftMode() Mode {
 		return Worker
 	case "temporalworker":
 		return TemporalWorker
+	case "terraformadmin":
+		return TerraformAdmin
 	}
 	return Default
 }

--- a/server/legacy/user_config_test.go
+++ b/server/legacy/user_config_test.go
@@ -51,6 +51,10 @@ func TestUserConfig_ToLyftMode(t *testing.T) {
 		expMode  server.Mode
 	}{
 		{
+			"terraformadmin",
+			server.TerraformAdmin,
+		},
+		{
 			"default",
 			server.Default,
 		},


### PR DESCRIPTION
I realize that the instructions say to add flags in alphabetic order, however I noticed that it seems for a while no one has done that, so to keep things organized I just put them together in their own section.