### PR TITLE
rename admin to adhoc for the new terraform mode stuff

### DIFF
--- a/server/neptune/workflows/activities/terraform/job.go
+++ b/server/neptune/workflows/activities/terraform/job.go
@@ -53,5 +53,5 @@ type WorkflowMode int
 const (
 	Deploy WorkflowMode = iota
 	PR
-	Admin
+	Adhoc
 )

--- a/server/neptune/workflows/internal/terraform/job/runner.go
+++ b/server/neptune/workflows/internal/terraform/job/runner.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
@@ -215,7 +216,7 @@ func (r *JobRunner) apply(executionCtx *ExecutionContext, planFile string, step 
 }
 
 func (r *JobRunner) plan(ctx *ExecutionContext, mode *terraform.PlanMode, workflowMode terraform.WorkflowMode, extraArgs []string) (activities.TerraformPlanResponse, error) {
-	if workflowMode == terraform.Admin {
+	if workflowMode == terraform.Adhoc {
 		// Admin mode doesn't need to run a plan.
 		return activities.TerraformPlanResponse{}, nil
 	}

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -27,7 +27,7 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func(wo
 		return nil, func(_ workflow.Context) error { return nil }, err
 	}
 
-	if r.Request.WorkflowMode == terraform.Admin {
+	if r.Request.WorkflowMode == terraform.Adhoc {
 		return fetchRootResponse.LocalRoot, func(c workflow.Context) error { return nil }, nil
 	}
 

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -3,9 +3,10 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 	"net/url"
 	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 	"go.temporal.io/api/enums/v1"
@@ -350,7 +351,7 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 		return Response{}, r.toExternalError(err, "running plan job")
 	}
 
-	if r.Request.WorkflowMode == terraform.Admin {
+	if r.Request.WorkflowMode == terraform.Adhoc {
 		return Response{}, nil
 	}
 

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
@@ -176,7 +177,7 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 		WorkflowMode: req.WorkflowMode,
 	}
 
-	if req.WorkflowMode == terraformModel.Admin {
+	if req.WorkflowMode == terraformModel.Adhoc {
 		tAct = nil
 	}
 
@@ -649,7 +650,7 @@ func TestSuccess_AdminMode(t *testing.T) {
 
 	// execute workflow
 	env.ExecuteWorkflow(testTerraformWorkflow, request{
-		WorkflowMode: terraformModel.Admin,
+		WorkflowMode: terraformModel.Adhoc,
 	})
 	assert.True(t, env.IsWorkflowCompleted())
 


### PR DESCRIPTION
We are renaming the flow to adhoc from admin, this is because it is adhoc terraform operations, even though it is still technically an administrator mode