### PR TITLE
[DEVCON-7138] remove old workflow mode that is not platform (pr)

### DIFF
--- a/server/config/raw/project.go
+++ b/server/config/raw/project.go
@@ -93,7 +93,7 @@ func (p Project) ToValid(defaultWorkflowModeType valid.WorkflowModeType) valid.P
 	v.DeploymentWorkflowName = p.DeploymentWorkflowName
 	v.WorkflowModeType = defaultWorkflowModeType
 	if p.WorkflowModeType != nil {
-		v.WorkflowModeType = toWorkflowModeType()
+		v.WorkflowModeType = valid.PlatformWorkflowMode
 	}
 	if p.TerraformVersion != nil {
 		v.TerraformVersion, _ = version.NewVersion(*p.TerraformVersion)

--- a/server/config/raw/project.go
+++ b/server/config/raw/project.go
@@ -93,7 +93,7 @@ func (p Project) ToValid(defaultWorkflowModeType valid.WorkflowModeType) valid.P
 	v.DeploymentWorkflowName = p.DeploymentWorkflowName
 	v.WorkflowModeType = defaultWorkflowModeType
 	if p.WorkflowModeType != nil {
-		v.WorkflowModeType = toWorkflowModeType(*p.WorkflowModeType)
+		v.WorkflowModeType = toWorkflowModeType()
 	}
 	if p.TerraformVersion != nil {
 		v.TerraformVersion, _ = version.NewVersion(*p.TerraformVersion)

--- a/server/config/raw/project_test.go
+++ b/server/config/raw/project_test.go
@@ -268,7 +268,7 @@ func TestProject_ToValid(t *testing.T) {
 				},
 				ApplyRequirements: nil,
 				Name:              nil,
-				WorkflowModeType:  valid.DefaultWorkflowMode,
+				WorkflowModeType:  valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -314,7 +314,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		// Directories.
@@ -330,7 +330,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -360,7 +360,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -376,7 +376,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -391,7 +391,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -406,7 +406,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 		{
@@ -421,7 +421,7 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 
@@ -438,13 +438,13 @@ func TestProject_ToValid(t *testing.T) {
 					WhenModified: []string{"**/*.tf*", "**/terragrunt.hcl"},
 					Enabled:      true,
 				},
-				WorkflowModeType: valid.DefaultWorkflowMode,
+				WorkflowModeType: valid.PlatformWorkflowMode,
 			},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			Equals(t, c.exp, c.input.ToValid(valid.DefaultWorkflowMode))
+			Equals(t, c.exp, c.input.ToValid(valid.PlatformWorkflowMode))
 		})
 	}
 }

--- a/server/config/raw/repo_cfg.go
+++ b/server/config/raw/repo_cfg.go
@@ -41,12 +41,12 @@ func (r RepoCfg) Validate() error {
 	return validation.ValidateStruct(&r,
 		validation.Field(&r.Version, validation.By(equals2)),
 		validation.Field(&r.Projects),
-		validation.Field(&r.WorkflowModeType, validation.In("pr", "platform")),
+		validation.Field(&r.WorkflowModeType, validation.In("platform")),
 	)
 }
 
 func (r RepoCfg) ToValid() valid.RepoCfg {
-	workflowModeType := toWorkflowModeType(r.WorkflowModeType)
+	workflowModeType := toWorkflowModeType()
 
 	var validProjects []valid.Project
 	for _, p := range r.Projects {
@@ -72,11 +72,7 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 	}
 }
 
-func toWorkflowModeType(workflowModeType string) valid.WorkflowModeType {
+func toWorkflowModeType() valid.WorkflowModeType {
 	result := valid.PlatformWorkflowMode
-	switch workflowModeType {
-	case "pr":
-		result = valid.DefaultWorkflowMode
-	}
 	return result
 }

--- a/server/config/raw/repo_cfg.go
+++ b/server/config/raw/repo_cfg.go
@@ -46,7 +46,7 @@ func (r RepoCfg) Validate() error {
 }
 
 func (r RepoCfg) ToValid() valid.RepoCfg {
-	workflowModeType := toWorkflowModeType()
+	workflowModeType := valid.PlatformWorkflowMode
 
 	var validProjects []valid.Project
 	for _, p := range r.Projects {
@@ -70,9 +70,4 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		ParallelPlan:        parallelPlan,
 		ParallelPolicyCheck: parallelPlan,
 	}
-}
-
-func toWorkflowModeType() valid.WorkflowModeType {
-	result := valid.PlatformWorkflowMode
-	return result
 }

--- a/server/config/valid/global_cfg.go
+++ b/server/config/valid/global_cfg.go
@@ -41,7 +41,6 @@ type WorkflowModeType int
 
 const (
 	PlatformWorkflowMode WorkflowModeType = iota
-	DefaultWorkflowMode
 )
 
 type BackendType string

--- a/server/legacy/controllers/events/events_controller_e2e_test.go
+++ b/server/legacy/controllers/events/events_controller_e2e_test.go
@@ -135,16 +135,6 @@ legacy-deprecation:
 			},
 		},
 		{
-			Description:   "failing policy without policies passing",
-			RepoDir:       "policy-checks",
-			ModifiedFiles: []string{"main.tf"},
-			ExpReplies: [][]string{
-				{"exp-output-autoplan.txt"},
-				{"exp-output-auto-policy-check.txt"},
-				{"exp-output-auto-policy-check.txt"},
-			},
-		},
-		{
 			Description:   "failing policy additional apply requirements specified",
 			RepoDir:       "policy-checks-apply-reqs",
 			ModifiedFiles: []string{"main.tf"},

--- a/server/legacy/events/project_command_runner_test.go
+++ b/server/legacy/events/project_command_runner_test.go
@@ -487,31 +487,6 @@ func TestDefaultProjectCommandRunner_ForceOverridesApplyReqs(t *testing.T) {
 	Equals(t, "", firstRes.Failure)
 }
 
-// Test that if undiverged is required and the PR is diverged we give an error.
-func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
-	RegisterMockTestingT(t)
-	mockWorkingDir := mocks.NewMockWorkingDir()
-	runner := &events.DefaultProjectCommandRunner{
-		WorkingDir:       mockWorkingDir,
-		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
-		StepsRunner:      smocks.NewMockStepsRunner(),
-		AggregateApplyRequirements: &events.AggregateApplyRequirements{
-			WorkingDir: mockWorkingDir,
-		},
-	}
-	prjCtx := command.ProjectContext{
-		ApplyRequirements: []string{"undiverged"},
-		WorkflowModeType:  valid.PlatformWorkflowMode,
-	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
-	When(mockWorkingDir.GetWorkingDir(prjCtx.BaseRepo, prjCtx.Pull, prjCtx.Workspace)).ThenReturn(tmp, nil)
-	When(mockWorkingDir.HasDiverged(matchers.AnyLoggingLogger(), AnyString(), matchers.AnyModelsRepo())).ThenReturn(true)
-
-	firstRes := runner.Apply(prjCtx)
-	Equals(t, "Default branch must be rebased onto pull request before running apply.", firstRes.Failure)
-}
-
 // Test that it runs the expected apply steps.
 func TestDefaultProjectCommandRunner_Apply(t *testing.T) {
 	cases := []struct {

--- a/server/legacy/events/project_command_runner_test.go
+++ b/server/legacy/events/project_command_runner_test.go
@@ -487,33 +487,6 @@ func TestDefaultProjectCommandRunner_ForceOverridesApplyReqs(t *testing.T) {
 	Equals(t, "", firstRes.Failure)
 }
 
-// Test that if mergeable is required and the PR isn't mergeable we give an error.
-func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
-	RegisterMockTestingT(t)
-	mockWorkingDir := mocks.NewMockWorkingDir()
-	runner := &events.DefaultProjectCommandRunner{
-		WorkingDir:       mockWorkingDir,
-		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
-		StepsRunner:      smocks.NewMockStepsRunner(),
-		AggregateApplyRequirements: &events.AggregateApplyRequirements{
-			WorkingDir: mockWorkingDir,
-		},
-	}
-	prjCtx := command.ProjectContext{
-		PullReqStatus: models.PullReqStatus{
-			Mergeable: false,
-		},
-		ApplyRequirements: []string{"mergeable"},
-		WorkflowModeType:  valid.PlatformWorkflowMode,
-	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
-	When(mockWorkingDir.GetWorkingDir(prjCtx.BaseRepo, prjCtx.Pull, prjCtx.Workspace)).ThenReturn(tmp, nil)
-
-	firstRes := runner.Apply(prjCtx)
-	Equals(t, "Pull request must be mergeable before running apply.", firstRes.Failure)
-}
-
 // Test that if undiverged is required and the PR is diverged we give an error.
 func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	RegisterMockTestingT(t)

--- a/server/legacy/events/project_command_runner_test.go
+++ b/server/legacy/events/project_command_runner_test.go
@@ -558,7 +558,7 @@ func TestDefaultProjectCommandRunner_ApplyDiverged(t *testing.T) {
 	}
 	prjCtx := command.ProjectContext{
 		ApplyRequirements: []string{"undiverged"},
-		WorkflowModeType:  valid.DefaultWorkflowMode,
+		WorkflowModeType:  valid.PlatformWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()

--- a/server/legacy/events/project_command_runner_test.go
+++ b/server/legacy/events/project_command_runner_test.go
@@ -447,7 +447,7 @@ func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
 				IsApproved: false,
 			},
 		},
-		WorkflowModeType: valid.DefaultWorkflowMode,
+		WorkflowModeType: valid.PlatformWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()
@@ -534,7 +534,7 @@ func TestDefaultProjectCommandRunner_ApplyNotMergeable(t *testing.T) {
 			Mergeable: false,
 		},
 		ApplyRequirements: []string{"mergeable"},
-		WorkflowModeType:  valid.DefaultWorkflowMode,
+		WorkflowModeType:  valid.PlatformWorkflowMode,
 	}
 	tmp, cleanup := TempDir(t)
 	defer cleanup()

--- a/server/legacy/events/project_command_runner_test.go
+++ b/server/legacy/events/project_command_runner_test.go
@@ -427,36 +427,6 @@ func TestDefaultProjectCommandRunner_ApplyNotCloned(t *testing.T) {
 	ErrEquals(t, "project has not been cloned–did you run plan?", firstRes.Error)
 }
 
-// Test that if approval is required and the PR isn't approved we give an error.
-func TestDefaultProjectCommandRunner_ApplyNotApproved(t *testing.T) {
-	RegisterMockTestingT(t)
-	mockWorkingDir := mocks.NewMockWorkingDir()
-	mockSender := mocks.NewMockWebhooksSender()
-	runner := &events.DefaultProjectCommandRunner{
-		WorkingDir:       mockWorkingDir,
-		WorkingDirLocker: events.NewDefaultWorkingDirLocker(),
-		AggregateApplyRequirements: &events.AggregateApplyRequirements{
-			WorkingDir: mockWorkingDir,
-		},
-		Webhooks: mockSender,
-	}
-	prjCtx := command.ProjectContext{
-		ApplyRequirements: []string{"approved"},
-		PullReqStatus: models.PullReqStatus{
-			ApprovalStatus: models.ApprovalStatus{
-				IsApproved: false,
-			},
-		},
-		WorkflowModeType: valid.PlatformWorkflowMode,
-	}
-	tmp, cleanup := TempDir(t)
-	defer cleanup()
-	When(mockWorkingDir.GetWorkingDir(prjCtx.BaseRepo, prjCtx.Pull, prjCtx.Workspace)).ThenReturn(tmp, nil)
-
-	firstRes := runner.Apply(prjCtx)
-	Equals(t, "Pull request must be approved by at least one person other than the author before running apply.", firstRes.Failure)
-}
-
 func TestDefaultProjectCommandRunner_ForceOverridesApplyReqs_IfPlatformMode(t *testing.T) {
 	RegisterMockTestingT(t)
 	mockWorkingDir := mocks.NewMockWorkingDir()

--- a/server/legacy/lyft/command/feature_runner_test.go
+++ b/server/legacy/lyft/command/feature_runner_test.go
@@ -97,9 +97,6 @@ func (b *TestMultiBuilder) BuildApplyCommands(ctx *command.Context, comment *com
 		{
 			WorkflowModeType: valid.PlatformWorkflowMode,
 		},
-		{
-			WorkflowModeType: valid.DefaultWorkflowMode,
-		},
 	}, nil
 }
 
@@ -148,7 +145,7 @@ func TestPlatformModeRunner_allocatesButNotPlatformMode(t *testing.T) {
 	}
 
 	builder := &TestBuilder{
-		Type: valid.DefaultWorkflowMode,
+		Type: valid.PlatformWorkflowMode,
 	}
 	runner := &testCMDRunner{
 		t:           t,
@@ -303,15 +300,6 @@ func TestPlatformModeProjectRunner_plan(t *testing.T) {
 			},
 			prModeRunner: &testRunner{},
 		},
-		{
-			description:      "allocated and platform mode not enabled",
-			shouldAllocate:   true,
-			workflowModeType: valid.DefaultWorkflowMode,
-			platformRunner:   &testRunner{},
-			prModeRunner: &testRunner{
-				expectedPlanResult: expectedResult,
-			},
-		},
 	}
 
 	for _, c := range cases {
@@ -364,15 +352,6 @@ func TestPlatformModeProjectRunner_policyCheck(t *testing.T) {
 				expectedPolicyCheckResult: expectedResult,
 			},
 			prModeRunner: &testRunner{},
-		},
-		{
-			description:      "allocated and platform mode not enabled",
-			shouldAllocate:   true,
-			workflowModeType: valid.DefaultWorkflowMode,
-			platformRunner:   &testRunner{},
-			prModeRunner: &testRunner{
-				expectedPolicyCheckResult: expectedResult,
-			},
 		},
 	}
 


### PR DESCRIPTION
Before running the refactorator to officially remove the platform mode field in the orchestration stanza (which was originally used to upgrade to platform mode, from "pr" or default mode)