### PR TITLE
Fix: Use underscores in terraform workflow metric names for M3 compatibility

### DIFF
--- a/server/metrics/common.go
+++ b/server/metrics/common.go
@@ -46,8 +46,8 @@ const (
 	ManualOverrideReasonTag = "reason"
 
 	// Terraform workflow execution metrics
-	TerraformWorkflowExecution = "terraform.workflow.execution"
-	TerraformWorkflowDuration  = "terraform.workflow.duration"
+	TerraformWorkflowExecution = "terraform_workflow_execution"
+	TerraformWorkflowDuration  = "terraform_workflow_duration"
 	WorkflowType               = "workflow_type" // PR, Deploy, Adhoc
 	WorkflowStatus             = "status"        // success, failure
 	WorkflowRepo               = "repository"


### PR DESCRIPTION
**Problem**
Terraform workflow metrics used dots (terraform.workflow.execution) which don't appear correctly in M3 queries.

**Solution**
Changed metric names to use underscores to match codebase convention:
terraform.workflow.execution → terraform_workflow_execution
terraform.workflow.duration → terraform_workflow_duration