### PR TITLE
adding nil check before checking conftest version so it doesnt panic

### DIFF
--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -150,7 +150,6 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing version %s", tfConfig.DefaultVersion)
 	}
-	defaultConftestVersion := validationConfig.DefaultVersion
 
 	tfClient, err := command.NewAsyncClient(
 		defaultTfVersion,
@@ -160,12 +159,16 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 		return nil, err
 	}
 
-	conftestClient, err := command.NewAsyncClient(
-		defaultConftestVersion,
-		conftestVersionCache,
-	)
-	if err != nil {
-		return nil, err
+	defaultConftestVersion := validationConfig.DefaultVersion
+	var confTestClient *command.AsyncClient
+	if defaultConftestVersion != nil {
+		confTestClient, err = command.NewAsyncClient(
+			defaultConftestVersion,
+			conftestVersionCache,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	policies := convertPolicies(validationConfig.Policies.PolicySets)
@@ -188,7 +191,7 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 		},
 		conftestActivity: &conftestActivity{
 			DefaultConftestVersion: defaultConftestVersion,
-			ConftestClient:         conftestClient,
+			ConftestClient:         confTestClient,
 			StreamHandler:          streamHandler,
 			Policies:               policies,
 			FileValidator:          &file.Validator{},

--- a/server/neptune/workflows/activities/main.go
+++ b/server/neptune/workflows/activities/main.go
@@ -160,9 +160,9 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 	}
 
 	defaultConftestVersion := validationConfig.DefaultVersion
-	var confTestClient *command.AsyncClient
+	var conftestClient *command.AsyncClient
 	if defaultConftestVersion != nil {
-		confTestClient, err = command.NewAsyncClient(
+		conftestClient, err = command.NewAsyncClient(
 			defaultConftestVersion,
 			conftestVersionCache,
 		)
@@ -191,7 +191,7 @@ func NewTerraform(tfConfig config.TerraformConfig, validationConfig config.Valid
 		},
 		conftestActivity: &conftestActivity{
 			DefaultConftestVersion: defaultConftestVersion,
-			ConftestClient:         confTestClient,
+			ConftestClient:         conftestClient,
 			StreamHandler:          streamHandler,
 			Policies:               policies,
 			FileValidator:          &file.Validator{},


### PR DESCRIPTION
as suggested on this PR https://github.com/lyft/atlantis/pull/746 , we will now check for nil in the version so it doesn't panic when it tries to `Get` on it