### PR TITLE
log that job logs are persisted in cleanup instead of normal close path

### DIFF
--- a/server/neptune/temporalworker/job/store.go
+++ b/server/neptune/temporalworker/job/store.go
@@ -209,6 +209,7 @@ func (s *StorageBackendJobStore) Remove(jobID string) {
 func (s *StorageBackendJobStore) Cleanup(ctx context.Context) error {
 	failedJobs := []string{}
 	for jobID, job := range s.InMemoryStore.GetJobs() {
+		s.logger.WarnContext(ctx, fmt.Sprintf("job: %s was not persisted before shutdown, persisting now during cleanup", jobID))
 		_, err := s.storageBackend.Write(ctx, jobID, job.Output)
 
 		// Track failed jobs, log errors and continue with other jobs


### PR DESCRIPTION
It's possible for a worker to get killed before a job can persist logs from in-memory to storage backend. When a new worker picks up the pending CloseJob activity, the cleanup path will retry the job Close routine but the logs that were only in-memory before the previous worker shutdown would be lost.

On user side this would look like an empty temporal log despite an alantis plan/validate/apply process completing.

We can't recover the lost logs but this warning just tells us that this is what happened.