### PR TITLE
use int instead of string for app id since its a number and we need to read it in correctly in the env var

### DIFF
--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -27,6 +27,27 @@ type GlobalCfg struct {
 	RevisionSetter       RevisionSetter       `yaml:"revision_setter" json:"revision_setter"`
 	Admin                Admin                `yaml:"admin" json:"admin"`
 	AdhocMode            AdhocMode            `yaml:"adhoc_mode" json:"adhoc_mode"`
+	ExtraGithubRateLimit ExtraGithubRateLimit `yaml:"extra_github_rate_limit" json:"extra_github_rate_limit"`
+}
+
+type ExtraGithubRateLimit struct {
+	Enabled  bool   `yaml:"enabled" json:"enabled"`
+	GHSlug   string `yaml:"gh_slug" json:"gh_slug"`
+	GHAppID  string `yaml:"gh_app_id" json:"gh_app_id"`
+	GHAppKey string `yaml:"gh_app_key" json:"gh_app_key"`
+}
+
+func (t ExtraGithubRateLimit) ToValid() valid.ExtraGithubRateLimit {
+	return valid.ExtraGithubRateLimit{
+		Enabled:  t.Enabled,
+		GHSlug:   t.GHSlug,
+		GHAppID:  t.GHAppID,
+		GHAppKey: t.GHAppKey,
+	}
+}
+
+func (t ExtraGithubRateLimit) Validate() error {
+	return nil
 }
 
 type AdhocMode struct {
@@ -215,6 +236,7 @@ func (g GlobalCfg) ToValid(defaultCfg valid.GlobalCfg) valid.GlobalCfg {
 		Admin:                g.Admin.ToValid(),
 		RevisionSetter:       g.RevisionSetter.ToValid(),
 		AdhocMode:            g.AdhocMode.ToValid(),
+		ExtraGithubRateLimit: g.ExtraGithubRateLimit.ToValid(),
 	}
 }
 

--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -31,7 +31,6 @@ type GlobalCfg struct {
 }
 
 type ExtraGithubRateLimit struct {
-	Enabled  bool   `yaml:"enabled" json:"enabled"`
 	GHSlug   string `yaml:"gh_slug" json:"gh_slug"`
 	GHAppID  string `yaml:"gh_app_id" json:"gh_app_id"`
 	GHAppKey string `yaml:"gh_app_key" json:"gh_app_key"`
@@ -39,7 +38,6 @@ type ExtraGithubRateLimit struct {
 
 func (t ExtraGithubRateLimit) ToValid() valid.ExtraGithubRateLimit {
 	return valid.ExtraGithubRateLimit{
-		Enabled:  t.Enabled,
 		GHSlug:   t.GHSlug,
 		GHAppID:  t.GHAppID,
 		GHAppKey: t.GHAppKey,

--- a/server/config/raw/global_cfg.go
+++ b/server/config/raw/global_cfg.go
@@ -32,7 +32,7 @@ type GlobalCfg struct {
 
 type ExtraGithubRateLimit struct {
 	GHSlug   string `yaml:"gh_slug" json:"gh_slug"`
-	GHAppID  string `yaml:"gh_app_id" json:"gh_app_id"`
+	GHAppID  int    `yaml:"gh_app_id" json:"gh_app_id"`
 	GHAppKey string `yaml:"gh_app_key" json:"gh_app_key"`
 }
 

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -69,7 +69,6 @@ type GlobalCfg struct {
 }
 
 type ExtraGithubRateLimit struct {
-	Enabled  bool
 	GHSlug   string
 	GHAppID  string
 	GHAppKey string

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -68,9 +68,10 @@ type GlobalCfg struct {
 	ExtraGithubRateLimit ExtraGithubRateLimit
 }
 
+// This is here for using an extra github app
 type ExtraGithubRateLimit struct {
 	GHSlug   string
-	GHAppID  string
+	GHAppID  int // note that this is also known as the "integration ID"
 	GHAppKey string
 }
 

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -65,6 +65,14 @@ type GlobalCfg struct {
 	RevisionSetter       RevisionSetter
 	Admin                Admin
 	AdhocMode            AdhocMode
+	ExtraGithubRateLimit ExtraGithubRateLimit
+}
+
+type ExtraGithubRateLimit struct {
+	Enabled  bool
+	GHSlug   string
+	GHAppID  string
+	GHAppKey string
 }
 
 type AdhocMode struct {


### PR DESCRIPTION
just like PrNum, we need to treat it like a number not string otherwise it breaks