### PR TITLE
Fix cleanup context and add logging

### DIFF
--- a/server/neptune/workflows/internal/terraform/root_fetcher.go
+++ b/server/neptune/workflows/internal/terraform/root_fetcher.go
@@ -33,13 +33,19 @@ func (r *RootFetcher) Fetch(ctx workflow.Context) (*terraform.LocalRoot, func(wo
 	}
 
 	return fetchRootResponse.LocalRoot, func(c workflow.Context) error {
+		logger := workflow.GetLogger(c)
+		logger.Info("starting cleanup of deployment directory", "deploy_directory", fetchRootResponse.DeployDirectory)
+
 		var cleanupResponse activities.CleanupResponse
 		err = workflow.ExecuteActivity(c, r.Ta.Cleanup, activities.CleanupRequest{ //nolint:gosimple // unnecessary to add a method to convert reponses
 			DeployDirectory: fetchRootResponse.DeployDirectory,
-		}).Get(ctx, &cleanupResponse)
+		}).Get(c, &cleanupResponse) // Use `c` (disconnected context) instead of `ctx` which may be cancelled
 		if err != nil {
+			logger.Error("failed to cleanup deployment directory", "deploy_directory", fetchRootResponse.DeployDirectory, "error", err)
 			return errors.Wrap(err, "cleaning up")
 		}
+
+		logger.Info("successfully cleaned up deployment directory", "deploy_directory", fetchRootResponse.DeployDirectory)
 		return nil
 	}, nil
 }


### PR DESCRIPTION
Bug fix:
- Changed .Get(ctx, ...) to .Get(c, ...) in cleanup activity execution
- The cleanup was using the parent workflow context (ctx) instead of the disconnected context (c), causing cleanup to fail when the parent workflow was cancelled

Logging:
- Added info log when cleanup starts with deploy_directory
- Added error log on cleanup failure with deploy_directory and error
- Added info log on successful cleanup with deploy_directory

This should fix orphaned deployment directories accumulating on disk.