### PR TITLE
simple path for terraform fetch

### DIFF
--- a/server/neptune/workflows/activities/github.go
+++ b/server/neptune/workflows/activities/github.go
@@ -249,6 +249,7 @@ type FetchRootRequest struct {
 	Root         terraform.Root
 	DeploymentID string
 	Revision     string
+	WorkflowMode terraform.WorkflowMode
 }
 
 type FetchRootResponse struct {
@@ -265,6 +266,10 @@ func (a *githubActivities) GithubFetchRoot(ctx context.Context, request FetchRoo
 	defer cancel()
 
 	deployBasePath := filepath.Join(a.DataDir, deploymentsDirName, request.DeploymentID)
+	// if we are in Adhoc mode, we can use a simple file path without a UUID since there will only be one repository
+	if request.WorkflowMode == terraform.Adhoc {
+		deployBasePath = filepath.Join(a.DataDir)
+	}
 	repositoryPath := filepath.Join(deployBasePath, "repo")
 	opts := &github.RepositoryContentGetOptions{
 		Ref: request.Revision,

--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -21,6 +21,7 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func(wo
 		Root:         r.Request.Root,
 		DeploymentID: r.Request.DeploymentID,
 		Revision:     r.Request.Revision,
+		WorkflowMode: r.Request.WorkflowMode,
 	}).Get(ctx, &fetchRootResponse)
 
 	if err != nil {

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -175,7 +175,7 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 		Root:         testLocalRoot.Root,
 		Repo:         testGithubRepo,
 		DeploymentID: testDeploymentID,
-		WorkflowMode: testWorkflowMode,
+		WorkflowMode: req.WorkflowMode,
 	}
 
 	if req.WorkflowMode == terraformModel.Adhoc {

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -497,6 +497,7 @@ func TestSuccess_PRMode(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -645,6 +646,7 @@ func TestSuccess_AdminMode(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -727,6 +729,7 @@ func TestSuccess_PRMode_FailedPolicy(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -869,6 +872,7 @@ func TestUpdateJobError(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		DeployDirectory: DeployDir,
 		LocalRoot:       testLocalRoot,
@@ -915,6 +919,7 @@ func TestPlanRejection(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		DeployDirectory: DeployDir,
 		LocalRoot:       testLocalRoot,
@@ -1083,6 +1088,7 @@ func TestFetchRootError(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		DeployDirectory: DeployDir,
 		LocalRoot:       testLocalRoot,

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -35,6 +35,8 @@ const (
 	DeployDir        = "deployments/123"
 )
 
+var testWorkflowMode terraformModel.WorkflowMode = terraformModel.Deploy
+
 var testGithubRepo = github.Repo{
 	Name: testRepoName,
 }
@@ -174,7 +176,7 @@ func testTerraformWorkflow(ctx workflow.Context, req request) (*response, error)
 		Root:         testLocalRoot.Root,
 		Repo:         testGithubRepo,
 		DeploymentID: testDeploymentID,
-		WorkflowMode: req.WorkflowMode,
+		WorkflowMode: testWorkflowMode,
 	}
 
 	if req.WorkflowMode == terraformModel.Adhoc {
@@ -287,6 +289,7 @@ func TestSuccess_DeployMode(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
+		WorkflowMode: testWorkflowMode,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -33,9 +33,8 @@ const (
 	testDeploymentID = "123"
 	testPath         = "rel/path"
 	DeployDir        = "deployments/123"
+	testWorkflowMode = terraformModel.Deploy
 )
-
-var testWorkflowMode terraformModel.WorkflowMode = terraformModel.Deploy
 
 var testGithubRepo = github.Repo{
 	Name: testRepoName,

--- a/server/neptune/workflows/internal/terraform/workflow_test.go
+++ b/server/neptune/workflows/internal/terraform/workflow_test.go
@@ -497,7 +497,7 @@ func TestSuccess_PRMode(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
-		WorkflowMode: testWorkflowMode,
+		WorkflowMode: terraformModel.PR,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -646,7 +646,7 @@ func TestSuccess_AdminMode(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
-		WorkflowMode: testWorkflowMode,
+		WorkflowMode: terraformModel.Adhoc,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,
@@ -729,7 +729,7 @@ func TestSuccess_PRMode_FailedPolicy(t *testing.T) {
 		Repo:         testGithubRepo,
 		Root:         testLocalRoot.Root,
 		DeploymentID: testDeploymentID,
-		WorkflowMode: testWorkflowMode,
+		WorkflowMode: terraformModel.PR,
 	}).Return(activities.FetchRootResponse{
 		LocalRoot:       testLocalRoot,
 		DeployDirectory: DeployDir,


### PR DESCRIPTION
Similar to https://github.com/lyft/atlantis/pull/737, we can use a simpler file path without the UUID stuff in adhoc mode since we will only have the 1 repository