### PR TITLE
add extra rate limit stuff to global cfg

### DIFF
--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -27,6 +27,27 @@ type GlobalCfg struct {
 	RevisionSetter       RevisionSetter       `yaml:"revision_setter" json:"revision_setter"`
 	Admin                Admin                `yaml:"admin" json:"admin"`
 	AdhocMode            AdhocMode            `yaml:"adhoc_mode" json:"adhoc_mode"`
+	ExtraGithubRateLimit ExtraGithubRateLimit `yaml:"extra_github_rate_limit" json:"extra_github_rate_limit"`
+}
+
+type ExtraGithubRateLimit struct {
+	Enabled  bool   `yaml:"enabled" json:"enabled"`
+	GHSlug   string `yaml:"gh_slug" json:"gh_slug"`
+	GHAppID  string `yaml:"gh_app_id" json:"gh_app_id"`
+	GHAppKey string `yaml:"gh_app_key" json:"gh_app_key"`
+}
+
+func (t ExtraGithubRateLimit) ToValid() valid.ExtraGithubRateLimit {
+	return valid.ExtraGithubRateLimit{
+		Enabled:  t.Enabled,
+		GHSlug:   t.GHSlug,
+		GHAppID:  t.GHAppID,
+		GHAppKey: t.GHAppKey,
+	}
+}
+
+func (t ExtraGithubRateLimit) Validate() error {
+	return nil
 }
 
 type AdhocMode struct {
@@ -215,6 +236,7 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 		Admin:                g.Admin.ToValid(),
 		RevisionSetter:       g.RevisionSetter.ToValid(),
 		AdhocMode:            g.AdhocMode.ToValid(),
+		ExtraGithubRateLimit: g.ExtraGithubRateLimit.ToValid(),
 	}
 }
 

--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -31,7 +31,6 @@ type GlobalCfg struct {
 }
 
 type ExtraGithubRateLimit struct {
-	Enabled  bool   `yaml:"enabled" json:"enabled"`
 	GHSlug   string `yaml:"gh_slug" json:"gh_slug"`
 	GHAppID  string `yaml:"gh_app_id" json:"gh_app_id"`
 	GHAppKey string `yaml:"gh_app_key" json:"gh_app_key"`
@@ -39,7 +38,6 @@ type ExtraGithubRateLimit struct {
 
 func (t ExtraGithubRateLimit) ToValid() valid.ExtraGithubRateLimit {
 	return valid.ExtraGithubRateLimit{
-		Enabled:  t.Enabled,
 		GHSlug:   t.GHSlug,
 		GHAppID:  t.GHAppID,
 		GHAppKey: t.GHAppKey,

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -69,7 +69,6 @@ type GlobalCfg struct {
 }
 
 type ExtraGithubRateLimit struct {
-	Enabled  bool
 	GHSlug   string
 	GHAppID  string
 	GHAppKey string

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -65,6 +65,14 @@ type GlobalCfg struct {
 	RevisionSetter       RevisionSetter
 	Admin                Admin
 	AdhocMode            AdhocMode
+	ExtraGithubRateLimit ExtraGithubRateLimit
+}
+
+type ExtraGithubRateLimit struct {
+	Enabled  bool
+	GHSlug   string
+	GHAppID  string
+	GHAppKey string
 }
 
 type AdhocMode struct {


### PR DESCRIPTION
Eventually we will use this when we build an abstraction on top of `clientCreator` to make a "client creator pool" with multiple configs