### PR TITLE
Skip plan on admin mode

### DIFF
--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -215,8 +215,11 @@ func (r *JobRunner) apply(executionCtx *ExecutionContext, planFile string, step 
 }
 
 func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, workflowMode terraform.WorkflowMode, extraArgs []string) (activities.TerraformPlanResponse, error) {
+	if workflowMode == terraform.Admin {
+		// Admin mode doesn't need to run a plan.
+		return activities.TerraformPlanResponse{}, nil
+	}
 	var resp activities.TerraformPlanResponse
-
 	args, err := command.NewArgumentList(extraArgs)
 	if err != nil {
 		return resp, errors.Wrapf(err, "creating argument list")


### PR DESCRIPTION
Keeping the admin workflow at the bare minimum by skipping the plan step.