### PR TITLE
add validation config for init purposes even though we won't use it

### DIFF
--- a/cmd/adhoc.go
+++ b/cmd/adhoc.go
@@ -75,6 +75,10 @@ func (a *Adhoc) NewServer(userConfig legacy.UserConfig, config legacy.Config) (S
 		GithubAppKeyFile: userConfig.GithubAppKeyFile,
 		GithubAppSlug:    userConfig.GithubAppSlug,
 		GlobalCfg:        globalCfg,
+		ValidationConfig: neptune.ValidationConfig{
+			DefaultVersion: globalCfg.PolicySets.Version,
+			Policies:       globalCfg.PolicySets,
+		},
 	}
 	return adhoc.NewServer(cfg)
 }

--- a/server/neptune/adhoc/config/config.go
+++ b/server/neptune/adhoc/config/config.go
@@ -31,4 +31,6 @@ type Config struct {
 	GithubHostname   string
 
 	GlobalCfg valid.GlobalCfg
+
+	ValidationConfig neptune.ValidationConfig
 }

--- a/server/neptune/adhoc/server.go
+++ b/server/neptune/adhoc/server.go
@@ -34,7 +34,6 @@ import (
 	neptune_http "github.com/runatlantis/atlantis/server/neptune/http"
 	internalSync "github.com/runatlantis/atlantis/server/neptune/sync"
 	"github.com/runatlantis/atlantis/server/neptune/temporal"
-	neptune "github.com/runatlantis/atlantis/server/neptune/temporalworker/config"
 	"github.com/runatlantis/atlantis/server/neptune/workflows"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/static"
@@ -104,9 +103,20 @@ func NewServer(config *adhocconfig.Config) (*Server, error) {
 		Logger:      config.CtxLogger,
 	}
 
+	/*
+		config.TerraformCfg,
+		config.ValidationConfig,
+		config.App,
+		config.DataDir,
+		config.ServerCfg.URL,
+		config.TemporalCfg.TerraformTaskQueue,
+		config.GithubCfg.TemporalAppInstallationID,
+		jobStreamHandler,
+	*/
+
 	terraformActivities, err := activities.NewTerraform(
 		config.TerraformCfg,
-		neptune.ValidationConfig{},
+		config.ValidationConfig,
 		config.App,
 		config.DataDir,
 		config.ServerCfg.URL,

--- a/server/neptune/adhoc/server.go
+++ b/server/neptune/adhoc/server.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/runatlantis/atlantis/server/legacy/events/vcs"
-	"github.com/runatlantis/atlantis/server/neptune/lyft/feature"
 	"github.com/runatlantis/atlantis/server/neptune/sync/crons"
 	ghClient "github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/vcs/provider/github"
@@ -103,17 +102,6 @@ func NewServer(config *adhocconfig.Config) (*Server, error) {
 		Logger:      config.CtxLogger,
 	}
 
-	/*
-		config.TerraformCfg,
-		config.ValidationConfig,
-		config.App,
-		config.DataDir,
-		config.ServerCfg.URL,
-		config.TemporalCfg.TerraformTaskQueue,
-		config.GithubCfg.TemporalAppInstallationID,
-		jobStreamHandler,
-	*/
-
 	terraformActivities, err := activities.NewTerraform(
 		config.TerraformCfg,
 		config.ValidationConfig,
@@ -136,33 +124,15 @@ func NewServer(config *adhocconfig.Config) (*Server, error) {
 		return nil, errors.Wrap(err, "client creator")
 	}
 
-	repoConfig := feature.RepoConfig{
-		Owner:  config.FeatureConfig.FFOwner,
-		Repo:   config.FeatureConfig.FFRepo,
-		Branch: config.FeatureConfig.FFBranch,
-		Path:   config.FeatureConfig.FFPath,
-	}
 	installationFetcher := &github.InstallationRetriever{
 		ClientCreator: clientCreator,
-	}
-	fileFetcher := &github.SingleFileContentsFetcher{
-		ClientCreator: clientCreator,
-	}
-	retriever := &feature.CustomGithubInstallationRetriever{
-		InstallationFetcher: installationFetcher,
-		FileContentsFetcher: fileFetcher,
-		Cfg:                 repoConfig,
-	}
-	featureAllocator, err := feature.NewGHSourcedAllocator(retriever, config.CtxLogger)
-	if err != nil {
-		return nil, errors.Wrap(err, "initializing feature allocator")
 	}
 
 	githubActivities, err := activities.NewGithub(
 		clientCreator,
 		config.GithubCfg.TemporalAppInstallationID,
 		config.DataDir,
-		featureAllocator,
+		nil,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing github activities")


### PR DESCRIPTION
we need the validation config for init purposes even though we don't actually use it

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xa06c13]
goroutine 1 [running]:
github.com/hashicorp/go-version.(*Version).String(0x0)
/code/go/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:369 +0x33
github.com/runatlantis/atlantis/server/legacy/core/runtime/cache.(*ExecutionVersionMemoryLayer).Get(0xc00003d860, 0x0)
/code/atlantis-private/atlantis/server/legacy/core/runtime/cache/version_path.go:93 +0x4d
github.com/runatlantis/atlantis/server/neptune/workflows/activities/command.NewAsyncClient(0x0, {0x222f380, 0xc00003d860})
/code/atlantis-private/atlantis/server/neptune/workflows/activities/command/async_client.go:27 +0x30
github.com/runatlantis/atlantis/server/neptune/workflows/activities.NewTerraform({{_, _}, {_, _}, {{_, _, _}}}, {0x0, {0x0, {0x0, ...}, ...}}, ...)
/code/atlantis-private/atlantis/server/neptune/workflows/activities/main.go:163 +0x6ef
github.com/runatlantis/atlantis/server/neptune/adhoc.NewServer(0xc000ad64b8)
/code/atlantis-private/atlantis/server/neptune/adhoc/server.go:111 +0x90c
github.com/runatlantis/atlantis/cmd.(*Adhoc).NewServer(_, {{0x7ffd2611b74a, 0x4b}, {0x1cfed33, 0x36}, {0x1c90b1f, 0x6}, {0x7ffd2611b7a1, 0xe}, 0x0, ...}, ...)
/code/atlantis-private/atlantis/cmd/adhoc.go:71 +0x685
github.com/runatlantis/atlantis/cmd.(*ServerCreatorProxy).NewServer(_, {{0x7ffd2611b74a, 0x4b}, {0x1cfed33, 0x36}, {0x1c90b1f, 0x6}, {0x7ffd2611b7a1, 0xe}, 0x0, ...}, ...)
/code/atlantis-private/atlantis/cmd/server.go:396 +0x3b5
github.com/runatlantis/atlantis/cmd.(*ServerCmd).run(0xc0006e60c0)
/code/atlantis-private/atlantis/cmd/server.go:533 +0x538
github.com/runatlantis/atlantis/cmd.(*ServerCmd).Init.func2(0x22?, {0x23?, 0x0?, 0xf?})
/code/atlantis-private/atlantis/cmd/server.go:414 +0x17
github.com/runatlantis/atlantis/cmd.(*ServerCmd).Init.(*ServerCmd).withErrPrint.func5(0xc0007e6000?, {0xc0007f8908?, 0x4?, 0x1c8ee70?})
/code/atlantis-private/atlantis/cmd/server.go:742 +0x29
github.com/spf13/cobra.(*Command).execute(0xc0006be248, {0xc0007f86c8, 0x22, 0x23})
/code/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20170905172051-b78744579491/command.go:650 +0x483
github.com/spf13/cobra.(*Command).ExecuteC(0x30c4ac0)
/code/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20170905172051-b78744579491/command.go:729 +0x22d
github.com/spf13/cobra.(*Command).Execute(...)
/code/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20170905172051-b78744579491/command.go:688
github.com/runatlantis/atlantis/cmd.Execute()
/code/atlantis-private/atlantis/cmd/root.go:30 +0x1a
main.main()
/code/atlantis-private/atlantis/main.go:37 +0x3be
```