### PR TITLE
[DEVCON-2524] output deploy queue to checkrun summary

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,4 +35,4 @@ issues:
         - dogsled
 linters-settings:
   interfacebloat:
-    max: 6
+    max: 7

--- a/server/neptune/workflows/activities/github/revision_url_markdown.go
+++ b/server/neptune/workflows/activities/github/revision_url_markdown.go
@@ -6,3 +6,8 @@ func BuildRevisionURLMarkdown(repoFullName string, revision string) string {
 	// uses Markdown formatting to generate the link on GH
 	return fmt.Sprintf("[%s](https://github.com/%s/commit/%s)", revision, repoFullName, revision)
 }
+
+func BuildRunURLMarkdown(repoFullName string, revision string, runId int64) string {
+	// uses Markdown formatting to generate the link on GH
+	return fmt.Sprintf("[%s](https://github.com/%s/runs/%d)", revision, repoFullName, runId)
+}

--- a/server/neptune/workflows/internal/deploy/lock/lock.go
+++ b/server/neptune/workflows/internal/deploy/lock/lock.go
@@ -1,0 +1,15 @@
+package lock
+
+type LockStatus int
+
+type LockState struct {
+	Revision string
+	Status   LockStatus
+}
+
+const (
+	UnlockedStatus LockStatus = iota
+	LockedStatus
+
+	QueueDepthStat = "queue.depth"
+)

--- a/server/neptune/workflows/internal/deploy/revision/notifier/slack.go
+++ b/server/neptune/workflows/internal/deploy/revision/notifier/slack.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/slack-go/slack"
 	"go.temporal.io/sdk/workflow"
@@ -24,7 +25,7 @@ type Slack struct {
 func (s *Slack) Notify(ctx workflow.Context) error {
 	state := s.DeployQueue.GetLockState()
 
-	if state.Status == queue.UnlockedStatus {
+	if state.Status == lock.UnlockedStatus {
 		return nil
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/notifier/slack_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/notifier/slack_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
@@ -20,7 +21,7 @@ import (
 )
 
 type request struct {
-	LockState    queue.LockState
+	LockState    lock.LockState
 	InitialItems []terraform.DeploymentInfo
 }
 
@@ -51,7 +52,7 @@ func testWorkflow(ctx workflow.Context, request request) error {
 
 func TestNotifier(t *testing.T) {
 	t.Run("empty queue", func(t *testing.T) {
-		state := queue.LockState{Status: queue.UnlockedStatus}
+		state := lock.LockState{Status: lock.UnlockedStatus}
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 
@@ -68,7 +69,7 @@ func TestNotifier(t *testing.T) {
 	})
 
 	t.Run("locked state", func(t *testing.T) {
-		state := queue.LockState{Status: queue.LockedStatus}
+		state := lock.LockState{Status: lock.LockedStatus}
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 
@@ -85,7 +86,7 @@ func TestNotifier(t *testing.T) {
 	})
 
 	t.Run("no slack config", func(t *testing.T) {
-		state := queue.LockState{Status: queue.LockedStatus}
+		state := lock.LockState{Status: lock.LockedStatus}
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 
@@ -121,7 +122,7 @@ func TestNotifier(t *testing.T) {
 	})
 
 	t.Run("activity called", func(t *testing.T) {
-		state := queue.LockState{Status: queue.LockedStatus}
+		state := lock.LockState{Status: lock.LockedStatus}
 		ts := testsuite.WorkflowTestSuite{}
 		env := ts.NewTestWorkflowEnvironment()
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -92,7 +93,8 @@ func (q *Deploy) GetQueuedRevisionsSummary() string {
 		return "No other revisions ahead In queue."
 	}
 	for _, deploy := range q.Scan() {
-		revisions = append(revisions, deploy.Commit.Revision)
+		revisionLink := github.BuildRevisionURLMarkdown(deploy.Repo.GetFullName(), deploy.Commit.Revision)
+		revisions = append(revisions, revisionLink)
 	}
 	return fmt.Sprintf("Revisions in queue: %s", strings.Join(revisions, ", "))
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -7,23 +7,10 @@ import (
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"go.temporal.io/sdk/workflow"
-)
-
-type LockStatus int
-
-type LockState struct {
-	Revision string
-	Status   LockStatus
-}
-
-const (
-	UnlockedStatus LockStatus = iota
-	LockedStatus
-
-	QueueDepthStat = "queue.depth"
 )
 
 type Deploy struct {
@@ -32,7 +19,7 @@ type Deploy struct {
 	scope              metrics.Scope
 
 	// mutable: default is unlocked
-	lock LockState
+	lock lock.LockState
 }
 
 func NewQueue(callback func(workflow.Context, *Deploy), scope metrics.Scope) *Deploy {
@@ -43,12 +30,12 @@ func NewQueue(callback func(workflow.Context, *Deploy), scope metrics.Scope) *De
 	}
 }
 
-func (q *Deploy) GetLockState() LockState {
+func (q *Deploy) GetLockState() lock.LockState {
 	return q.lock
 }
 
-func (q *Deploy) SetLockForMergedItems(ctx workflow.Context, state LockState) {
-	if state.Status == LockedStatus {
+func (q *Deploy) SetLockForMergedItems(ctx workflow.Context, state lock.LockState) {
+	if state.Status == lock.LockedStatus {
 		q.scope.Counter("locked").Inc(1)
 	} else {
 		q.scope.Counter("unlocked").Inc(1)
@@ -58,11 +45,11 @@ func (q *Deploy) SetLockForMergedItems(ctx workflow.Context, state LockState) {
 }
 
 func (q *Deploy) CanPop() bool {
-	return q.queue.HasItemsOfPriority(High) || (q.lock.Status == UnlockedStatus && !q.queue.IsEmpty())
+	return q.queue.HasItemsOfPriority(High) || (q.lock.Status == lock.UnlockedStatus && !q.queue.IsEmpty())
 }
 
 func (q *Deploy) Pop() (terraform.DeploymentInfo, error) {
-	defer q.scope.Gauge(QueueDepthStat).Update(float64(q.queue.Size()))
+	defer q.scope.Gauge(lock.QueueDepthStat).Update(float64(q.queue.Size()))
 	return q.queue.Pop()
 }
 
@@ -79,7 +66,7 @@ func (q *Deploy) IsEmpty() bool {
 }
 
 func (q *Deploy) Push(msg terraform.DeploymentInfo) {
-	defer q.scope.Gauge(QueueDepthStat).Update(float64(q.queue.Size()))
+	defer q.scope.Gauge(lock.QueueDepthStat).Update(float64(q.queue.Size()))
 	if msg.Root.TriggerInfo.Type == activity.ManualTrigger {
 		q.queue.Push(msg, High)
 		return

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"container/list"
 	"fmt"
+	"strings"
 
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
@@ -83,6 +84,17 @@ func (q *Deploy) Push(msg terraform.DeploymentInfo) {
 		return
 	}
 	q.queue.Push(msg, Low)
+}
+
+func (q *Deploy) GetQueuedRevisionsSummary() string {
+	var revisions []string
+	if q.IsEmpty() {
+		return "No other revisions ahead In queue."
+	}
+	for _, deploy := range q.Scan() {
+		revisions = append(revisions, deploy.Commit.Revision)
+	}
+	return fmt.Sprintf("Revisions in queue: %s", strings.Join(revisions, ", "))
 }
 
 // priority is a simple 2 priority queue implementation

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue.go
@@ -90,13 +90,13 @@ func (q *Deploy) Push(msg terraform.DeploymentInfo) {
 func (q *Deploy) GetQueuedRevisionsSummary() string {
 	var revisions []string
 	if q.IsEmpty() {
-		return "No other revisions ahead In queue."
+		return "No other runs ahead in queue."
 	}
 	for _, deploy := range q.Scan() {
-		revisionLink := github.BuildRevisionURLMarkdown(deploy.Repo.GetFullName(), deploy.Commit.Revision)
-		revisions = append(revisions, revisionLink)
+		runLink := github.BuildRunURLMarkdown(deploy.Repo.GetFullName(), deploy.Commit.Revision, deploy.CheckRunID)
+		revisions = append(revisions, runLink)
 	}
-	return fmt.Sprintf("Revisions in queue: %s", strings.Join(revisions, ", "))
+	return fmt.Sprintf("Runs in queue: %s", strings.Join(revisions, ", "))
 }
 
 // priority is a simple 2 priority queue implementation

--- a/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/queue_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -38,8 +39,8 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(func(ctx workflow.Context, d *queue.Deploy) {
 			called = true
 		}, metrics.NewNullableScope())
-		q.SetLockForMergedItems(test.Background(), queue.LockState{
-			Status: queue.LockedStatus,
+		q.SetLockForMergedItems(test.Background(), lock.LockState{
+			Status: lock.LockedStatus,
 		})
 
 		assert.True(t, called)
@@ -52,8 +53,8 @@ func TestQueue(t *testing.T) {
 
 	t.Run("can pop empty queue locked", func(t *testing.T) {
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
-		q.SetLockForMergedItems(test.Background(), queue.LockState{
-			Status: queue.LockedStatus,
+		q.SetLockForMergedItems(test.Background(), lock.LockState{
+			Status: lock.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())
 	})
@@ -61,8 +62,8 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
 		msg1 := wrap("1", activity.ManualTrigger)
 		q.Push(msg1)
-		q.SetLockForMergedItems(test.Background(), queue.LockState{
-			Status: queue.LockedStatus,
+		q.SetLockForMergedItems(test.Background(), lock.LockState{
+			Status: lock.LockedStatus,
 		})
 		assert.Equal(t, true, q.CanPop())
 	})
@@ -76,8 +77,8 @@ func TestQueue(t *testing.T) {
 		q := queue.NewQueue(noopCallback, metrics.NewNullableScope())
 		msg1 := wrap("1", activity.MergeTrigger)
 		q.Push(msg1)
-		q.SetLockForMergedItems(test.Background(), queue.LockState{
-			Status: queue.LockedStatus,
+		q.SetLockForMergedItems(test.Background(), lock.LockState{
+			Status: lock.LockedStatus,
 		})
 		assert.Equal(t, false, q.CanPop())
 	})

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+
 	key "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
@@ -24,12 +25,13 @@ func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *De
 
 	var actions []github.CheckRunAction
 	var summary string
+	var revisionsSummary string = queue.GetQueuedRevisionsSummary()
 	state := github.CheckRunQueued
 	if lock.Status == LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
 		revisionLink := github.BuildRevisionURLMarkdown(repoFullName, lock.Revision)
-		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.", revisionLink)
+		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.\n%s", revisionLink, revisionsSummary)
 	}
 
 	for _, i := range infos {

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater.go
@@ -7,6 +7,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -20,17 +21,17 @@ type LockStateUpdater struct {
 }
 
 func (u *LockStateUpdater) UpdateQueuedRevisions(ctx workflow.Context, queue *Deploy, repoFullName string) {
-	lock := queue.GetLockState()
+	queueLock := queue.GetLockState()
 	infos := queue.GetOrderedMergedItems()
 
 	var actions []github.CheckRunAction
 	var summary string
 	var revisionsSummary string = queue.GetQueuedRevisionsSummary()
 	state := github.CheckRunQueued
-	if lock.Status == LockedStatus {
+	if queueLock.Status == lock.LockedStatus {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		revisionLink := github.BuildRevisionURLMarkdown(repoFullName, lock.Revision)
+		revisionLink := github.BuildRevisionURLMarkdown(repoFullName, queueLock.Revision)
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.\n%s", revisionLink, revisionsSummary)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -1,9 +1,10 @@
 package queue_test
 
 import (
-	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"testing"
 	"time"
+
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
@@ -14,6 +15,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -25,9 +27,13 @@ type testCheckRunClient struct {
 }
 
 func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error) {
-	assert.Equal(t.expectedT, t.expectedRequest, request)
-	assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID)
+	switch {
+	case assert.Equal(t.expectedT, t.expectedRequest, request):
 
+	case assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID):
+	default:
+		return 1, temporal.NewApplicationError("failing workflow", "myType")
+	}
 	return 1, nil
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -32,7 +31,7 @@ func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID s
 
 	case assert.Equal(t.expectedT, t.expectedDeploymentID, deploymentID):
 	default:
-		return 1, temporal.NewApplicationError("failing workflow", "myType")
+		t.expectedT.FailNow()
 	}
 	return 1, nil
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/updater_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	tfActivity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -126,8 +127,8 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 
 	env.ExecuteWorkflow(testUpdaterWorkflow, updaterReq{
 		Queue: []terraform.DeploymentInfo{info},
-		Lock: queue.LockState{
-			Status:   queue.LockedStatus,
+		Lock: lock.LockState{
+			Status:   lock.LockedStatus,
 			Revision: "1234",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
@@ -152,7 +153,7 @@ func TestLockStateUpdater_locked_new_version(t *testing.T) {
 
 type updaterReq struct {
 	Queue                []terraform.DeploymentInfo
-	Lock                 queue.LockState
+	Lock                 lock.LockState
 	ExpectedRequest      notifier.GithubCheckRunRequest
 	ExpectedDeploymentID string
 	ExpectedT            *testing.T

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -13,6 +13,7 @@ import (
 	internalContext "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	tfModel "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
@@ -24,9 +25,10 @@ type queue interface {
 	IsEmpty() bool
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)
-	SetLockForMergedItems(ctx workflow.Context, state LockState)
+	SetLockForMergedItems(ctx workflow.Context, state lock.LockState)
 	GetOrderedMergedItems() []terraform.DeploymentInfo
 	GetQueuedRevisionsSummary() string
+	GetLockState() lock.LockState
 }
 
 type deployer interface {
@@ -114,8 +116,8 @@ func NewWorker(
 	// we don't persist lock state anywhere so in the case of workflow completion we need to rebuild
 	// the lock state
 	if latestDeployment != nil && latestDeployment.Root.Trigger == string(tfModel.ManualTrigger) {
-		q.SetLockForMergedItems(ctx, LockState{
-			Status:   LockedStatus,
+		q.SetLockForMergedItems(ctx, lock.LockState{
+			Status:   lock.LockedStatus,
 			Revision: latestDeployment.Revision,
 		})
 	}
@@ -181,8 +183,8 @@ func (w *Worker) Work(ctx workflow.Context) {
 			workflow.GetMetricsHandler(ctx).WithTags(map[string]string{metricNames.SignalNameTag: UnlockSignalName}).
 				Counter(metricNames.SignalReceive).
 				Inc(1)
-			w.Queue.SetLockForMergedItems(ctx, LockState{
-				Status: UnlockedStatus,
+			w.Queue.SetLockForMergedItems(ctx, lock.LockState{
+				Status: lock.UnlockedStatus,
 			})
 			continue
 		default:

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -25,6 +25,7 @@ type queue interface {
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)
 	SetLockForMergedItems(ctx workflow.Context, state LockState)
+	GetQueuedRevisionsSummary() string
 }
 
 type deployer interface {
@@ -96,7 +97,7 @@ func NewWorker(
 		},
 	}
 
-	tfWorkflowRunner := terraform.NewWorkflowRunner(tfWorkflow, notifiers, additionalNotifiers...)
+	tfWorkflowRunner := terraform.NewWorkflowRunner(q, tfWorkflow, notifiers, additionalNotifiers...)
 	deployer := &Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker.go
@@ -25,6 +25,7 @@ type queue interface {
 	CanPop() bool
 	Pop() (terraform.DeploymentInfo, error)
 	SetLockForMergedItems(ctx workflow.Context, state LockState)
+	GetOrderedMergedItems() []terraform.DeploymentInfo
 	GetQueuedRevisionsSummary() string
 }
 
@@ -97,7 +98,7 @@ func NewWorker(
 		},
 	}
 
-	tfWorkflowRunner := terraform.NewWorkflowRunner(q, tfWorkflow, notifiers, additionalNotifiers...)
+	tfWorkflowRunner := terraform.NewWorkflowRunner(q, tfWorkflow, githubCheckRunCache, notifiers, additionalNotifiers...)
 	deployer := &Deployer{
 		Activities:              a,
 		TerraformWorkflowRunner: tfWorkflowRunner,

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_state_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_state_test.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -47,7 +48,7 @@ func testStateWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, e
 		Queue: list.New(),
 	}
 
-	q.SetLockForMergedItems(ctx, queue.LockState{Status: r.InitialLockStatus})
+	q.SetLockForMergedItems(ctx, lock.LockState{Status: r.InitialLockStatus})
 
 	workflow.Go(ctx, func(ctx workflow.Context) {
 		ch := workflow.GetSignalChannel(ctx, "add-to-queue")
@@ -109,8 +110,8 @@ func TestWorker_StartsWithEmptyQueue(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.LockState{
-			Status: queue.UnlockedStatus,
+		assert.Equal(t, lock.LockState{
+			Status: lock.UnlockedStatus,
 		}, q.Lock)
 		assert.Equal(t, queue.WaitingWorkerState, q.State)
 	}, 2*time.Second)
@@ -145,8 +146,8 @@ func TestWorker_StartsWithEmptyQueue(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.LockState{
-			Status: queue.UnlockedStatus,
+		assert.Equal(t, lock.LockState{
+			Status: lock.UnlockedStatus,
 		}, q.Lock)
 		assert.Equal(t, queue.WorkingWorkerState, q.State)
 	}, 6*time.Second)

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -51,6 +51,10 @@ func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.Lock
 	q.Lock = state
 }
 
+func (q *testQueue) GetQueuedRevisionsSummary() string {
+	return "Revisions in queue"
+}
+
 type workerRequest struct {
 	Queue                         []internalTerraform.DeploymentInfo
 	ExpectedValidationErrors      []*queue.ValidationError

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -47,6 +47,14 @@ func (q *testQueue) Push(msg internalTerraform.DeploymentInfo) {
 	q.Queue.PushBack(msg)
 }
 
+func (q *testQueue) GetOrderedMergedItems() []internalTerraform.DeploymentInfo {
+	var result []internalTerraform.DeploymentInfo
+	for e := q.Queue.Front(); e != nil; e = e.Next() {
+		result = append(result, e.Value.(internalTerraform.DeploymentInfo))
+	}
+	return result
+}
+
 func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.LockState) {
 	q.Lock = state
 }

--- a/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/queue/worker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/deployment"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
@@ -25,7 +26,7 @@ import (
 
 type testQueue struct {
 	Queue *list.List
-	Lock  queue.LockState
+	Lock  lock.LockState
 }
 
 func (q *testQueue) IsEmpty() bool {
@@ -55,8 +56,12 @@ func (q *testQueue) GetOrderedMergedItems() []internalTerraform.DeploymentInfo {
 	return result
 }
 
-func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.LockState) {
+func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state lock.LockState) {
 	q.Lock = state
+}
+
+func (q *testQueue) GetLockState() lock.LockState {
+	return q.Lock
 }
 
 func (q *testQueue) GetQueuedRevisionsSummary() string {
@@ -68,7 +73,7 @@ type workerRequest struct {
 	ExpectedValidationErrors      []*queue.ValidationError
 	ExpectedPlanRejectionErrros   []*internalTerraform.PlanRejectionError
 	ExpectedTerraformClientErrors []*activities.TerraformClientError
-	InitialLockStatus             queue.LockStatus
+	InitialLockStatus             lock.LockStatus
 }
 
 type workerResponse struct {
@@ -80,7 +85,7 @@ type workerResponse struct {
 type queueAndState struct {
 	QueueIsEmpty      bool
 	State             queue.WorkerState
-	Lock              queue.LockState
+	Lock              lock.LockState
 	CurrentDeployment queue.CurrentDeployment
 	LatestDeployment  *deployment.Info
 }
@@ -125,7 +130,7 @@ func testWorkerWorkflow(ctx workflow.Context, r workerRequest) (workerResponse, 
 		Queue: list.New(),
 	}
 
-	q.SetLockForMergedItems(ctx, queue.LockState{Status: r.InitialLockStatus})
+	q.SetLockForMergedItems(ctx, lock.LockState{Status: r.InitialLockStatus})
 
 	var infos []*deployment.Info
 	for _, s := range r.Queue {
@@ -191,8 +196,8 @@ func TestWorker_ReceivesUnlockSignal(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, q.QueueIsEmpty)
-		assert.Equal(t, queue.LockState{
-			Status: queue.UnlockedStatus,
+		assert.Equal(t, lock.LockState{
+			Status: lock.UnlockedStatus,
 		}, q.Lock)
 		assert.Equal(t, queue.WaitingWorkerState, q.State)
 
@@ -201,7 +206,7 @@ func TestWorker_ReceivesUnlockSignal(t *testing.T) {
 
 	env.ExecuteWorkflow(testWorkerWorkflow, workerRequest{
 		// start locked and ensure we can unlock it.
-		InitialLockStatus: queue.LockedStatus,
+		InitialLockStatus: lock.LockedStatus,
 	})
 
 	env.AssertExpectations(t)
@@ -400,7 +405,7 @@ func TestNewWorker(t *testing.T) {
 	}
 
 	type res struct {
-		Lock queue.LockState
+		Lock lock.LockState
 	}
 
 	testWorkflow := func(ctx workflow.Context) (res, error) {
@@ -444,9 +449,9 @@ func TestNewWorker(t *testing.T) {
 		err := env.GetWorkflowResult(&r)
 		assert.NoError(t, err)
 
-		assert.Equal(t, queue.LockState{
+		assert.Equal(t, lock.LockState{
 			Revision: "1234",
-			Status:   queue.LockedStatus,
+			Status:   lock.LockedStatus,
 		}, r.Lock)
 	})
 
@@ -475,7 +480,7 @@ func TestNewWorker(t *testing.T) {
 		err := env.GetWorkflowResult(&r)
 		assert.NoError(t, err)
 
-		assert.Equal(t, queue.LockState{}, r.Lock)
+		assert.Equal(t, lock.LockState{}, r.Lock)
 	})
 
 	t.Run("first deploy", func(t *testing.T) {
@@ -497,7 +502,7 @@ func TestNewWorker(t *testing.T) {
 		err := env.GetWorkflowResult(&r)
 		assert.NoError(t, err)
 
-		assert.Equal(t, queue.LockState{}, r.Lock)
+		assert.Equal(t, lock.LockState{}, r.Lock)
 	})
 }
 

--- a/server/neptune/workflows/internal/deploy/revision/revision.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision.go
@@ -13,6 +13,7 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	activity "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request/converter"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
@@ -43,8 +44,8 @@ type NewRevisionRequest struct {
 
 type Queue interface {
 	Push(terraform.DeploymentInfo)
-	GetLockState() queue.LockState
-	SetLockForMergedItems(ctx workflow.Context, state queue.LockState)
+	GetLockState() lock.LockState
+	SetLockForMergedItems(ctx workflow.Context, state lock.LockState)
 	Scan() []terraform.DeploymentInfo
 	GetQueuedRevisionsSummary() string
 }
@@ -115,8 +116,8 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 	// lock the queue on a manual deployment
 	if root.TriggerInfo.Type == activity.ManualTrigger {
 		// Lock the queue on a manual deployment
-		n.queue.SetLockForMergedItems(ctx, queue.LockState{
-			Status:   queue.LockedStatus,
+		n.queue.SetLockForMergedItems(ctx, lock.LockState{
+			Status:   lock.LockedStatus,
 			Revision: request.Revision,
 		})
 	}
@@ -135,16 +136,16 @@ func (n *Receiver) Receive(c workflow.ReceiveChannel, more bool) {
 }
 
 func (n *Receiver) createCheckRun(ctx workflow.Context, id, revision string, root activity.Root, repo github.Repo) int64 {
-	lock := n.queue.GetLockState()
+	queueLock := n.queue.GetLockState()
 	var actions []github.CheckRunAction
 	var revisionsSummary string = n.queue.GetQueuedRevisionsSummary()
 	summary := "This deploy is queued and will be processed as soon as possible.\n" + revisionsSummary
 	state := github.CheckRunQueued
 
-	if lock.Status == queue.LockedStatus && (root.TriggerInfo.Type == activity.MergeTrigger) {
+	if queueLock.Status == lock.LockedStatus && (root.TriggerInfo.Type == activity.MergeTrigger) {
 		actions = append(actions, github.CreateUnlockAction())
 		state = github.CheckRunActionRequired
-		revisionLink := github.BuildRevisionURLMarkdown(repo.GetFullName(), lock.Revision)
+		revisionLink := github.BuildRevisionURLMarkdown(repo.GetFullName(), queueLock.Revision)
 		summary = fmt.Sprintf("This deploy is locked from a manual deployment for revision %s.  Unlock to proceed.\n%s", revisionLink, revisionsSummary)
 	}
 

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
 	terraformWorkflow "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/stretchr/testify/assert"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
@@ -29,8 +28,7 @@ type testCheckRunClient struct {
 func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error) {
 	ok := assert.Equal(t.expectedT, t.expectedRequest, request)
 	if !ok {
-		return 1, temporal.NewApplicationError("failing workflow", "myType")
-		// t.expectedT.Exit("CreateOrUpdate had unexpected request")
+		t.expectedT.FailNow()
 	}
 	return 1, nil
 }
@@ -57,7 +55,7 @@ func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.Lock
 }
 
 func (q *testQueue) IsEmpty() bool {
-	return q.Queue == nil || len(q.Queue) == 0
+	return len(q.Queue) == 0
 }
 
 func (q *testQueue) GetQueuedRevisionsSummary() string {
@@ -371,7 +369,7 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Title:   "atlantis/deploy: root",
 			Sha:     rev,
 			Repo:    github.Repo{Name: "nish"},
-			Summary: "This deploy is locked from a manual deployment for revision [123334444555](https://github.com//nish/commit/123334444555).  Unlock to proceed.\nRevisions in queue: 12333444455",
+			Summary: "This deploy is locked from a manual deployment for revision [123334444555](https://github.com//nish/commit/123334444555).  Unlock to proceed.\nRevisions in queue: 123334444555",
 			Actions: []github.CheckRunAction{github.CreateUnlockAction()},
 			State:   github.CheckRunActionRequired,
 		},

--- a/server/neptune/workflows/internal/deploy/revision/revision_test.go
+++ b/server/neptune/workflows/internal/deploy/revision/revision_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/request"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/revision/queue"
@@ -35,7 +36,7 @@ func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID s
 
 type testQueue struct {
 	Queue []terraformWorkflow.DeploymentInfo
-	Lock  queue.LockState
+	Lock  lock.LockState
 }
 
 func (q *testQueue) Scan() []terraformWorkflow.DeploymentInfo {
@@ -46,11 +47,11 @@ func (q *testQueue) Push(msg terraformWorkflow.DeploymentInfo) {
 	q.Queue = append(q.Queue, msg)
 }
 
-func (q *testQueue) GetLockState() queue.LockState {
+func (q *testQueue) GetLockState() lock.LockState {
 	return q.Lock
 }
 
-func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state queue.LockState) {
+func (q *testQueue) SetLockForMergedItems(ctx workflow.Context, state lock.LockState) {
 	q.Lock = state
 }
 
@@ -79,7 +80,7 @@ func (t testWorker) GetCurrentDeploymentState() queue.CurrentDeployment {
 
 type req struct {
 	ID              uuid.UUID
-	Lock            queue.LockState
+	Lock            lock.LockState
 	Current         queue.CurrentDeployment
 	InitialElements []terraformWorkflow.DeploymentInfo
 	ExpectedRequest notifier.GithubCheckRunRequest
@@ -88,7 +89,7 @@ type req struct {
 
 type response struct {
 	Queue   []terraformWorkflow.DeploymentInfo
-	Lock    queue.LockState
+	Lock    lock.LockState
 	Timeout bool
 }
 
@@ -186,8 +187,8 @@ func TestEnqueue(t *testing.T) {
 			Repo: github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.LockState{
-		Status: queue.UnlockedStatus,
+	assert.Equal(t, lock.LockState{
+		Status: lock.UnlockedStatus,
 	}, resp.Lock)
 	assert.False(t, resp.Timeout)
 }
@@ -247,8 +248,8 @@ func TestEnqueue_ManualTrigger(t *testing.T) {
 			Repo: github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.LockState{
-		Status:   queue.LockedStatus,
+	assert.Equal(t, lock.LockState{
+		Status:   lock.LockedStatus,
 		Revision: "1234",
 	}, resp.Lock)
 	assert.False(t, resp.Timeout)
@@ -279,9 +280,9 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID: id,
-		Lock: queue.LockState{
+		Lock: lock.LockState{
 			// ensure that the lock gets updated
-			Status:   queue.LockedStatus,
+			Status:   lock.LockedStatus,
 			Revision: "123334444555",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
@@ -314,8 +315,8 @@ func TestEnqueue_ManualTrigger_QueueAlreadyLocked(t *testing.T) {
 			Repo: github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.LockState{
-		Status:   queue.LockedStatus,
+	assert.Equal(t, lock.LockState{
+		Status:   lock.LockedStatus,
 		Revision: "1234",
 	}, resp.Lock)
 	assert.False(t, resp.Timeout)
@@ -360,9 +361,9 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 	env.ExecuteWorkflow(testWorkflow, req{
 		ID:              id,
 		InitialElements: []terraformWorkflow.DeploymentInfo{deploymentInfo},
-		Lock: queue.LockState{
+		Lock: lock.LockState{
 			// ensure that the lock gets updated
-			Status:   queue.LockedStatus,
+			Status:   lock.LockedStatus,
 			Revision: "123334444555",
 		},
 		ExpectedRequest: notifier.GithubCheckRunRequest{
@@ -397,8 +398,8 @@ func TestEnqueue_MergeTrigger_QueueAlreadyLocked(t *testing.T) {
 			Repo: github.Repo{Name: "nish"},
 		},
 	}, resp.Queue)
-	assert.Equal(t, queue.LockState{
-		Status:   queue.LockedStatus,
+	assert.Equal(t, lock.LockState{
+		Status:   lock.LockedStatus,
 		Revision: "123334444555",
 	}, resp.Lock)
 	assert.False(t, resp.Timeout)

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -33,10 +33,21 @@ type stateReceiver interface {
 	Receive(ctx workflow.Context, c workflow.ReceiveChannel, deploymentInfo DeploymentInfo)
 }
 
-func NewWorkflowRunner(w Workflow, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {
+type deployQueue interface {
+	// IsEmpty() bool
+	// CanPop() bool
+	// Pop() (DeploymentInfo, error)
+	// Scan() []DeploymentInfo
+	// GetLockState() queue.LockState
+	// SetLockForMergedItems(ctx workflow.Context, state queue.LockState)
+	GetQueuedRevisionsSummary() string
+}
+
+func NewWorkflowRunner(queue deployQueue, w Workflow, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {
 	return &WorkflowRunner{
 		Workflow: w,
 		StateReceiver: &StateReceiver{
+			Queue:               queue,
 			InternalNotifiers:   internalNotifiers,
 			AdditionalNotifiers: additionalNotifiers,
 		},

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -34,20 +34,16 @@ type stateReceiver interface {
 }
 
 type deployQueue interface {
-	// IsEmpty() bool
-	// CanPop() bool
-	// Pop() (DeploymentInfo, error)
-	// Scan() []DeploymentInfo
-	// GetLockState() queue.LockState
-	// SetLockForMergedItems(ctx workflow.Context, state queue.LockState)
+	GetOrderedMergedItems() []DeploymentInfo
 	GetQueuedRevisionsSummary() string
 }
 
-func NewWorkflowRunner(queue deployQueue, w Workflow, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {
+func NewWorkflowRunner(queue deployQueue, w Workflow, githubCheckRunCache CheckRunClient, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {
 	return &WorkflowRunner{
 		Workflow: w,
 		StateReceiver: &StateReceiver{
 			Queue:               queue,
+			CheckRunCache:       githubCheckRunCache,
 			InternalNotifiers:   internalNotifiers,
 			AdditionalNotifiers: additionalNotifiers,
 		},

--- a/server/neptune/workflows/internal/deploy/terraform/runner.go
+++ b/server/neptune/workflows/internal/deploy/terraform/runner.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"github.com/pkg/errors"
 	terraformActivities "github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/metrics"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
@@ -36,6 +37,7 @@ type stateReceiver interface {
 type deployQueue interface {
 	GetOrderedMergedItems() []DeploymentInfo
 	GetQueuedRevisionsSummary() string
+	GetLockState() lock.LockState
 }
 
 func NewWorkflowRunner(queue deployQueue, w Workflow, githubCheckRunCache CheckRunClient, internalNotifiers []WorkflowNotifier, additionalNotifiers ...plugins.TerraformWorkflowNotifier) *WorkflowRunner {

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -1,10 +1,12 @@
 package terraform
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/runatlantis/atlantis/server/metrics"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/notifier"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
@@ -15,11 +17,16 @@ type WorkflowNotifier interface {
 	Notify(workflow.Context, notifier.Info, *state.Workflow) error
 }
 
+type CheckRunClient interface {
+	CreateOrUpdate(ctx workflow.Context, deploymentID string, request notifier.GithubCheckRunRequest) (int64, error)
+}
+
 type StateReceiver struct {
 
 	// We have separate classes of notifiers since we can be more flexible with our internal ones in terms of the data model
 	// What we support externally should be well thought out so for now this is kept to a minimum.
 	Queue               deployQueue
+	CheckRunCache       CheckRunClient
 	InternalNotifiers   []WorkflowNotifier
 	AdditionalNotifiers []plugins.TerraformWorkflowNotifier
 }
@@ -41,8 +48,31 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 		}
 	}
 
-	if workflowState.Apply.Status == state.WaitingJobStatus && reflect.ValueOf(workflowState.Apply.OnWaitingActions).IsZero() {
-		// lock the queue item
+	if workflowState.Apply.Status == state.WaitingJobStatus && !reflect.ValueOf(workflowState.Apply.OnWaitingActions).IsZero() {
+		// update queue with information about current deployment pending confirm/reject action
+		infos := n.Queue.GetOrderedMergedItems()
+
+		revisionsSummary := n.Queue.GetQueuedRevisionsSummary()
+		state := github.CheckRunQueued
+		revisionLink := github.BuildRevisionURLMarkdown(deploymentInfo.Repo.GetFullName(), deploymentInfo.Commit.Revision)
+		summary := fmt.Sprintf("This deploy is queued pending action on revision %s.\n%s", revisionLink, revisionsSummary)
+
+		for _, i := range infos {
+			request := notifier.GithubCheckRunRequest{
+				Title:   notifier.BuildDeployCheckRunTitle(i.Root.Name),
+				Sha:     i.Commit.Revision,
+				State:   state,
+				Repo:    i.Repo,
+				Summary: summary,
+			}
+
+			workflow.GetLogger(ctx).Debug(fmt.Sprintf("Updating action pending summary for deployment id: %s", i.ID.String()))
+			_, err := n.CheckRunCache.CreateOrUpdate(ctx, i.ID.String(), request)
+
+			if err != nil {
+				workflow.GetLogger(ctx).Debug(fmt.Sprintf("updating check run for revision %s", i.Commit.Revision), err)
+			}
+		}
 	}
 
 	for _, notifier := range n.InternalNotifiers {

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -56,8 +56,8 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 
 		revisionsSummary := n.Queue.GetQueuedRevisionsSummary()
 		state := github.CheckRunQueued
-		revisionLink := github.BuildRevisionURLMarkdown(deploymentInfo.Repo.GetFullName(), deploymentInfo.Commit.Revision)
-		summary := fmt.Sprintf("This deploy is queued pending action on revision %s.\n%s", revisionLink, revisionsSummary)
+		runLink := github.BuildRunURLMarkdown(deploymentInfo.Repo.GetFullName(), deploymentInfo.Commit.Revision, deploymentInfo.CheckRunID)
+		summary := fmt.Sprintf("This deploy is queued pending action on run for revision %s.\n%s", runLink, revisionsSummary)
 
 		for _, i := range infos {
 			request := notifier.GithubCheckRunRequest{

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -48,7 +48,9 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 		}
 	}
 
-	if workflowState.Apply.Status == state.WaitingJobStatus && !reflect.ValueOf(workflowState.Apply.OnWaitingActions).IsZero() {
+	if workflowState.Apply != nil &&
+		workflowState.Apply.Status == state.WaitingJobStatus &&
+		!reflect.ValueOf(workflowState.Apply.OnWaitingActions).IsZero() {
 		// update queue with information about current deployment pending confirm/reject action
 		infos := n.Queue.GetOrderedMergedItems()
 

--- a/server/neptune/workflows/internal/deploy/terraform/state.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state.go
@@ -49,6 +49,7 @@ func (n *StateReceiver) Receive(ctx workflow.Context, c workflow.ReceiveChannel,
 		}
 	}
 	// Updates github check run with Terraform statuses for the current running deployment
+	// TODO: do not notify github if workflowState.Result.Status == InProgressWorkflowStatus && workflowState.Result.Reason == UnknownCompletionReason
 	for _, notifier := range n.InternalNotifiers {
 		if err := notifier.Notify(ctx, deploymentInfo.ToInternalInfo(), workflowState); err != nil {
 			workflow.GetMetricsHandler(ctx).Counter("notifier_failure").Inc(1)

--- a/server/neptune/workflows/internal/deploy/terraform/state_test.go
+++ b/server/neptune/workflows/internal/deploy/terraform/state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/github"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/terraform"
+	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/lock"
 	internalTerraform "github.com/runatlantis/atlantis/server/neptune/workflows/internal/deploy/terraform"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/internal/terraform/state"
 	"github.com/runatlantis/atlantis/server/neptune/workflows/plugins"
@@ -63,6 +64,11 @@ func (t *testCheckRunClient) CreateOrUpdate(ctx workflow.Context, deploymentID s
 
 type testQueue struct {
 	Queue []internalTerraform.DeploymentInfo
+	Lock  lock.LockState
+}
+
+func (q *testQueue) GetLockState() lock.LockState {
+	return q.Lock
 }
 
 func (q *testQueue) GetQueuedRevisionsSummary() string {


### PR DESCRIPTION
### Issue:
Previously, when a revision is queued, we mark the github status as queued but have no other indication in the check run itself that this check run is waiting on something.
Users have to figure out which check run is holding up the queue which is difficult because deploys for a root can happen off any branch. We can figure this out using the temporal UI however it would be a better CX if we could just surface the queue itself in the check run.

### Part 1
Add queue info to checkrun summary on creating new check run or unlock signal. Queue info is shown as [commit SHA](link to specific check run)

<img width="1224" alt="Screenshot 2024-10-31 at 1 23 43 PM" src="https://github.com/user-attachments/assets/7e6e176c-4c7f-4858-bd6f-41d29b743e6e">


### Part 2
Check run summaries do not get updated in cases where a a Terraform workflow is pending Confirm/Reject checkrun action between Plan and Apply steps, since the deploy queue lock only tracks the "Unlock" checkrun action.
* Surfaces deploy queue from queue package to deploy/terraform package. Some complication using Queue structs here due to cyclic dependencies between the two packages.
* To avoid restructuring the two packages, instead we will pass the GithubCheckRunCache (github package) over from queue worker to deploy/terraform workflow.
* StateReceiver will use GithubCheckRunCache to update checkrun summaries for each revision on the queue when a Confirm/Reject action is pending.

<img width="1044" alt="Screenshot 2024-11-04 at 12 46 37 PM" src="https://github.com/user-attachments/assets/508e9376-8362-46cd-80c9-653a218ddcf4">

### Test Plan

1. Recreating Unlock action: open 2 PRs, run `atlantis apply -f` on PR 1, and try to merge PR 2. PR 2 will be locked by confirm reject action on PR 1. Any subsequent queued deploys will show up as queued commits (with corresponding links) in checkrun summary.
2. Recreating diverged confirm/reject action: run `atlantis apply -f` on unmerged PR 1 and confirm. Create PR 3 and run `atlantis apply -f` on unmerged PR 3.
3. Merged PR 1 deploy will update to to show pending action on PR 3. Links will go directly to the specific run instead of just the commit in case there were multiple forced applies on PR 1.

### Improve Test Cases
Fix queue_test and updater_test where assertions in CreateOrUpdate were not getting caught since the function is called within a temporal worker.