### PR TITLE
put automated PRs in slow queue

### DIFF
--- a/server/neptune/lyft/activities/github.go
+++ b/server/neptune/lyft/activities/github.go
@@ -44,9 +44,7 @@ func (a *Github) GithubListPRs(ctx context.Context, request ListPRsRequest) (Lis
 
 	pullRequests := []internal.PullRequest{}
 	for _, pullRequest := range prs {
-
 		isAutomated := IsPRAutomated(pullRequest)
-
 		pullRequests = append(pullRequests, internal.PullRequest{
 			Number:        pullRequest.GetNumber(),
 			UpdatedAt:     pullRequest.GetUpdatedAt(),

--- a/server/neptune/lyft/activities/github.go
+++ b/server/neptune/lyft/activities/github.go
@@ -58,7 +58,7 @@ func (a *Github) GithubListPRs(ctx context.Context, request ListPRsRequest) (Lis
 }
 
 func IsPRAutomated(pr *github.PullRequest) bool {
-	if pr.Labels == nil {
+	if pr == nil || len(pr.Labels) == 0 {
 		return false
 	}
 	for _, label := range pr.Labels {

--- a/server/neptune/lyft/activities/github.go
+++ b/server/neptune/lyft/activities/github.go
@@ -44,15 +44,31 @@ func (a *Github) GithubListPRs(ctx context.Context, request ListPRsRequest) (Lis
 
 	pullRequests := []internal.PullRequest{}
 	for _, pullRequest := range prs {
+
+		isAutomated := IsPRAutomated(pullRequest)
+
 		pullRequests = append(pullRequests, internal.PullRequest{
-			Number:    pullRequest.GetNumber(),
-			UpdatedAt: pullRequest.GetUpdatedAt(),
+			Number:        pullRequest.GetNumber(),
+			UpdatedAt:     pullRequest.GetUpdatedAt(),
+			IsAutomatedPR: isAutomated,
 		})
 	}
 
 	return ListPRsResponse{
 		PullRequests: pullRequests,
 	}, nil
+}
+
+func IsPRAutomated(pr *github.PullRequest) bool {
+	if pr.Labels == nil {
+		return false
+	}
+	for _, label := range pr.Labels {
+		if label.GetName() == "automated" {
+			return true
+		}
+	}
+	return false
 }
 
 type ListModifiedFilesRequest struct {

--- a/server/neptune/lyft/workflows/prrevision/workflow.go
+++ b/server/neptune/lyft/workflows/prrevision/workflow.go
@@ -132,8 +132,8 @@ func (r *Runner) listModifiedFilesAsync(ctx workflow.Context, req Request, prs [
 	oldPRCounter := r.Scope.SubScope("open_prs").Counter(fmt.Sprintf("more_than_%d_days", r.SlowProcessingCutOffDays))
 	newPRCounter := r.Scope.SubScope("open_prs").Counter(fmt.Sprintf("less_than_%d_days", r.SlowProcessingCutOffDays))
 	for _, pr := range prs {
-		// schedule on slow tq if pr is not updated within x days
-		if !r.isPrUpdatedWithinDays(ctx, pr, r.SlowProcessingCutOffDays) {
+		// schedule on slow tq if pr is not updated within x days, or if its an automated PR (aka refactorator PR, a PR with the label "automated")
+		if !r.isPrUpdatedWithinDays(ctx, pr, r.SlowProcessingCutOffDays) || pr.IsAutomatedPR {
 			options := workflow.GetActivityOptions(ctx)
 			options.TaskQueue = SlowTaskQueue
 			ctx = workflow.WithActivityOptions(ctx, options)

--- a/server/neptune/workflows/activities/github/pull.go
+++ b/server/neptune/workflows/activities/github/pull.go
@@ -8,6 +8,8 @@ import (
 type PullRequest struct {
 	Number    int
 	UpdatedAt time.Time
+	// Whether the PR has a label of "automated" or not, useful for identifying refactorator PRs
+	IsAutomatedPR bool
 }
 
 type PullRequestState string


### PR DESCRIPTION
It was said that we can use the slow task queue for `automated` PRs aka refactorator PRs.