### PR TITLE
Add Terraform Workflow Execution Metrics

### DIFF
--- a/server/metrics/common.go
+++ b/server/metrics/common.go
@@ -47,6 +47,7 @@ const (
 
 	// Terraform workflow execution metrics
 	TerraformWorkflowExecution = "terraform.workflow.execution"
+	TerraformWorkflowDuration  = "terraform.workflow.duration"
 	WorkflowType               = "workflow_type" // PR, Deploy, Adhoc
 	WorkflowStatus             = "status"        // success, failure
 	WorkflowRepo               = "repository"

--- a/server/metrics/common.go
+++ b/server/metrics/common.go
@@ -47,9 +47,9 @@ const (
 
 	// Terraform workflow execution metrics
 	TerraformWorkflowExecution = "terraform.workflow.execution"
-	WorkflowType              = "workflow_type"    // PR, Deploy, Adhoc
-	WorkflowStatus            = "status"           // success, failure
-	WorkflowRepo              = "repository"
-	WorkflowPRNum             = "pr_number"
-	WorkflowRoot              = "root_name"
+	WorkflowType               = "workflow_type" // PR, Deploy, Adhoc
+	WorkflowStatus             = "status"        // success, failure
+	WorkflowRepo               = "repository"
+	WorkflowPRNum              = "pr_number"
+	WorkflowRoot               = "root_name"
 )

--- a/server/metrics/common.go
+++ b/server/metrics/common.go
@@ -44,4 +44,12 @@ const (
 
 	ManualOverride          = "manual_override"
 	ManualOverrideReasonTag = "reason"
+
+	// Terraform workflow execution metrics
+	TerraformWorkflowExecution = "terraform.workflow.execution"
+	WorkflowType              = "workflow_type"    // PR, Deploy, Adhoc
+	WorkflowStatus            = "status"           // success, failure
+	WorkflowRepo              = "repository"
+	WorkflowPRNum             = "pr_number"
+	WorkflowRoot              = "root_name"
 )

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -359,7 +359,7 @@ func (r *Runner) run(ctx workflow.Context) (Response, error) {
 
 	defer func() {
 		// Record execution time
-		taggedHandler.Timer("workflow.duration").Record(time.Since(startTime))
+		taggedHandler.Timer(metrics.TerraformWorkflowDuration).Record(time.Since(startTime))
 	}()
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{

--- a/server/neptune/workflows/internal/terraform/workflow.go
+++ b/server/neptune/workflows/internal/terraform/workflow.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/runatlantis/atlantis/server/neptune/workflows/activities/conftest"
 
-	key "github.com/runatlantis/atlantis/server/neptune/context"
 	"github.com/runatlantis/atlantis/server/metrics"
+	key "github.com/runatlantis/atlantis/server/neptune/context"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
 


### PR DESCRIPTION
**Summary**
This PR improves on Terraform workflow observability by adding two key metrics to the workflow runner:

- `terraform.workflow.execution `– Counts workflow executions, tagged by type, repo, and root.
- `workflow.duration` – Measures total execution time with the same tagging for correlation.

These metrics fill critical gaps in our observability stack by enabling:

- Execution tracking across teams/repos
- Full workflow performance measurement
- Usage attribution and capacity planning
