### PR TITLE
Disconnected context cancel

### DIFF
--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -347,7 +347,6 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 		return Response{}, r.toExternalError(err, "fetching root")
 	}
 
-	// Create disconnected context for cleanup outside defer to prevent non-determinism
 	var cleanupCtx workflow.Context
 	version := workflow.GetVersion(ctx, "DisconnectedCleanupContext", workflow.DefaultVersion, workflow.Version(1))
 	if version != workflow.DefaultVersion {

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -349,7 +349,7 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 
 	// Create disconnected context for cleanup outside defer to prevent non-determinism
 	var cleanupCtx workflow.Context
-	version := workflow.GetVersion(ctx, "DisconnectedCleanupContext", workflow.DefaultVersion, 1)
+	version := workflow.GetVersion(ctx, "DisconnectedCleanupContext", workflow.DefaultVersion, workflow.Version(1))
 	if version != workflow.DefaultVersion {
 		cleanupCtx, _ = workflow.NewDisconnectedContext(ctx)
 	} else {


### PR DESCRIPTION
We want cleanup to run always, so why not pass in a disconnected context?

This in theory should prevent a potential race in case cancel was issues at the same timing the Cleanup activity is executed.  