### PR TITLE
add revision to globalCfg for adhoc mode

### DIFF
--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -30,14 +30,16 @@ type GlobalCfg struct {
 }
 
 type AdhocMode struct {
-	Repo string `yaml:"repo" json:"repo"`
-	Root string `yaml:"root" json:"root"`
+	Repo     string `yaml:"repo" json:"repo"`
+	Root     string `yaml:"root" json:"root"`
+	Revision string `yaml:"revision" json:"revision"`
 }
 
 func (t AdhocMode) ToValid() valid.AdhocMode {
 	return valid.AdhocMode{
-		Repo: t.Repo,
-		Root: t.Root,
+		Repo:     t.Repo,
+		Root:     t.Root,
+		Revision: t.Revision,
 	}
 }
 

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -68,8 +68,9 @@ type GlobalCfg struct {
 }
 
 type AdhocMode struct {
-	Repo string
-	Root string
+	Repo     string
+	Root     string
+	Revision string
 }
 
 type GithubTeam struct {


### PR DESCRIPTION
I realized that we could use the revision as well when we do things like use the root config builder etc