### PR TITLE
add legacyhandler back (deleted it in 766 oops)

### DIFF
--- a/server/legacy/lyft/gateway/events_controller.go
+++ b/server/legacy/lyft/gateway/events_controller.go
@@ -60,9 +60,13 @@ func NewVCSEventsController(
 	clientCreator githubapp.ClientCreator,
 	defaultTFVersion string,
 ) *VCSEventsController {
+	legacyHandler := &gateway_handlers.LegacyPullHandler{
+		Logger:           logger,
+		VCSStatusUpdater: vcsStatusUpdater,
+	}
 	prSignaler := &pr.WorkflowSignaler{TemporalClient: temporalClient, DefaultTFVersion: defaultTFVersion}
 	prRequirementChecker := requirement.NewPRAggregate(globalCfg)
-	modifiedPullHandler := gateway_handlers.NewModifiedPullHandler(logger, asyncScheduler, rootConfigBuilder, globalCfg, prRequirementChecker, prSignaler)
+	modifiedPullHandler := gateway_handlers.NewModifiedPullHandler(logger, asyncScheduler, rootConfigBuilder, globalCfg, prRequirementChecker, prSignaler, legacyHandler)
 	closedPullHandler := &gateway_handlers.ClosedPullRequestHandler{
 		Logger:          logger,
 		PRCloseSignaler: prSignaler,

--- a/server/neptune/gateway/event/legacy_pull_handler.go
+++ b/server/neptune/gateway/event/legacy_pull_handler.go
@@ -1,0 +1,36 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/runatlantis/atlantis/server/config/valid"
+	"github.com/runatlantis/atlantis/server/legacy/events/command"
+	"github.com/runatlantis/atlantis/server/legacy/http"
+	"github.com/runatlantis/atlantis/server/logging"
+	"github.com/runatlantis/atlantis/server/models"
+)
+
+const PlatformModeApplyStatusMessage = "THIS IS A LEGACY STATUS CHECK AND IS NOT RELEVANT PLEASE LOOK AT atlantis/deploy status checks"
+
+type vcsStatusUpdater interface {
+	UpdateCombined(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, statusID string, output string) (string, error)
+	UpdateCombinedCount(ctx context.Context, repo models.Repo, pull models.PullRequest, status models.VCSStatus, cmdName fmt.Stringer, numSuccess int, numTotal int, statusID string) (string, error)
+}
+
+type LegacyPullHandler struct {
+	VCSStatusUpdater vcsStatusUpdater
+	Logger           logging.Logger
+}
+
+func (l *LegacyPullHandler) Handle(ctx context.Context, request *http.BufferedRequest, event PullRequest, allRoots []*valid.MergedProjectCfg) error {
+	// mark legacy statuses as successful if there are no roots in general
+	// this is processed here to make it easy to clean up when we deprecate legacy mode
+	if len(allRoots) == 0 {
+		if _, statusErr := l.VCSStatusUpdater.UpdateCombinedCount(ctx, event.Pull.HeadRepo, event.Pull, models.SuccessVCSStatus, command.Plan, 0, 0, ""); statusErr != nil {
+			l.Logger.WarnContext(ctx, fmt.Sprintf("unable to update commit status: %s", statusErr))
+		}
+		return nil
+	}
+	return nil
+}


### PR DESCRIPTION
In https://github.com/lyft/atlantis/pull/766/files#top I accidently deleted the legacyHandler functionality. It worked in staging so I assumed it was fine, but apparently not, since some people had problems where the status was reported. This should fix that.

Just to clarify why it is ok to delete the other parts and not the legacyHandler:
- The legacyHandler actually calls the UpdateCombinedCount func that is needed for github updates
- The other parts, like the comment handler and error handler only forwarded things to sns, which is why we don't need them