### PR TITLE
use simple path for cloning in adhoc flow

### DIFF
--- a/server/vcs/provider/github/repo_fetcher.go
+++ b/server/vcs/provider/github/repo_fetcher.go
@@ -75,7 +75,7 @@ func (g *RepoFetcher) clone(ctx context.Context, repo models.Repo, branch string
 	destinationPath := g.generateDirPath(repo.Name)
 	// If simple path is enabled, we don't need a prefix and UUID
 	if options.SimplePath {
-		destinationPath = g.generateSimpleDirPath(repo.Name)
+		destinationPath = g.GenerateSimpleDirPath(repo.Name)
 	}
 
 	// Create the directory and parents if necessary.
@@ -119,7 +119,7 @@ func (g *RepoFetcher) generateDirPath(repoName string) string {
 	return filepath.Join(g.DataDir, workingDirPrefix, repoName, uuid.New().String())
 }
 
-func (g *RepoFetcher) generateSimpleDirPath(repoName string) string {
+func (g *RepoFetcher) GenerateSimpleDirPath(repoName string) string {
 	return filepath.Join(g.DataDir, repoName)
 }
 

--- a/server/vcs/provider/github/repo_fetcher.go
+++ b/server/vcs/provider/github/repo_fetcher.go
@@ -72,7 +72,6 @@ func (g *RepoFetcher) Fetch(ctx context.Context, repo models.Repo, branch string
 }
 
 func (g *RepoFetcher) clone(ctx context.Context, repo models.Repo, branch string, sha string, options RepoFetcherOptions) (string, func(ctx context.Context, filePath string), error) {
-
 	destinationPath := g.generateDirPath(repo.Name)
 	// If simple path is enabled, we don't need a prefix and UUID
 	if options.SimplePath {

--- a/server/vcs/provider/github/repo_fetcher.go
+++ b/server/vcs/provider/github/repo_fetcher.go
@@ -37,6 +37,8 @@ type RepoFetcher struct {
 
 type RepoFetcherOptions struct {
 	CloneDepth int
+	// Use simple path for adhoc mode, where there is only 1 repo so we can use a simpler path rather than one with UUID and repos prefix
+	SimplePath bool
 }
 
 func (g *RepoFetcher) Fetch(ctx context.Context, repo models.Repo, branch string, sha string, options RepoFetcherOptions) (string, func(ctx context.Context, filePath string), error) {
@@ -70,7 +72,13 @@ func (g *RepoFetcher) Fetch(ctx context.Context, repo models.Repo, branch string
 }
 
 func (g *RepoFetcher) clone(ctx context.Context, repo models.Repo, branch string, sha string, options RepoFetcherOptions) (string, func(ctx context.Context, filePath string), error) {
+
 	destinationPath := g.generateDirPath(repo.Name)
+	// If simple path is enabled, we don't need a prefix and UUID
+	if options.SimplePath {
+		destinationPath = g.generateSimpleDirPath(repo.Name)
+	}
+
 	// Create the directory and parents if necessary.
 	if err := os.MkdirAll(destinationPath, 0700); err != nil {
 		return "", nil, errors.Wrap(err, "creating new directory")
@@ -110,6 +118,10 @@ func (g *RepoFetcher) clone(ctx context.Context, repo models.Repo, branch string
 
 func (g *RepoFetcher) generateDirPath(repoName string) string {
 	return filepath.Join(g.DataDir, workingDirPrefix, repoName, uuid.New().String())
+}
+
+func (g *RepoFetcher) generateSimpleDirPath(repoName string) string {
+	return filepath.Join(g.DataDir, repoName)
 }
 
 func (g *RepoFetcher) run(ctx context.Context, args []string, destinationPath string) ([]byte, error) {

--- a/server/vcs/provider/github/repo_fetcher.go
+++ b/server/vcs/provider/github/repo_fetcher.go
@@ -75,7 +75,7 @@ func (g *RepoFetcher) clone(ctx context.Context, repo models.Repo, branch string
 	destinationPath := g.generateDirPath(repo.Name)
 	// If simple path is enabled, we don't need a prefix and UUID
 	if options.SimplePath {
-		destinationPath = g.GenerateSimpleDirPath(repo.Name)
+		destinationPath = g.generateSimpleDirPath(repo.Name)
 	}
 
 	// Create the directory and parents if necessary.
@@ -119,7 +119,7 @@ func (g *RepoFetcher) generateDirPath(repoName string) string {
 	return filepath.Join(g.DataDir, workingDirPrefix, repoName, uuid.New().String())
 }
 
-func (g *RepoFetcher) GenerateSimpleDirPath(repoName string) string {
+func (g *RepoFetcher) generateSimpleDirPath(repoName string) string {
 	return filepath.Join(g.DataDir, repoName)
 }
 

--- a/server/vcs/provider/github/repo_fetcher_test.go
+++ b/server/vcs/provider/github/repo_fetcher_test.go
@@ -329,7 +329,7 @@ func TestDirPaths(t *testing.T) {
 	assert.NoError(t, err)
 
 	// make sure the simple file path is correct
-	assert.Equal(t, fmt.Sprintf("%s", dataDir), destinationPath)
+	assert.Equal(t, fmt.Sprintf("%s/%s", dataDir, "repo"), destinationPath)
 }
 
 func newBaseRepo(repoDir string) models.Repo {
@@ -340,6 +340,7 @@ func newBaseRepo(repoDir string) models.Repo {
 		FullName:      "nish/repo",
 		DefaultBranch: "branch",
 		CloneURL:      fmt.Sprintf("file://%s", repoDir),
+		Name:          "repo",
 	}
 }
 

--- a/server/vcs/provider/github/repo_fetcher_test.go
+++ b/server/vcs/provider/github/repo_fetcher_test.go
@@ -290,6 +290,13 @@ func TestFetch_ErrorGettingGHToken(t *testing.T) {
 	assert.ErrorContains(t, err, "error")
 }
 
+func TestDirPaths(t *testing.T) {
+	fetcher := &github.RepoFetcher{
+		DataDir: "/data",
+	}
+	assert.Equal(t, "/data/repo", fetcher.GenerateSimpleDirPath("repo"))
+}
+
 func newBaseRepo(repoDir string) models.Repo {
 	return models.Repo{
 		VCSHost: models.VCSHost{


### PR DESCRIPTION
we don't need to use the uuid and all that stuff since we only have 1 repo on our batch pod. To actually use this func, in the other PR we will pass in the option of simplePath = true