### PR TITLE
DEVCON-7212: Upgrade atlantis to Go 1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           args: --timeout 3m --verbose --disable revive
-          version: v1.61.0
+          version: v1.60.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           args: --timeout 3m --verbose --disable revive
-          version: v1.56.2
+          version: v1.60.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           args: --timeout 3m --verbose --disable revive
-          version: v1.61.1
+          version: v1.61.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/checkout@v3
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           args: --timeout 3m --verbose --disable revive
-          version: v1.60.2
+          version: v1.61.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
             && sudo cp conftest /usr/local/bin/conftest
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.23
       - uses: actions/checkout@v3
       - run: make test-all

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runatlantis/atlantis
 
-go 1.22
+go 1.23
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.45.0
 

--- a/server/legacy/controllers/jobs_controller.go
+++ b/server/legacy/controllers/jobs_controller.go
@@ -41,7 +41,7 @@ func (j *JobsController) getProjectJobs(w http.ResponseWriter, r *http.Request) 
 	jobID, err := j.KeyGenerator.Generate(r)
 
 	if err != nil {
-		j.respond(w, http.StatusBadRequest, err.Error())
+		j.respond(w, http.StatusBadRequest, "%s", err.Error())
 		return err
 	}
 
@@ -71,7 +71,7 @@ func (j *JobsController) getProjectJobsWS(w http.ResponseWriter, r *http.Request
 	err := j.WsMux.Handle(w, r)
 
 	if err != nil {
-		j.respond(w, http.StatusBadRequest, err.Error())
+		j.respond(w, http.StatusBadRequest, "%s", err.Error())
 		return err
 	}
 
@@ -90,8 +90,6 @@ func (j *JobsController) GetProjectJobsWS(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// disabling govet linter for now as it has a bug as highlighted in https://github.com/argoproj/argo-cd/issues/19772 also
-// nolint: govet
 func (j *JobsController) respond(w http.ResponseWriter, responseCode int, format string, args ...interface{}) {
 	response := fmt.Sprintf(format, args...)
 	j.Logger.Error(response)

--- a/server/legacy/controllers/jobs_controller.go
+++ b/server/legacy/controllers/jobs_controller.go
@@ -90,6 +90,8 @@ func (j *JobsController) GetProjectJobsWS(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// disabling govet linter for now as it has a bug as highlighted in https://github.com/argoproj/argo-cd/issues/19772 also
+// nolint: govet
 func (j *JobsController) respond(w http.ResponseWriter, responseCode int, format string, args ...interface{}) {
 	response := fmt.Sprintf(format, args...)
 	j.Logger.Error(response)

--- a/server/legacy/core/runtime/show_step_runner.go
+++ b/server/legacy/core/runtime/show_step_runner.go
@@ -53,7 +53,7 @@ func (p *ShowStepRunner) Run(ctx context.Context, prjCtx command.ProjectContext,
 		return output, errors.Wrap(err, "running terraform show")
 	}
 
-	if err := os.WriteFile(showResultFile, []byte(output), os.ModePerm); err != nil {
+	if err := os.WriteFile(showResultFile, []byte(output), 0600); err != nil {
 		return "", errors.Wrap(err, "writing terraform show result")
 	}
 

--- a/server/legacy/core/runtime/show_step_runner.go
+++ b/server/legacy/core/runtime/show_step_runner.go
@@ -53,7 +53,7 @@ func (p *ShowStepRunner) Run(ctx context.Context, prjCtx command.ProjectContext,
 		return output, errors.Wrap(err, "running terraform show")
 	}
 
-	if err := os.WriteFile(showResultFile, []byte(output), 0600); err != nil {
+	if err := os.WriteFile(showResultFile, []byte(output), os.ModePerm); err != nil { //nolint:gosec
 		return "", errors.Wrap(err, "writing terraform show result")
 	}
 

--- a/server/legacy/events/working_dir_iterator_test.go
+++ b/server/legacy/events/working_dir_iterator_test.go
@@ -41,7 +41,7 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 	t.Run("pull not found", func(t *testing.T) {
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
 
 		pullNotFound := &vcs.PullRequestNotFound{Err: errors.New("error")}
 

--- a/server/legacy/events/working_dir_iterator_test.go
+++ b/server/legacy/events/working_dir_iterator_test.go
@@ -41,7 +41,7 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 	t.Run("pull not found", func(t *testing.T) {
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm) //nolint:gosec
 
 		pullNotFound := &vcs.PullRequestNotFound{Err: errors.New("error")}
 
@@ -72,7 +72,7 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm) //nolint:gosec
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", 1)).ThenReturn(expectedGithubPull, nil)
 		pegomock.When(mockEventParser.ParseGithubPull(expectedGithubPull)).ThenReturn(expectedInternalPull, models.Repo{}, models.Repo{}, nil)
@@ -112,8 +112,8 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "2", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm) //nolint:gosec
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "2", "default"), os.ModePerm) //nolint:gosec
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum1)).ThenReturn(expectedGithubPull1, nil)
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum2)).ThenReturn(expectedGithubPull2, nil)
@@ -156,8 +156,8 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo2", "2", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm) //nolint:gosec
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo2", "2", "default"), os.ModePerm) //nolint:gosec
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum1)).ThenReturn(expectedGithubPull1, nil)
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo2", "nish", pullNum2)).ThenReturn(expectedGithubPull2, nil)

--- a/server/legacy/events/working_dir_iterator_test.go
+++ b/server/legacy/events/working_dir_iterator_test.go
@@ -72,7 +72,7 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", 1)).ThenReturn(expectedGithubPull, nil)
 		pegomock.When(mockEventParser.ParseGithubPull(expectedGithubPull)).ThenReturn(expectedInternalPull, models.Repo{}, models.Repo{}, nil)
@@ -112,8 +112,8 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm)
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "2", "default"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "2", "default"), 0600)
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum1)).ThenReturn(expectedGithubPull1, nil)
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum2)).ThenReturn(expectedGithubPull2, nil)
@@ -156,8 +156,8 @@ func TestListCurrentWorkingDirPulls(t *testing.T) {
 
 		baseDir := t.TempDir()
 
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), os.ModePerm)
-		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo2", "2", "default"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo1", "1", "default"), 0600)
+		_ = os.MkdirAll(filepath.Join(baseDir, "repos", "nish", "repo2", "2", "default"), 0600)
 
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo1", "nish", pullNum1)).ThenReturn(expectedGithubPull1, nil)
 		pegomock.When(mockGHClient.GetPullRequestFromName("repo2", "nish", pullNum2)).ThenReturn(expectedGithubPull2, nil)

--- a/server/neptune/temporalworker/controllers/job_controller.go
+++ b/server/neptune/temporalworker/controllers/job_controller.go
@@ -78,7 +78,7 @@ func NewJobsController(
 func (j *JobsController) getProjectJobs(w http.ResponseWriter, r *http.Request) error {
 	jobID, err := j.KeyGenerator.Generate(r)
 	if err != nil {
-		j.respond(w, http.StatusBadRequest, err.Error())
+		j.respond(w, http.StatusBadRequest, "%s", err.Error())
 		return err
 	}
 
@@ -106,7 +106,7 @@ func (j *JobsController) GetProjectJobs(w http.ResponseWriter, r *http.Request) 
 func (j *JobsController) getProjectJobsWS(w http.ResponseWriter, r *http.Request) error {
 	err := j.WsMux.Handle(w, r)
 	if err != nil {
-		j.respond(w, http.StatusBadRequest, err.Error())
+		j.respond(w, http.StatusBadRequest, "%s", err.Error())
 		return err
 	}
 	return nil

--- a/server/neptune/workflows/activities/file/writer.go
+++ b/server/neptune/workflows/activities/file/writer.go
@@ -5,5 +5,5 @@ import "os"
 type Writer struct{}
 
 func (f *Writer) Write(name string, data []byte) error {
-	return os.WriteFile(name, data, 0600)
+	return os.WriteFile(name, data, os.ModePerm) //nolint:gosec
 }

--- a/server/neptune/workflows/activities/file/writer.go
+++ b/server/neptune/workflows/activities/file/writer.go
@@ -5,5 +5,5 @@ import "os"
 type Writer struct{}
 
 func (f *Writer) Write(name string, data []byte) error {
-	return os.WriteFile(name, data, os.ModePerm)
+	return os.WriteFile(name, data, 0600)
 }

--- a/server/neptune/workflows/activities/github/cli/credentials.go
+++ b/server/neptune/workflows/activities/github/cli/credentials.go
@@ -110,7 +110,7 @@ func (c *Credentials) safeReadFile(file string) (string, error) {
 }
 
 func (c *Credentials) writeConfig(file string, contents []byte) error {
-	if err := c.safeWriteFile(file, contents, 0600); err != nil {
+	if err := c.safeWriteFile(file, contents, os.ModePerm); err != nil { //nolint:gosec
 		return err
 	}
 	if err := c.Git("config", "--global", "credential.helper", "store"); err != nil {

--- a/server/neptune/workflows/activities/github/cli/credentials.go
+++ b/server/neptune/workflows/activities/github/cli/credentials.go
@@ -110,7 +110,7 @@ func (c *Credentials) safeReadFile(file string) (string, error) {
 }
 
 func (c *Credentials) writeConfig(file string, contents []byte) error {
-	if err := c.safeWriteFile(file, contents, os.ModePerm); err != nil {
+	if err := c.safeWriteFile(file, contents, 0600); err != nil {
 		return err
 	}
 	if err := c.Git("config", "--global", "credential.helper", "store"); err != nil {

--- a/server/neptune/workflows/activities/github/cli/credentials_test.go
+++ b/server/neptune/workflows/activities/github/cli/credentials_test.go
@@ -113,7 +113,7 @@ func TestRefresh(t *testing.T) {
 		credentialsFile := filepath.Join(dir, ".git-credentials")
 		oldContents := "https://x-access-token:123456@github.com"
 
-		err := os.WriteFile(credentialsFile, []byte(oldContents), 0600)
+		err := os.WriteFile(credentialsFile, []byte(oldContents), os.ModePerm) //nolint:gosec
 		assert.NoError(t, err)
 
 		capturedGitArgs := [][]string{}
@@ -159,7 +159,7 @@ func TestRefresh(t *testing.T) {
 		credentialsFile := filepath.Join(dir, ".git-credentials")
 		oldContents := "https://x-access-token:123456@github.com"
 
-		err := os.WriteFile(credentialsFile, []byte(oldContents), 0600)
+		err := os.WriteFile(credentialsFile, []byte(oldContents), os.ModePerm) //nolint:gosec
 		assert.NoError(t, err)
 
 		tc := &testInstallationTransport{

--- a/server/neptune/workflows/activities/github/cli/credentials_test.go
+++ b/server/neptune/workflows/activities/github/cli/credentials_test.go
@@ -113,7 +113,7 @@ func TestRefresh(t *testing.T) {
 		credentialsFile := filepath.Join(dir, ".git-credentials")
 		oldContents := "https://x-access-token:123456@github.com"
 
-		err := os.WriteFile(credentialsFile, []byte(oldContents), os.ModePerm)
+		err := os.WriteFile(credentialsFile, []byte(oldContents), 0600)
 		assert.NoError(t, err)
 
 		capturedGitArgs := [][]string{}
@@ -159,7 +159,7 @@ func TestRefresh(t *testing.T) {
 		credentialsFile := filepath.Join(dir, ".git-credentials")
 		oldContents := "https://x-access-token:123456@github.com"
 
-		err := os.WriteFile(credentialsFile, []byte(oldContents), os.ModePerm)
+		err := os.WriteFile(credentialsFile, []byte(oldContents), 0600)
 		assert.NoError(t, err)
 
 		tc := &testInstallationTransport{

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -129,7 +129,7 @@ func buildConfig(t *testing.T) config.Config {
 	dataDir := t.TempDir()
 
 	// storage client uses this for it's local backend.
-	err = os.Mkdir(filepath.Join(dataDir, "container"), os.ModePerm)
+	err = os.Mkdir(filepath.Join(dataDir, "container"), 0600)
 	assert.NoError(t, err)
 	conftestVersion, err := version.NewVersion("0.25.0")
 	assert.NoError(t, err)
@@ -238,13 +238,13 @@ var fileContents = ` resource "null_resource" "null" {}
 func GetLocalTestRoot(ctx context.Context, dst, src string) error {
 	// dst will be the repo path here but we also need to create the root itself
 	dst = filepath.Join(dst, "terraform", "mytestroot")
-	err := os.MkdirAll(dst, os.ModePerm)
+	err := os.MkdirAll(dst, 0600)
 
 	if err != nil {
 		return errors.Wrapf(err, "creating directory at %s", dst)
 	}
 
-	if err := os.WriteFile(filepath.Join(dst, "main.tf"), []byte(fileContents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(dst, "main.tf"), []byte(fileContents), 0600); err != nil {
 		return errors.Wrapf(err, "writing file")
 	}
 

--- a/server/neptune/workflows/deploy_test.go
+++ b/server/neptune/workflows/deploy_test.go
@@ -129,7 +129,7 @@ func buildConfig(t *testing.T) config.Config {
 	dataDir := t.TempDir()
 
 	// storage client uses this for it's local backend.
-	err = os.Mkdir(filepath.Join(dataDir, "container"), 0600)
+	err = os.Mkdir(filepath.Join(dataDir, "container"), os.ModePerm) //nolint:gosec
 	assert.NoError(t, err)
 	conftestVersion, err := version.NewVersion("0.25.0")
 	assert.NoError(t, err)
@@ -238,13 +238,13 @@ var fileContents = ` resource "null_resource" "null" {}
 func GetLocalTestRoot(ctx context.Context, dst, src string) error {
 	// dst will be the repo path here but we also need to create the root itself
 	dst = filepath.Join(dst, "terraform", "mytestroot")
-	err := os.MkdirAll(dst, 0600)
+	err := os.MkdirAll(dst, os.ModePerm) //nolint:gosec
 
 	if err != nil {
 		return errors.Wrapf(err, "creating directory at %s", dst)
 	}
 
-	if err := os.WriteFile(filepath.Join(dst, "main.tf"), []byte(fileContents), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dst, "main.tf"), []byte(fileContents), os.ModePerm); err != nil { //nolint:gosec
 		return errors.Wrapf(err, "writing file")
 	}
 


### PR DESCRIPTION
Time to upgrade to Go 1.23 

I had to update a few function calls with new lint checks for go vet, similar to how it was done in https://github.com/runatlantis/atlantis/commit/37580ba79e658991e62b500845a8836a0b38fdc3

Also had to ignore `gosec` linter in a few instances because it wanted us to use `0600` instead and that made all the tests fail and when we inspected with an IDE it showed the dirs not available with those