### PR TITLE
add env var for PluginCacheMayBreakDependencyLockFile

### DIFF
--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -421,6 +421,8 @@ func (t *terraformActivities) addTerraformEnvs(envs map[string]string, path stri
 	envs[AtlantisTerraformVersion] = tfVersion.String()
 	envs[Dir] = path
 	envs[TFPluginCacheDir] = t.CacheDir
-	// This is
+	// This is not a long-term fix. Eventually the underlying functionality in terraform will be changed.
+	// See https://developer.hashicorp.com/terraform/cli/config/config-file#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file
+	// and https://github.com/hashicorp/terraform/issues/32205 for discussions and context.
 	envs[PluginCacheMayBreakDependencyLockFile] = "true"
 }

--- a/server/neptune/workflows/activities/terraform.go
+++ b/server/neptune/workflows/activities/terraform.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 	"io"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 	"go.temporal.io/sdk/activity"
@@ -23,11 +24,12 @@ import (
 )
 
 const (
-	TFInAutomation           = "TF_IN_AUTOMATION"
-	TFInAutomationVal        = "true"
-	AtlantisTerraformVersion = "ATLANTIS_TERRAFORM_VERSION"
-	Dir                      = "DIR"
-	TFPluginCacheDir         = "TF_PLUGIN_CACHE_DIR"
+	TFInAutomation                        = "TF_IN_AUTOMATION"
+	TFInAutomationVal                     = "true"
+	AtlantisTerraformVersion              = "ATLANTIS_TERRAFORM_VERSION"
+	Dir                                   = "DIR"
+	TFPluginCacheDir                      = "TF_PLUGIN_CACHE_DIR"
+	PluginCacheMayBreakDependencyLockFile = "TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE"
 )
 
 // TerraformClientError can be used to assert a non-retryable error type for
@@ -419,4 +421,6 @@ func (t *terraformActivities) addTerraformEnvs(envs map[string]string, path stri
 	envs[AtlantisTerraformVersion] = tfVersion.String()
 	envs[Dir] = path
 	envs[TFPluginCacheDir] = t.CacheDir
+	// This is
+	envs[PluginCacheMayBreakDependencyLockFile] = "true"
 }

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -3,10 +3,11 @@ package activities
 import (
 	"context"
 	"fmt"
-	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/command"
 
 	"github.com/hashicorp/go-version"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/file"
@@ -133,6 +134,7 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -157,6 +159,7 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -173,6 +176,7 @@ func TestTerraformInit_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 
 			// defaults
@@ -267,6 +271,7 @@ func TestTerraformInit_StreamsOutput(t *testing.T) {
 			"DIR":                        "some/path",
 			"TF_IN_AUTOMATION":           "true",
 			"TF_PLUGIN_CACHE_DIR":        "some/dir",
+			"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 		},
 		version: expectedVersion,
 		resp:    expectedMsgStr,
@@ -337,6 +342,7 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -367,6 +373,7 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -387,6 +394,7 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -404,6 +412,7 @@ func TestTerraformPlan_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 
 			// default
@@ -512,6 +521,7 @@ func TestTerraformPlan_ReturnsResponse(t *testing.T) {
 					"DIR":                        "some/path",
 					"TF_IN_AUTOMATION":           "true",
 					"TF_PLUGIN_CACHE_DIR":        "some/dir",
+					"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 				},
 				version: expectedVersion,
 				resp:    expectedMsgStr,
@@ -526,6 +536,7 @@ func TestTerraformPlan_ReturnsResponse(t *testing.T) {
 					"DIR":                        "some/path",
 					"TF_IN_AUTOMATION":           "true",
 					"TF_PLUGIN_CACHE_DIR":        "some/dir",
+					"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 				},
 				version: expectedVersion,
 				resp:    "{\"format_version\": \"1.0\",\"resource_changes\":[{\"change\":{\"actions\":[\"update\"]},\"address\":\"type.resource\"}]}",
@@ -602,6 +613,7 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{
@@ -624,6 +636,7 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 		},
 		{

--- a/server/neptune/workflows/activities/terraform_test.go
+++ b/server/neptune/workflows/activities/terraform_test.go
@@ -653,6 +653,7 @@ func TestTerraformApply_RequestValidation(t *testing.T) {
 				"DIR":                        "some/path",
 				"TF_IN_AUTOMATION":           "true",
 				"TF_PLUGIN_CACHE_DIR":        "some/dir",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 			},
 
 			//default
@@ -733,6 +734,7 @@ func TestTerraformApply_StreamsOutput(t *testing.T) {
 			"DIR":                        "some/path",
 			"TF_IN_AUTOMATION":           "true",
 			"TF_PLUGIN_CACHE_DIR":        "some/dir",
+			"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "true",
 		},
 		version: expectedVersion,
 		resp:    expectedMsgStr,


### PR DESCRIPTION
The situation:

In the attempt to upgrade projects to terraform 1.5.7 (mostly from 1.3.1) we encountered strange behavior where it would not use the cache despite the providers (i.e. aws and github) having already been downloaded to the cache. This resulted in us seeing an error `text file busy` when different roots would be trying to access the cache (there were also problems with an incorrect checksum, which was probably caused by the file being overwritten / corrupted) It turns out there was an underlying change in terraform 1.4 in regards to how lockfiles interact with the plugin cache. 

From this pr https://github.com/hashicorp/terraform/commit/d0a35c60a764d3b1be53d5ba16c035190e6a3959
`This change addresses that problem by essentially flipping the decision so
that we'll prioritize the lock file behavior over the provider cache
behavior. Now a global cache entry is eligible for use if and only if the
lock file already contains a checksum that matches the cache entry. This
means that the first time a particular configuration sees a new provider
it will always be fetched from the configured installation source
(typically the origin registry) and record the checksums from that source.`

This PR adds the env var which tells terraform to do the old behavior (pre 1.4), which works for us because it will stop our concurrency issues by not overwriting the cache each time.



Note this is a somewhat controversial fix
https://github.com/hashicorp/terraform/issues/32205
https://developer.hashicorp.com/terraform/cli/config/config-file#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file

Note that other solutions were considered (such as just disabling cache) but those were determined to be suboptimal so not appropriate.